### PR TITLE
Implement in-memory cache filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(duckdb/third_party/httplib)
 set(EXTENSION_SOURCES
     src/read_cache_fs_extension.cpp
     src/disk_cache_filesystem.cpp
+    src/in_memory_cache_filesystem.cpp
     src/utils/filesystem_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp
     duckdb-httpfs/extension/httpfs/crypto.cpp
@@ -48,6 +49,10 @@ include_directories(duckdb/third_party/catch)
 
 add_executable(test_disk_cache_filesystem unit/test_disk_cache_filesystem.cpp)
 target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})
+
+add_executable(test_in_memory_cache_filesystem
+               unit/test_in_memory_cache_filesystem.cpp)
+target_link_libraries(test_in_memory_cache_filesystem ${EXTENSION_NAME})
 
 add_executable(test_stale_deletion unit/test_stale_deletion.cpp)
 target_link_libraries(test_stale_deletion ${EXTENSION_NAME})

--- a/src/in_memory_cache_filesystem.cpp
+++ b/src/in_memory_cache_filesystem.cpp
@@ -1,0 +1,210 @@
+#include "in_memory_cache_filesystem.hpp"
+#include "duckdb/common/thread.hpp"
+#include "crypto.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "utils/include/resize_uninitialized.hpp"
+#include "utils/include/filesystem_utils.hpp"
+
+#include <cstdint>
+#include <utility>
+#include <utime.h>
+
+namespace duckdb {
+
+namespace {
+
+// All read requests are split into chunks, and executed in parallel.
+// A [CacheReadChunk] represents a chunked IO request and its corresponding
+// partial IO request.
+struct CacheReadChunk {
+  // Requested memory address and file offset to read from for current chunk.
+  char *requested_start_addr = nullptr;
+  uint64_t requested_start_offset = 0;
+  // Block size aligned [requested_start_offset].
+  uint64_t aligned_start_offset = 0;
+
+  // Number of bytes for the chunk for IO operations, apart from the last chunk
+  // it's always cache block size.
+  uint64_t chunk_size = 0;
+
+  // Number of bytes to copy from [content] to requested memory address.
+  uint64_t bytes_to_copy = 0;
+
+  // Copy from [content] to application-provided buffer.
+  void CopyBufferToRequestedMemory(const std::string &content) {
+    const uint64_t delta_offset = requested_start_offset - aligned_start_offset;
+    std::memmove(requested_start_addr,
+                 const_cast<char *>(content.data()) + delta_offset,
+                 bytes_to_copy);
+  }
+};
+
+} // namespace
+
+InMemoryCacheFileHandle::InMemoryCacheFileHandle(
+    unique_ptr<FileHandle> internal_file_handle_p, InMemoryCacheFileSystem &fs)
+    : FileHandle(fs, internal_file_handle_p->GetPath(),
+                 internal_file_handle_p->GetFlags()),
+      internal_file_handle(std::move(internal_file_handle_p)) {}
+
+InMemoryCacheFileSystem::InMemoryCacheFileSystem(
+    unique_ptr<FileSystem> internal_filesystem_p,
+    InMemoryCacheConfig cache_config_p)
+    : cache_config(std::move(cache_config_p)),
+      internal_filesystem(std::move(internal_filesystem_p)),
+      cache(cache_config.block_count) {}
+
+void InMemoryCacheFileSystem::Read(FileHandle &handle, void *buffer,
+                                   int64_t nr_bytes, idx_t location) {
+  ReadImpl(handle, buffer, nr_bytes, location, DEFAULT_BLOCK_SIZE);
+}
+int64_t InMemoryCacheFileSystem::Read(FileHandle &handle, void *buffer,
+                                      int64_t nr_bytes) {
+  const int64_t bytes_read = ReadImpl(
+      handle, buffer, nr_bytes, handle.SeekPosition(), DEFAULT_BLOCK_SIZE);
+  handle.Seek(handle.SeekPosition() + bytes_read);
+  return bytes_read;
+}
+int64_t InMemoryCacheFileSystem::ReadForTesting(FileHandle &handle,
+                                                void *buffer, int64_t nr_bytes,
+                                                idx_t location,
+                                                uint64_t block_size) {
+  return ReadImpl(handle, buffer, nr_bytes, location, block_size);
+}
+
+void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
+                                           uint64_t requested_start_offset,
+                                           uint64_t requested_bytes_to_read,
+                                           uint64_t file_size,
+                                           uint64_t block_size) {
+  const uint64_t aligned_start_offset =
+      requested_start_offset / block_size * block_size;
+  const uint64_t aligned_last_chunk_offset =
+      (requested_start_offset + requested_bytes_to_read) / block_size *
+      block_size;
+
+  // Indicate the meory address to copy to for each IO operation
+  char *addr_to_write = buffer;
+  // Used to calculate bytes to copy for last chunk.
+  uint64_t already_read_bytes = 0;
+  // Threads to parallelly perform IO.
+  vector<thread> io_threads;
+
+  // To improve IO performance, we split requested bytes (after alignment) into
+  // multiple chunks and fetch them in parallel.
+  for (uint64_t io_start_offset = aligned_start_offset;
+       io_start_offset <= aligned_last_chunk_offset;
+       io_start_offset += block_size) {
+    CacheReadChunk cache_read_chunk;
+    cache_read_chunk.requested_start_addr = addr_to_write;
+    cache_read_chunk.aligned_start_offset = io_start_offset;
+    cache_read_chunk.requested_start_offset = requested_start_offset;
+
+    // Implementation-wise, middle chunks are easy to handle -- read in
+    // [block_size], and copy the whole chunk to the requested memory address;
+    // but the first and last chunk require special handling.
+    // For first chunk, requested start offset might not be aligned with block
+    // size; for the last chunk, we might not need to copy the whole
+    // [block_size] of memory.
+    //
+    // Case-1: If there's only one chunk, which serves as both the first chunk
+    // and the last one.
+    if (io_start_offset == aligned_start_offset &&
+        io_start_offset == aligned_last_chunk_offset) {
+      cache_read_chunk.chunk_size =
+          std::min<uint64_t>(block_size, file_size - io_start_offset);
+      cache_read_chunk.bytes_to_copy = requested_bytes_to_read;
+    }
+    // Case-2: First chunk.
+    else if (io_start_offset == aligned_start_offset) {
+      const uint64_t delta_offset =
+          requested_start_offset - aligned_start_offset;
+      addr_to_write += block_size - delta_offset;
+      already_read_bytes += block_size - delta_offset;
+
+      cache_read_chunk.chunk_size = block_size;
+      cache_read_chunk.bytes_to_copy = block_size - delta_offset;
+    }
+    // Case-3: Last chunk.
+    else if (io_start_offset == aligned_last_chunk_offset) {
+      cache_read_chunk.chunk_size =
+          std::min<uint64_t>(block_size, file_size - io_start_offset);
+      cache_read_chunk.bytes_to_copy =
+          requested_bytes_to_read - already_read_bytes;
+    }
+    // Case-4: Middle chunks.
+    else {
+      addr_to_write += block_size;
+      already_read_bytes += block_size;
+
+      cache_read_chunk.bytes_to_copy = block_size;
+      cache_read_chunk.chunk_size = block_size;
+    }
+
+    // Update read offset for next chunk read.
+    requested_start_offset = io_start_offset + block_size;
+
+    // Perform read operation in parallel.
+    io_threads.emplace_back(
+        [this, &handle, block_size,
+         cache_read_chunk = std::move(cache_read_chunk)]() mutable {
+          // Check local cache first, see if we could do a cached read.
+          InMemCacheBlock block_key;
+          block_key.fname = handle.GetPath();
+          block_key.start_off = cache_read_chunk.aligned_start_offset;
+          block_key.blk_size = cache_read_chunk.chunk_size;
+          string block_key_str = block_key.ToString();
+          auto cache_block = cache.Get(block_key_str);
+
+          // TODO(hjiang): Add documentation and implementation for stale cache
+          // eviction policy, before that it's safe to access cache file
+          // directly.
+          if (cache_block != nullptr) {
+            cache_read_chunk.CopyBufferToRequestedMemory(*cache_block);
+            return;
+          }
+
+          // We suffer a cache loss, fallback to remote access then local
+          // filesystem write.
+          auto content =
+              CreateResizeUninitializedString(cache_read_chunk.chunk_size);
+          auto &in_mem_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+          internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle,
+                                    const_cast<char *>(content.data()),
+                                    content.length(),
+                                    cache_read_chunk.aligned_start_offset);
+
+          // Copy to destination buffer.
+          cache_read_chunk.CopyBufferToRequestedMemory(content);
+
+          // Attempt to cache file locally.
+          cache.Put(std::move(block_key_str),
+                    std::make_shared<std::string>(std::move(content)));
+        });
+  }
+  for (auto &cur_thd : io_threads) {
+    D_ASSERT(cur_thd.joinable());
+    cur_thd.join();
+  }
+}
+
+int64_t InMemoryCacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
+                                          int64_t nr_bytes, idx_t location,
+                                          uint64_t block_size) {
+  const auto file_size = handle.GetFileSize();
+
+  // No more bytes to read.
+  if (location == file_size) {
+    return 0;
+  }
+
+  const int64_t bytes_to_read =
+      std::min<int64_t>(nr_bytes, file_size - location);
+  ReadAndCache(handle, static_cast<char *>(buffer), location, bytes_to_read,
+               file_size, block_size);
+
+  return bytes_to_read;
+}
+
+} // namespace duckdb

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -17,6 +17,10 @@ inline const std::string ON_DISK_CACHE_DIRECTORY =
 // if insufficient.
 inline const uint64_t MIN_DISK_SPACE_FOR_CACHE = 1_MiB;
 
+// Maximum in-memory cache block number, which caps the overall memory
+// consumption as (block size * max block count).
+inline const uint64_t MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
+
 // Number of seconds which we define as the threshold of staleness.
 inline constexpr uint64_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
 
@@ -26,6 +30,13 @@ struct OnDiskCacheConfig {
   uint64_t block_size = DEFAULT_BLOCK_SIZE;
   // Cache storage location on local filesystem.
   std::string on_disk_cache_directory = ON_DISK_CACHE_DIRECTORY;
+};
+
+struct InMemoryCacheConfig {
+  // Cache block size.
+  uint64_t block_size = DEFAULT_BLOCK_SIZE;
+  // Max cache size.
+  uint64_t block_count = MAX_IN_MEM_CACHE_BLOCK_COUNT;
 };
 
 } // namespace duckdb

--- a/src/include/in_mem_cache_block.hpp
+++ b/src/include/in_mem_cache_block.hpp
@@ -1,0 +1,26 @@
+// In-memory cache cache block key.
+
+#pragma once
+
+#include <string>
+#include <tuple>
+#include <cstdint>
+#include <functional>
+
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+// TODO(hjiang): Use customized hash and equal functor to store in cache,
+// temporarily unblock by using string as key.
+struct InMemCacheBlock {
+  std::string fname;
+  uint64_t start_off = 0;
+  uint64_t blk_size = 0;
+
+  string ToString() const {
+    return StringUtil::Format("%s-%llu-%llu", fname, start_off, blk_size);
+  }
+};
+
+} // namespace duckdb

--- a/src/include/in_memory_cache_filesystem.hpp
+++ b/src/include/in_memory_cache_filesystem.hpp
@@ -1,0 +1,218 @@
+// A filesystem wrapper, which performs in-memory cache for read operations.
+//
+// TODO(hjiang): The implementation for parallel read, check and update cache is
+// basically the same, should extract into a comon function.
+
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "cache_filesystem_config.hpp"
+#include "in_mem_cache_block.hpp"
+#include "lru_cache.hpp"
+
+namespace duckdb {
+
+// Forward declaration.
+class InMemoryCacheFileSystem;
+
+class InMemoryCacheFileHandle : public FileHandle {
+public:
+  InMemoryCacheFileHandle(unique_ptr<FileHandle> internal_file_handle_p,
+                          InMemoryCacheFileSystem &fs);
+  ~InMemoryCacheFileHandle() override = default;
+  void Close() override {}
+
+private:
+  friend class InMemoryCacheFileSystem;
+  unique_ptr<FileHandle> internal_file_handle;
+};
+
+class InMemoryCacheFileSystem : public FileSystem {
+public:
+  explicit InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
+      : InMemoryCacheFileSystem(std::move(internal_filesystem_p),
+                                InMemoryCacheConfig{}) {}
+  InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
+                          InMemoryCacheConfig cache_config);
+  std::string GetName() const override { return "in_mem_cache_filesystem"; }
+
+  void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
+  int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+
+  // Expose `Read` interface with testing property injected, underlying it uses
+  // the same implementation as production one.
+  int64_t ReadForTesting(FileHandle &handle, void *buffer, int64_t nr_bytes,
+                         idx_t location, uint64_t block_size);
+
+  // For other API calls, delegate to [internal_filesystem] to handle.
+  unique_ptr<FileHandle>
+  OpenFile(const string &path, FileOpenFlags flags,
+           optional_ptr<FileOpener> opener = nullptr) override {
+    auto file_handle = internal_filesystem->OpenFile(
+        path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
+    return make_uniq<InMemoryCacheFileHandle>(std::move(file_handle), *this);
+  }
+  unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle,
+                                            bool write) override {
+    auto file_handle =
+        internal_filesystem->OpenCompressedFile(std::move(handle), write);
+    return make_uniq<InMemoryCacheFileHandle>(std::move(file_handle), *this);
+  }
+  void Write(FileHandle &handle, void *buffer, int64_t nr_bytes,
+             idx_t location) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer,
+                               nr_bytes, location);
+  }
+  int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->Write(*disk_cache_handle.internal_file_handle,
+                                      buffer, nr_bytes);
+  }
+  bool Trim(FileHandle &handle, idx_t offset_bytes,
+            idx_t length_bytes) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle,
+                                     offset_bytes, length_bytes);
+  }
+  int64_t GetFileSize(FileHandle &handle) {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->GetFileSize(
+        *disk_cache_handle.internal_file_handle);
+  }
+  time_t GetLastModifiedTime(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->GetLastModifiedTime(
+        *disk_cache_handle.internal_file_handle);
+  }
+  FileType GetFileType(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->GetFileType(
+        *disk_cache_handle.internal_file_handle);
+  }
+  void Truncate(FileHandle &handle, int64_t new_size) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->Truncate(
+        *disk_cache_handle.internal_file_handle, new_size);
+  }
+  bool DirectoryExists(const string &directory,
+                       optional_ptr<FileOpener> opener = nullptr) override {
+    return internal_filesystem->DirectoryExists(directory, opener);
+  }
+  void CreateDirectory(const string &directory,
+                       optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->CreateDirectory(directory, opener);
+  }
+  void RemoveDirectory(const string &directory,
+                       optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->RemoveDirectory(directory, opener);
+  }
+  bool ListFiles(const string &directory,
+                 const std::function<void(const string &, bool)> &callback,
+                 FileOpener *opener = nullptr) override {
+    return internal_filesystem->ListFiles(directory, callback, opener);
+  }
+  void MoveFile(const string &source, const string &target,
+                optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->MoveFile(source, target, opener);
+  }
+  bool FileExists(const string &filename,
+                  optional_ptr<FileOpener> opener = nullptr) override {
+    return internal_filesystem->FileExists(filename, opener);
+  }
+  bool IsPipe(const string &filename,
+              optional_ptr<FileOpener> opener = nullptr) override {
+    return internal_filesystem->IsPipe(filename, opener);
+  }
+  void RemoveFile(const string &filename,
+                  optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->RemoveFile(filename, opener);
+  }
+  void FileSync(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
+  }
+  string GetHomeDirectory() override {
+    return internal_filesystem->GetHomeDirectory();
+  }
+  string ExpandPath(const string &path) override {
+    return internal_filesystem->ExpandPath(path);
+  }
+  string PathSeparator(const string &path) override {
+    return internal_filesystem->PathSeparator(path);
+  }
+  vector<string> Glob(const string &path,
+                      FileOpener *opener = nullptr) override {
+    return internal_filesystem->Glob(path, opener);
+  }
+  void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
+    internal_filesystem->RegisterSubSystem(std::move(sub_fs));
+  }
+  void RegisterSubSystem(FileCompressionType compression_type,
+                         unique_ptr<FileSystem> fs) override {
+    internal_filesystem->RegisterSubSystem(compression_type, std::move(fs));
+  }
+  void UnregisterSubSystem(const string &name) override {
+    internal_filesystem->UnregisterSubSystem(name);
+  }
+  vector<string> ListSubSystems() override {
+    return internal_filesystem->ListSubSystems();
+  }
+  bool CanHandleFile(const string &fpath) override {
+    return internal_filesystem->CanHandleFile(fpath);
+  }
+  void Seek(FileHandle &handle, idx_t location) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    internal_filesystem->Seek(*disk_cache_handle.internal_file_handle,
+                              location);
+  }
+  void Reset(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    internal_filesystem->Reset(*disk_cache_handle.internal_file_handle);
+  }
+  idx_t SeekPosition(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->SeekPosition(
+        *disk_cache_handle.internal_file_handle);
+  }
+  // Mutual set acts partially as priority system, which means if multiple
+  // filesystem instance could handle a certain path, if mutual set true,
+  // first-fit fs instance will be selected. Set cached filesystem always
+  // mutually set, so it has higher priority than non-cached version.
+  bool IsManuallySet() override { return true; }
+  bool CanSeek() override { return internal_filesystem->CanSeek(); }
+  bool OnDiskFile(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
+    return internal_filesystem->OnDiskFile(
+        *disk_cache_handle.internal_file_handle);
+  }
+  void SetDisabledFileSystems(const vector<string> &names) override {
+    internal_filesystem->SetDisabledFileSystems(names);
+  }
+
+private:
+  // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
+  // to local filesystem and return to user.
+  void ReadAndCache(FileHandle &handle, char *buffer,
+                    uint64_t requested_start_offset,
+                    uint64_t requested_bytes_to_read, uint64_t file_size,
+                    uint64_t block_size);
+
+  // Read from [location] on [nr_bytes] for the given [handle] into [buffer].
+  // Return the actual number of bytes to read.
+  int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes,
+                   idx_t location, uint64_t block_size);
+
+  // Read-cache filesystem configuration.
+  InMemoryCacheConfig cache_config;
+  // Used to access remote files.
+  unique_ptr<FileSystem> internal_filesystem;
+  // LRU cache to store blocks.
+  // TODO(hjiang): Temporarily use string as key, should switch to customized
+  // hash.
+  ThreadSafeSharedLruCache<string, string> cache;
+};
+
+} // namespace duckdb

--- a/src/utils/include/resize_uninitialized.hpp
+++ b/src/utils/include/resize_uninitialized.hpp
@@ -59,7 +59,7 @@ inline void STLStringResizeUninitialized(string_type *s, size_t new_size) {
 
 // Create a string with the given size, with all bytes uninitialized. Useful to
 // use as a buffer.
-std::string CreateResizeUninitializedString(size_t size) {
+inline std::string CreateResizeUninitializedString(size_t size) {
   std::string content;
   STLStringResizeUninitialized(&content, size);
   return content;

--- a/unit/test_in_memory_cache_filesystem.cpp
+++ b/unit/test_in_memory_cache_filesystem.cpp
@@ -1,0 +1,82 @@
+// Unit test for in-memory cache filesystem.
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "duckdb/common/local_file_system.hpp"
+#include "in_memory_cache_filesystem.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "cache_filesystem_config.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+constexpr uint64_t TEST_FILE_SIZE = 26;
+const auto TEST_FILE_CONTENT = []() {
+  string content(TEST_FILE_SIZE, '\0');
+  for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
+    content[idx] = 'a' + idx;
+  }
+  return content;
+}();
+const auto TEST_FILENAME =
+    StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
+const InMemoryCacheConfig TEST_CACHE_CONFIG = []() {
+  InMemoryCacheConfig cache_config;
+  return cache_config;
+}();
+} // namespace
+
+TEST_CASE("Test on in-memory cache filesystem",
+          "[in-memory cache filesystem test]") {
+  InMemoryCacheFileSystem in_mem_cache_fs{LocalFileSystem::CreateLocal(),
+                                          TEST_CACHE_CONFIG};
+
+  // First uncached read.
+  {
+    auto handle =
+        in_mem_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+    const uint64_t start_offset = 1;
+    const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
+    string content(bytes_to_read, '\0');
+    const uint64_t test_block_size = 26;
+    const uint64_t bytes_read = in_mem_cache_fs.ReadForTesting(
+        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
+        bytes_to_read, start_offset, test_block_size);
+    REQUIRE(bytes_read == bytes_to_read);
+    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+  }
+
+  // Second cached read.
+  {
+    auto handle =
+        in_mem_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+    const uint64_t start_offset = 1;
+    const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
+    string content(bytes_to_read, '\0');
+    const uint64_t test_block_size = 26;
+    const uint64_t bytes_read = in_mem_cache_fs.ReadForTesting(
+        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
+        bytes_to_read, start_offset, test_block_size);
+    REQUIRE(bytes_read == bytes_to_read);
+    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+  }
+}
+
+int main(int argc, char **argv) {
+  auto local_filesystem = LocalFileSystem::CreateLocal();
+  auto file_handle = local_filesystem->OpenFile(
+      TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
+                         FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+  local_filesystem->Write(
+      *file_handle,
+      const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
+      TEST_FILE_SIZE, /*location=*/0);
+  file_handle->Sync();
+  file_handle->Close();
+
+  int result = Catch::Session().run(argc, argv);
+  local_filesystem->RemoveFile(TEST_FILENAME);
+  return result;
+}


### PR DESCRIPTION
Basically mimic the implementation for on-disk cache (i.e. parallelize IO requests, check cache and copy cache to target address).

TODO list:
- Use customized hash, instead of using debug string as cache key;
- Extract common parts with on-disk cache filesystem into a separate class, so we could share code and unit tests