### PR TITLE
IO request benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,3 +51,7 @@ target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})
 
 add_executable(test_stale_deletion unit/test_stale_deletion.cpp)
 target_link_libraries(test_stale_deletion ${EXTENSION_NAME})
+
+# Benchmark
+add_executable(read_s3_object benchmark/read_s3_object.cpp)
+target_link_libraries(read_s3_object ${EXTENSION_NAME})

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
-format-test:
+format-all:
 	find unit/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
+	find benchmark/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i

--- a/benchmark/read_s3_object.cpp
+++ b/benchmark/read_s3_object.cpp
@@ -1,0 +1,126 @@
+// This file serves as a benchmark to read a whole S3 objects; it only tests
+// uncached read.
+
+#include "disk_cache_filesystem.hpp"
+#include "duckdb/storage/standard_buffer_manager.hpp"
+#include "s3fs.hpp"
+#include "duckdb/main/client_context_file_opener.hpp"
+
+#include <array>
+#include <iostream>
+
+namespace duckdb {
+
+namespace {
+
+// Set configuration in client context from env variables.
+void SetConfig(case_insensitive_map_t<Value> &setting, char *env_key,
+               char *secret_key) {
+  const char *env_val = getenv(env_key);
+  if (env_val == nullptr) {
+    return;
+  }
+  setting[secret_key] = Value(env_val);
+}
+
+// Baseline benchmark, which reads the whole file with no parallelism and
+// caching.
+void BaseLineRead() {
+  DuckDB db{};
+  StandardBufferManager buffer_manager{*db.instance,
+                                       "/tmp/cached_http_fs_benchmark"};
+  auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
+
+  auto client_context = make_shared_ptr<ClientContext>(db.instance);
+  auto &set_vars = client_context->config.set_variables;
+  SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
+  SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
+  SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
+  SetConfig(set_vars, "DUCKDB_S3_ENDPOINT", "s3_endpoint");
+
+  ClientContextFileOpener file_opener{*client_context};
+  client_context->transaction.BeginTransaction();
+  auto file_handle = s3fs->OpenFile(
+      "s3://s3-bucket-user-2skzy8zuigonczyfiofztl0zbug--use1-az6--x-s3/"
+      "large-csv.csv",
+      FileOpenFlags::FILE_FLAGS_READ, &file_opener);
+  const uint64_t file_size = s3fs->GetFileSize(*file_handle);
+  std::string content(file_size, '\0');
+
+  const auto now = std::chrono::steady_clock::now();
+  s3fs->Read(*file_handle, const_cast<char *>(content.data()), file_size,
+             /*location=*/0);
+  const auto end = std::chrono::steady_clock::now();
+  const auto duration_sec =
+      std::chrono::duration_cast<std::chrono::duration<double>>(end - now)
+          .count();
+  std::cout << "Baseline S3 filesystem reads " << file_size << " bytes takes "
+            << duration_sec << " seconds" << std::endl;
+}
+
+void ReadUncachedWholeFile(uint64_t block_size) {
+  DuckDB db{};
+  StandardBufferManager buffer_manager{*db.instance,
+                                       "/tmp/cached_http_fs_benchmark"};
+  auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
+
+  OnDiskCacheConfig cache_config;
+  cache_config.block_size = block_size;
+  FileSystem::CreateLocal()->RemoveDirectory(
+      cache_config.on_disk_cache_directory);
+  auto disk_cache_fs = make_uniq<DiskCacheFileSystem>(std::move(s3fs));
+
+  auto client_context = make_shared_ptr<ClientContext>(db.instance);
+  auto &set_vars = client_context->config.set_variables;
+  SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
+  SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
+  SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
+  SetConfig(set_vars, "DUCKDB_S3_ENDPOINT", "s3_endpoint");
+  ClientContextFileOpener file_opener{*client_context};
+  client_context->transaction.BeginTransaction();
+
+  auto file_handle = disk_cache_fs->OpenFile(
+      "s3://s3-bucket-user-2skzy8zuigonczyfiofztl0zbug--use1-az6--x-s3/"
+      "large-csv.csv",
+      FileOpenFlags::FILE_FLAGS_READ, &file_opener);
+  const uint64_t file_size = disk_cache_fs->GetFileSize(*file_handle);
+  std::string content(file_size, '\0');
+
+  auto read_whole_file = [&]() {
+    const auto now = std::chrono::steady_clock::now();
+    disk_cache_fs->Read(*file_handle, const_cast<char *>(content.data()),
+                        file_size, /*location=*/0);
+    const auto end = std::chrono::steady_clock::now();
+    const auto duration_sec =
+        std::chrono::duration_cast<std::chrono::duration<double>>(end - now)
+            .count();
+    std::cout << "Cached http filesystem reads " << file_size
+              << " bytes with block size " << block_size << " takes "
+              << duration_sec << " seconds" << std::endl;
+  };
+
+  // Uncached but parallel read.
+  read_whole_file();
+  // Cached and parallel read.
+  read_whole_file();
+}
+
+} // namespace
+
+} // namespace duckdb
+
+int main(int argc, char **argv) {
+  constexpr std::array<uint64_t, 10> BLOCK_SIZE_ARR{
+      64ULL * 1024,        // 64KiB
+      256ULL * 1024,       // 256KiB
+      1ULL * 1024 * 1024,  // 1MiB
+      4ULL * 1024 * 1024,  // 4MiB
+      16ULL * 1024 * 1024, // 16MiB
+  };
+
+  duckdb::BaseLineRead();
+  for (uint64_t cur_block_size : BLOCK_SIZE_ARR) {
+    duckdb::ReadUncachedWholeFile(cur_block_size);
+  }
+  return 0;
+}

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -7,15 +7,23 @@ namespace duckdb {
 
 // TODO(hjiang): Hard code block size for now, in the future we should allow
 // global configuration via `SET GLOBAL`.
-inline constexpr uint64_t DEFAULT_BLOCK_SIZE = 5000;
+inline constexpr uint64_t DEFAULT_BLOCK_SIZE = 64ULL * 1024;
 inline const std::string ON_DISK_CACHE_DIRECTORY =
     "/tmp/duckdb_cached_http_cache";
 
 // To prevent go out of disk space, we set a threshold to disable local caching
 // if insufficient.
-inline constexpr uint64_t MIN_DISK_SPACE_FOR_CACHE = 1024ULL * 1024 * 1024;
+inline constexpr uint64_t MIN_DISK_SPACE_FOR_CACHE = 1024ULL * 1024;
 
 // Number of seconds which we define as the threshold of staleness.
 inline constexpr uint64_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
+
+// TODO(hjiang): Add constraint on largest thread number.
+struct OnDiskCacheConfig {
+  // Cache block size.
+  uint64_t block_size = DEFAULT_BLOCK_SIZE;
+  // Cache storage location on local filesystem.
+  std::string on_disk_cache_directory = ON_DISK_CACHE_DIRECTORY;
+};
 
 } // namespace duckdb

--- a/src/include/disk_cache_filesystem.hpp
+++ b/src/include/disk_cache_filesystem.hpp
@@ -28,9 +28,9 @@ class DiskCacheFileSystem : public FileSystem {
 public:
   explicit DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
       : DiskCacheFileSystem(std::move(internal_filesystem_p),
-                            ON_DISK_CACHE_DIRECTORY) {}
+                            OnDiskCacheConfig{}) {}
   DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
-                      string cache_directory_p);
+                      OnDiskCacheConfig cache_directory_p);
   std::string GetName() const override { return "disk_cache_filesystem"; }
 
   void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
@@ -200,6 +200,8 @@ private:
   int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes,
                    idx_t location, uint64_t block_size);
 
+  // Read-cache filesystem configuration.
+  OnDiskCacheConfig cache_config;
   // Directory to store cache files.
   string cache_directory;
   // Used to access local cache files.

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -32,7 +32,11 @@ const auto TEST_FILE_CONTENT = []() {
 const auto TEST_FILENAME =
     StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
 const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
-
+const OnDiskCacheConfig TEST_CACHE_CONFIG = []() {
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  return cache_config;
+}();
 } // namespace
 
 // One chunk is involved, requested bytes include only "first and last chunk".
@@ -41,7 +45,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first "
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   // First uncached read.
   {
@@ -80,7 +84,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first and "
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   // First uncached read.
   {
@@ -119,7 +123,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first, "
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   // First uncached read.
   {
@@ -159,7 +163,7 @@ TEST_CASE(
     "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   // First uncached read.
   {
@@ -197,7 +201,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk at last of file",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   // First uncached read.
   {
@@ -254,7 +258,7 @@ TEST_CASE(
     "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   // First uncached read.
   {
@@ -310,7 +314,7 @@ TEST_CASE("Test on disk cache filesystem no new cache file after a full cache",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   // First uncached read.
   {
@@ -364,7 +368,7 @@ TEST_CASE("Test on disk cache filesystem read from end of file",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
 
   auto handle =
       disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
@@ -381,7 +385,7 @@ TEST_CASE("Test on reading non-existent file",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_ON_DISK_CACHE_DIRECTORY};
+                                    TEST_CACHE_CONFIG};
   REQUIRE_THROWS(disk_cache_fs.OpenFile("non-existent-file",
                                         FileOpenFlags::FILE_FLAGS_READ));
 }

--- a/unit/test_stale_deletion.cpp
+++ b/unit/test_stale_deletion.cpp
@@ -11,8 +11,6 @@
 
 using namespace duckdb; // NOLINT
 
-#include <iostream>
-
 namespace {
 const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
 } // namespace


### PR DESCRIPTION
This PR checks benchmark for IO request, which compares different comparisons for 
- cached vs uncached requests
- parallel vs sequential requests
- parallel requests for different cache block size

Benchmark setup:
- Read from us-west
- File stored in S3 us-east express one

Based on the benchmark, 
- Reading a ~1GiB file with httpfs takes ~32 sec
- Adjust block size (which also decided read request parallelism), block size of 256KiB performs best, which takes 6.5 sec, while others take >7seconds