### PR TITLE
On-disk filesystem read from local cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,8 @@ install(
 # C++ examples.
 add_executable(read_http_csv example/read_http_csv.cpp)
 target_link_libraries(read_http_csv duckdb)
+
+# Test cases.
+include_directories(duckdb/third_party/catch)
+add_executable(test_disk_cache_filesystem unit/test_disk_cache_filesystem.cpp)
+target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})

--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -13,26 +13,25 @@
 
 namespace duckdb {
 
-// TODO(hjiang): Hard code block size for now, in the future we should allow
-// global configuration via `SET GLOBAL`.
-static uint64_t BLOCK_SIZE = 10000;
-static string ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_cached_http_cache";
+namespace {
 
 // IO operations are performed based on block size, this function returns
 // aligned start offset and bytes to read.
-static std::pair<uint64_t, int64_t>
-GetStartOffsetAndBytesToRead(FileHandle &handle, uint64_t start_offset,
-                             int64_t bytes_to_read, uint64_t file_size) {
-  const uint64_t aligned_start_offset = start_offset / BLOCK_SIZE * BLOCK_SIZE;
+std::pair<uint64_t, int64_t> GetStartOffsetAndBytesToRead(FileHandle &handle,
+                                                          uint64_t start_offset,
+                                                          int64_t bytes_to_read,
+                                                          uint64_t file_size,
+                                                          uint64_t block_size) {
+  const uint64_t aligned_start_offset = start_offset / block_size * block_size;
   uint64_t aligned_end_offset =
-      ((start_offset + bytes_to_read - 1) / BLOCK_SIZE + 1) * BLOCK_SIZE;
+      ((start_offset + bytes_to_read - 1) / block_size + 1) * block_size;
   aligned_end_offset = std::min<uint64_t>(aligned_end_offset, file_size);
   return std::make_pair(aligned_start_offset,
                         aligned_end_offset - aligned_start_offset);
 }
 
 // Convert SHA256 value to hex string.
-static string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
+string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
   static constexpr char kHexChars[] = "0123456789abcdef";
   std::string result;
   // SHA256 has 32 byte, we encode 2 chars for each byte of SHA256.
@@ -53,8 +52,9 @@ static string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
 //
 // Considering the naming format, it's worth noting it might _NOT_ work for
 // local files, including mounted filesystems.
-static string GetLocalCacheFile(const string &remote_file,
-                                uint64_t start_offset, uint64_t bytes_to_read) {
+string GetLocalCacheFile(const string &cache_directory,
+                         const string &remote_file, uint64_t start_offset,
+                         uint64_t bytes_to_read) {
   duckdb::hash_bytes remote_file_sha256_val;
   duckdb::sha256(remote_file.data(), remote_file.length(),
                  remote_file_sha256_val);
@@ -62,10 +62,12 @@ static string GetLocalCacheFile(const string &remote_file,
       Sha256ToHexString(remote_file_sha256_val);
 
   const string fname = StringUtil::GetFileName(remote_file);
-  return StringUtil::Format("%s/%s.%s-%llu-%llu", ON_DISK_CACHE_DIRECTORY,
+  return StringUtil::Format("%s/%s.%s-%llu-%llu", cache_directory,
                             remote_file_sha256_str, fname, start_offset,
                             bytes_to_read);
 }
+
+} // namespace
 
 DiskCacheFileHandle::DiskCacheFileHandle(
     unique_ptr<FileHandle> internal_file_handle_p, DiskCacheFileSystem &fs)
@@ -74,72 +76,90 @@ DiskCacheFileHandle::DiskCacheFileHandle(
       internal_file_handle(std::move(internal_file_handle_p)) {}
 
 DiskCacheFileSystem::DiskCacheFileSystem(
-    unique_ptr<FileSystem> internal_filesystem_p)
-    : local_filesystem(FileSystem::CreateLocal()),
+    unique_ptr<FileSystem> internal_filesystem_p, string cache_directory_p)
+    : cache_directory(std::move(cache_directory_p)),
+      local_filesystem(FileSystem::CreateLocal()),
       internal_filesystem(std::move(internal_filesystem_p)) {
-  local_filesystem->CreateDirectory(ON_DISK_CACHE_DIRECTORY);
+  local_filesystem->CreateDirectory(cache_directory);
+}
+
+void DiskCacheFileSystem::Read(FileHandle &handle, void *buffer,
+                               int64_t nr_bytes, idx_t location) {
+  ReadImpl(handle, buffer, nr_bytes, location, DEFAULT_BLOCK_SIZE);
+}
+int64_t DiskCacheFileSystem::Read(FileHandle &handle, void *buffer,
+                                  int64_t nr_bytes) {
+  return ReadImpl(handle, buffer, nr_bytes, handle.SeekPosition(),
+                  DEFAULT_BLOCK_SIZE);
+}
+int64_t DiskCacheFileSystem::ReadForTesting(FileHandle &handle, void *buffer,
+                                            int64_t nr_bytes, idx_t location,
+                                            uint64_t block_size) {
+  return ReadImpl(handle, buffer, nr_bytes, location, block_size);
 }
 
 void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *start_addr,
                                        uint64_t start_offset,
-                                       uint64_t bytes_to_read) {
+                                       uint64_t bytes_to_read,
+                                       uint64_t block_size) {
   D_ASSERT(bytes_to_read >= 1);
-  const uint64_t io_op_count = (bytes_to_read - 1) / BLOCK_SIZE + 1;
+  const uint64_t io_op_count = (bytes_to_read - 1) / block_size + 1;
   vector<thread> threads;
   threads.reserve(io_op_count);
   for (uint64_t idx = 0; idx < io_op_count; ++idx) {
-    const uint64_t cur_start_offset = start_offset + BLOCK_SIZE * idx;
+    const uint64_t cur_start_offset = start_offset + block_size * idx;
     const int64_t cur_bytes_to_read =
         idx < (io_op_count - 1)
-            ? BLOCK_SIZE
-            : (bytes_to_read - BLOCK_SIZE * (io_op_count - 1));
-    char *cur_start_addr = start_addr + idx * BLOCK_SIZE;
-    threads.emplace_back(
-        [this, &handle, cur_start_offset, cur_bytes_to_read, cur_start_addr]() {
-          // Check local cache first, see if we could do a cached read.
-          const auto local_cache_file = GetLocalCacheFile(
-              handle.GetPath(), cur_start_offset, cur_bytes_to_read);
+            ? block_size
+            : (bytes_to_read - block_size * (io_op_count - 1));
+    char *cur_start_addr = start_addr + idx * block_size;
+    threads.emplace_back([this, &handle, cur_start_offset, cur_bytes_to_read,
+                          cur_start_addr]() {
+      // Check local cache first, see if we could do a cached read.
+      const auto local_cache_file =
+          GetLocalCacheFile(cache_directory, handle.GetPath(), cur_start_offset,
+                            cur_bytes_to_read);
 
-          // TODO(hjiang): Add documentation and implementation for stale cache
-          // eviction policy, before that it's safe to access cache file
-          // directly.
-          if (local_filesystem->FileExists(local_cache_file)) {
-            auto file_handle = local_filesystem->OpenFile(
-                local_cache_file, FileOpenFlags::FILE_FLAGS_READ);
-            local_filesystem->Read(*file_handle, cur_start_addr,
-                                   cur_bytes_to_read, /*location=*/0);
-            return;
-          }
+      // TODO(hjiang): Add documentation and implementation for stale cache
+      // eviction policy, before that it's safe to access cache file
+      // directly.
+      if (local_filesystem->FileExists(local_cache_file)) {
+        auto file_handle = local_filesystem->OpenFile(
+            local_cache_file, FileOpenFlags::FILE_FLAGS_READ);
+        local_filesystem->Read(*file_handle, cur_start_addr, cur_bytes_to_read,
+                               /*location=*/0);
+        return;
+      }
 
-          // We suffer a cache loss, fallback to remote access then local
-          // filesystem write.
-          auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-          internal_filesystem->Read(*disk_cache_handle.internal_file_handle,
-                                    cur_start_addr, cur_bytes_to_read,
-                                    cur_start_offset);
+      // We suffer a cache loss, fallback to remote access then local
+      // filesystem write.
+      auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
+      internal_filesystem->Read(*disk_cache_handle.internal_file_handle,
+                                cur_start_addr, cur_bytes_to_read,
+                                cur_start_offset);
 
-          // TODO(hjiang): Before local cache we should check whether there's
-          // enough space left, and trigger a stale file cleanup if necessary.
-          //
-          // Dump to a temporary location at local filesystem.
-          const auto fname = StringUtil::GetFileName(handle.GetPath());
-          const auto local_temp_file =
-              StringUtil::Format("%s%s.%s", ON_DISK_CACHE_DIRECTORY, fname,
-                                 UUID::ToString(UUID::GenerateRandomUUID()));
-          {
-            auto file_handle = local_filesystem->OpenFile(
-                local_temp_file, FileOpenFlags::FILE_FLAGS_WRITE |
-                                     FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-            local_filesystem->Write(*file_handle, cur_start_addr,
-                                    cur_bytes_to_read, /*location=*/0);
-            file_handle->Sync();
-          }
+      // TODO(hjiang): Before local cache we should check whether there's
+      // enough space left, and trigger a stale file cleanup if necessary.
+      //
+      // Dump to a temporary location at local filesystem.
+      const auto fname = StringUtil::GetFileName(handle.GetPath());
+      const auto local_temp_file =
+          StringUtil::Format("%s%s.%s.httpfs_local_cache", cache_directory,
+                             fname, UUID::ToString(UUID::GenerateRandomUUID()));
+      {
+        auto file_handle = local_filesystem->OpenFile(
+            local_temp_file, FileOpenFlags::FILE_FLAGS_WRITE |
+                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+        local_filesystem->Write(*file_handle, cur_start_addr, cur_bytes_to_read,
+                                /*location=*/0);
+        file_handle->Sync();
+      }
 
-          // Then atomically move to the target postion to prevent data
-          // corruption due to concurrent write.
-          local_filesystem->MoveFile(/*source=*/local_temp_file,
-                                     /*target=*/local_cache_file);
-        });
+      // Then atomically move to the target postion to prevent data
+      // corruption due to concurrent write.
+      local_filesystem->MoveFile(/*source=*/local_temp_file,
+                                 /*target=*/local_cache_file);
+    });
   }
   for (auto &cur_thd : threads) {
     D_ASSERT(cur_thd.joinable());
@@ -148,21 +168,23 @@ void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *start_addr,
 }
 
 int64_t DiskCacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
-                                      int64_t nr_bytes, idx_t location) {
+                                      int64_t nr_bytes, idx_t location,
+                                      uint64_t block_size) {
   const auto file_size = handle.GetFileSize();
-  const auto [start_offset, bytes_to_read] =
-      GetStartOffsetAndBytesToRead(handle, location, nr_bytes, file_size);
+  const auto [start_offset, bytes_to_read] = GetStartOffsetAndBytesToRead(
+      handle, location, nr_bytes, file_size, block_size);
 
   // TODO(hjiang): The only reason we need `content` is we could have unaligned
   // memory blocks, no need to read into `content` buffer if a read request is
   // perfectly aligned.
   string content(bytes_to_read, '\0');
   ReadAndCache(handle, const_cast<char *>(content.data()), start_offset,
-               bytes_to_read);
+               bytes_to_read, block_size);
 
   const uint64_t actual_bytes_requested =
       std::min<uint64_t>(file_size - location, nr_bytes);
-  std::memmove(buffer, const_cast<char *>(content.data()),
+  const uint64_t start_offset_delta = location - start_offset;
+  std::memmove(buffer, const_cast<char *>(content.data()) + start_offset_delta,
                actual_bytes_requested);
 
   return actual_bytes_requested;

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+
+namespace duckdb {
+
+// TODO(hjiang): Hard code block size for now, in the future we should allow
+// global configuration via `SET GLOBAL`.
+inline uint64_t DEFAULT_BLOCK_SIZE = 10000;
+inline std::string ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_cached_http_cache";
+
+} // namespace duckdb

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -1,0 +1,86 @@
+// Unit test for disk cache filesystem.
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "disk_cache_filesystem.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "cache_filesystem_config.hpp"
+
+using namespace duckdb;  // NOLINT
+
+namespace {
+
+constexpr uint64_t TEST_FILE_SIZE = 26;
+const auto TEST_FILE_CONTENT = []() {
+    string content(TEST_FILE_SIZE, '\0');
+    for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
+        content[idx] = 'a' + idx;
+    }
+    return content;
+}();
+const auto TEST_FILENAME = StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
+
+}  // namespace
+
+// Testing senario: (1) uncached read; (2) read block size aligned with file size. 
+TEST_CASE("Test on disk cache filesystem with cache size aligned and uncached read", "[on-disk cache test]") {
+    DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal()};
+    auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+    string content(TEST_FILE_SIZE, '\0');
+    const uint64_t test_block_size = TEST_FILE_SIZE;
+    disk_cache_fs.ReadForTesting(*handle, const_cast<void*>(static_cast<const void*>(content.data())), TEST_FILE_SIZE, /*location=*/0, test_block_size);
+    REQUIRE(content == TEST_FILE_CONTENT);
+}
+
+// Testing senario: (1) uncached read; (2) read block size is not aligned with file size.
+TEST_CASE("Test on disk cache filesystem with cache size un-aligned and uncached read", "[on-disk cache test]") {
+    DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal()};
+    auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+    const uint64_t test_block_size = TEST_FILE_SIZE;
+    const uint64_t test_location = 5;
+    string content(TEST_FILE_SIZE - test_location, '\0');
+    disk_cache_fs.ReadForTesting(*handle, const_cast<void*>(static_cast<const void*>(content.data())), TEST_FILE_SIZE, test_location, test_block_size);
+    REQUIRE(content == TEST_FILE_CONTENT.substr(test_location));
+}
+
+// Testing senario: (1) cached read; (2) read block size is not aligned with file size.
+TEST_CASE("Test on disk cache filesystem with cache size un-aligned and cached read", "[on-disk cache test]") {
+    DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal()};
+    const uint64_t test_block_size = TEST_FILE_SIZE;
+    
+    // First read caches whole test file content.
+    {
+        auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);        
+        string content(TEST_FILE_SIZE, '\0');
+        disk_cache_fs.ReadForTesting(*handle, const_cast<void*>(static_cast<const void*>(content.data())), TEST_FILE_SIZE, /*location=*/0, test_block_size);
+        REQUIRE(content == TEST_FILE_CONTENT);
+    }
+
+    // Second read hits cache file.
+    {
+        auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);  
+        const uint64_t test_block_size = TEST_FILE_SIZE;
+        const uint64_t test_location = 5;
+        string content(TEST_FILE_SIZE - test_location, '\0');
+        disk_cache_fs.ReadForTesting(*handle, const_cast<void*>(static_cast<const void*>(content.data())), TEST_FILE_SIZE, test_location, test_block_size);
+        REQUIRE(content == TEST_FILE_CONTENT.substr(test_location));
+    }
+}
+
+int main(int argc, char** argv) {
+    auto local_filesystem = LocalFileSystem::CreateLocal();
+    auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+    local_filesystem->Write(*file_handle, const_cast<void*>(static_cast<const void*>(TEST_FILE_CONTENT.data())), TEST_FILE_SIZE, /*location=*/0);
+    file_handle->Sync();
+    file_handle->Close();
+
+    int result = Catch::Session().run(argc, argv);
+
+    // TODO(hjiang): Use `SCOPE_GUARD` to delete automatically.
+    local_filesystem->RemoveFile(TEST_FILENAME);
+
+    return result;
+}


### PR DESCRIPTION
This PR 
- Implements on-disk cache filesystem reading from local cache if exists, then fallback to remote access;
- Add unit tests for multiple read caches, for example, cached/uncached read, offset and block size alignment;
- Leave TODO for a few improvements, left to next PRs.