### PR TITLE
Resize string with no initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
 include_directories(src/include)
+include_directories(utils/include)
 include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 

--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -1,12 +1,9 @@
-// TODO(hjiang): Use `resize_without_initialization` to save memset.
-// Reference:
-// https://github.com/abseil/abseil-cpp/blob/master/absl/strings/internal/resize_uninitialized.h
-
 #include "duckdb/common/thread.hpp"
 #include "disk_cache_filesystem.hpp"
 #include "crypto.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "resize_uninitialized.h"
 
 #include <utility>
 #include <cstdint>
@@ -177,7 +174,7 @@ int64_t DiskCacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
   // TODO(hjiang): The only reason we need `content` is we could have unaligned
   // memory blocks, no need to read into `content` buffer if a read request is
   // perfectly aligned.
-  string content(bytes_to_read, '\0');
+  string content = CreateResizeUninitializedString(bytes_to_read);
   ReadAndCache(handle, const_cast<char *>(content.data()), start_offset,
                bytes_to_read, block_size);
 

--- a/utils/include/resize_uninitialized.h
+++ b/utils/include/resize_uninitialized.h
@@ -1,0 +1,67 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Apapted from abseil `resize_uninitialized` implementation.
+
+#pragma once
+
+#include <type_traits>
+#include <cstddef>
+#include <string>
+
+#include "type_traits.hpp"
+
+namespace duckdb {
+
+namespace internal {
+
+// In this type trait, we look for a __resize_default_init member function, and
+// we use it if available, otherwise, we use resize. We provide HasMember to
+// indicate whether __resize_default_init is present.
+template <typename string_type, typename = void>
+struct ResizeUninitializedTraits {
+  using HasMember = std::false_type;
+  static void Resize(string_type* s, size_t new_size) { s->resize(new_size); }
+};
+
+// __resize_default_init is provided by libc++ >= 8.0
+template <typename string_type>
+struct ResizeUninitializedTraits<
+    string_type, void_t<decltype(std::declval<string_type&>()
+                                           .__resize_default_init(237))> > {
+  using HasMember = std::true_type;
+  static void Resize(string_type* s, size_t new_size) {
+    s->__resize_default_init(new_size);
+  }
+};
+
+}  // namespace internal
+
+// Like str->resize(new_size), except any new characters added to "*str" as a
+// result of resizing may be left uninitialized, rather than being filled with
+// '0' bytes. Typically used when code is then going to overwrite the backing
+// store of the std::string with known data.
+template <typename string_type, typename = void>
+inline void STLStringResizeUninitialized(string_type* s, size_t new_size) {
+  internal::ResizeUninitializedTraits<string_type>::Resize(s, new_size);
+}
+
+// Create a string with the given size, with all bytes uninitialized. Useful to use as a buffer.
+std::string CreateResizeUninitializedString(size_t size) {
+    std::string content;
+    STLStringResizeUninitialized(&content, size);
+    return content;
+}
+
+}  // namespace duckdb

--- a/utils/include/type_traits.hpp
+++ b/utils/include/type_traits.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace duckdb {
+
+template <typename... Ts>
+struct VoidTImpl {
+  using type = void;
+};
+
+template <typename... Ts>
+using void_t = typename VoidTImpl<Ts...>::type;
+
+}  // namespace duckdb


### PR DESCRIPTION
This PR transplant resize without initialization feature from abseil, so (if STL versions is new enough) buffers we use to hold remote file don't need to go through memset; par my past experience on object storage performance optimization, memset could sometimes leads to ~5% CPU overhead and latency on critical path.