### PR TITLE
Fix read cache filesystem open and read

### DIFF
--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -4,6 +4,12 @@
 
 namespace duckdb {
 
+DiskCacheFileHandle::DiskCacheFileHandle(
+    unique_ptr<FileHandle> internal_file_handle_p, DiskCacheFileSystem &fs)
+    : FileHandle(fs, internal_file_handle_p->GetPath(),
+                 internal_file_handle_p->GetFlags()),
+      internal_file_handle(std::move(internal_file_handle_p)) {}
+
 DiskCacheFileSystem::DiskCacheFileSystem(
     unique_ptr<FileSystem> internal_filesystem_p)
     : internal_filesystem(std::move(internal_filesystem_p)) {}

--- a/src/include/disk_cache_filesystem.hpp
+++ b/src/include/disk_cache_filesystem.hpp
@@ -4,54 +4,93 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/unique_ptr.hpp"
 
 namespace duckdb {
 
+// Forward declaration.
+class DiskCacheFileSystem;
+
+class DiskCacheFileHandle : public FileHandle {
+public:
+  DiskCacheFileHandle(unique_ptr<FileHandle> internal_file_handle_p,
+                      DiskCacheFileSystem &fs);
+  ~DiskCacheFileHandle() override = default;
+  void Close() override {}
+
+private:
+  friend class DiskCacheFileSystem;
+  unique_ptr<FileHandle> internal_file_handle;
+};
+
 class DiskCacheFileSystem : public FileSystem {
 public:
-  DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p);
+  explicit DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p);
   std::string GetName() const override { return "disk_cache_filesystem"; }
 
   void Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
             idx_t location) override {
-    internal_filesystem->Read(handle, buffer, nr_bytes, location);
+    // TODO(hjiang): Implement on-disk read cache.
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    internal_filesystem->Read(*disk_cache_handle.internal_file_handle, buffer,
+                              nr_bytes);
   }
   int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
-    return internal_filesystem->Read(handle, buffer, nr_bytes);
+    // TODO(hjiang): Implement on-disk read cache.
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->Read(*disk_cache_handle.internal_file_handle,
+                                     buffer, nr_bytes);
   }
 
   // For other API calls, delegate to [internal_filesystem] to handle.
   unique_ptr<FileHandle>
   OpenFile(const string &path, FileOpenFlags flags,
            optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->OpenFile(path, flags, opener);
+    auto file_handle = internal_filesystem->OpenFile(path, flags, opener);
+    return make_uniq<DiskCacheFileHandle>(std::move(file_handle), *this);
   }
   unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle,
                                             bool write) override {
-    return internal_filesystem->OpenCompressedFile(std::move(handle), write);
+    auto file_handle =
+        internal_filesystem->OpenCompressedFile(std::move(handle), write);
+    return make_uniq<DiskCacheFileHandle>(std::move(file_handle), *this);
   }
   void Write(FileHandle &handle, void *buffer, int64_t nr_bytes,
              idx_t location) override {
-    internal_filesystem->Write(handle, buffer, nr_bytes, location);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer,
+                               nr_bytes, location);
   }
   int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
-    return internal_filesystem->Write(handle, buffer, nr_bytes);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->Write(*disk_cache_handle.internal_file_handle,
+                                      buffer, nr_bytes);
   }
   bool Trim(FileHandle &handle, idx_t offset_bytes,
             idx_t length_bytes) override {
-    return internal_filesystem->Trim(handle, offset_bytes, length_bytes);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle,
+                                     offset_bytes, length_bytes);
   }
   int64_t GetFileSize(FileHandle &handle) {
-    return internal_filesystem->GetFileSize(handle);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->GetFileSize(
+        *disk_cache_handle.internal_file_handle);
   }
   time_t GetLastModifiedTime(FileHandle &handle) override {
-    return internal_filesystem->GetLastModifiedTime(handle);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->GetLastModifiedTime(
+        *disk_cache_handle.internal_file_handle);
   }
   FileType GetFileType(FileHandle &handle) override {
-    return internal_filesystem->GetFileType(handle);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->GetFileType(
+        *disk_cache_handle.internal_file_handle);
   }
   void Truncate(FileHandle &handle, int64_t new_size) override {
-    return internal_filesystem->Truncate(handle, new_size);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->Truncate(
+        *disk_cache_handle.internal_file_handle, new_size);
   }
   bool DirectoryExists(const string &directory,
                        optional_ptr<FileOpener> opener = nullptr) override {
@@ -87,7 +126,8 @@ public:
     internal_filesystem->RemoveFile(filename, opener);
   }
   void FileSync(FileHandle &handle) override {
-    internal_filesystem->FileSync(handle);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
   }
   string GetHomeDirectory() override {
     return internal_filesystem->GetHomeDirectory();
@@ -119,18 +159,29 @@ public:
     return internal_filesystem->CanHandleFile(fpath);
   }
   void Seek(FileHandle &handle, idx_t location) override {
-    internal_filesystem->Seek(handle, location);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    internal_filesystem->Seek(*disk_cache_handle.internal_file_handle,
+                              location);
   }
   void Reset(FileHandle &handle) override {
-    internal_filesystem->Reset(handle);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    internal_filesystem->Reset(*disk_cache_handle.internal_file_handle);
   }
   idx_t SeekPosition(FileHandle &handle) override {
-    return internal_filesystem->SeekPosition(handle);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->SeekPosition(
+        *disk_cache_handle.internal_file_handle);
   }
-  bool IsManuallySet() override { return internal_filesystem->IsManuallySet(); }
+  // Mutual set acts partially as priority system, which means if multiple
+  // filesystem instance could handle a certain path, if mutual set true,
+  // first-fit fs instance will be selected. Set cached filesystem always
+  // mutually set, so it has higher priority than non-cached version.
+  bool IsManuallySet() override { return true; }
   bool CanSeek() override { return internal_filesystem->CanSeek(); }
   bool OnDiskFile(FileHandle &handle) override {
-    return internal_filesystem->OnDiskFile(handle);
+    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+    return internal_filesystem->OnDiskFile(
+        *disk_cache_handle.internal_file_handle);
   }
   void SetDisabledFileSystems(const vector<string> &names) override {
     internal_filesystem->SetDisabledFileSystems(names);
@@ -140,7 +191,7 @@ private:
   // Used to access local cache files.
   [[maybe_unused]] unique_ptr<FileSystem> local_filesystem;
   // Used to access remote files.
-  [[maybe_unused]] unique_ptr<FileSystem> internal_filesystem;
+  unique_ptr<FileSystem> internal_filesystem;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This PR fixes a bug that `DiskCacheFileSystem::Read` is not used, the reason is `FileHandle::filesystem` is set via internal filesystem rather than our cached fs.

Test SQL to make sure cached read is actually called:
```
D LOAD read_cache_fs;
D select * from read_csv_auto('https://csvbase.com/meripaterson/stock-exchanges');
```