### PR TITLE
Extract out a common cache filesystem to share between on-disk and in-memory implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(duckdb/third_party/httplib)
 
 set(EXTENSION_SOURCES
     src/read_cache_fs_extension.cpp
+    src/base_cache_filesystem.cpp
     src/disk_cache_filesystem.cpp
     src/in_memory_cache_filesystem.cpp
     src/utils/filesystem_utils.cpp

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
 
-format-all:
+format-all: format
 	find unit/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i
 	find benchmark/ -iname *.hpp -o -iname *.cpp | xargs clang-format --sort-includes=0 -style=file -i

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ LOAD read_cache_fs;
 SELECT * FROM read_csv_auto('https://csvbase.com/meripaterson/stock-exchanges') LIMIT 10;
 ```
 
+## Formatting
+All code should be formatted as `make format-all`.
+When new folder added, `Makefile` might be changed to include more files to lint.
+
 ## TODO items
 - [ ] Expose a function to clean read cache files on local filesystem
 - [ ] Provide options to configure parameters, for example, block size, total memory consumption for in-memory cache, etc

--- a/src/base_cache_filesystem.cpp
+++ b/src/base_cache_filesystem.cpp
@@ -1,0 +1,46 @@
+#include "base_cache_filesystem.hpp"
+#include "cache_filesystem_config.hpp"
+
+namespace duckdb {
+
+CacheFileSystemHandle::CacheFileSystemHandle(
+    unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs)
+    : FileHandle(fs, internal_file_handle_p->GetPath(),
+                 internal_file_handle_p->GetFlags()),
+      internal_file_handle(std::move(internal_file_handle_p)) {}
+
+void CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
+                           idx_t location) {
+  ReadImpl(handle, buffer, nr_bytes, location, DEFAULT_BLOCK_SIZE);
+}
+int64_t CacheFileSystem::Read(FileHandle &handle, void *buffer,
+                              int64_t nr_bytes) {
+  const int64_t bytes_read = ReadImpl(
+      handle, buffer, nr_bytes, handle.SeekPosition(), DEFAULT_BLOCK_SIZE);
+  handle.Seek(handle.SeekPosition() + bytes_read);
+  return bytes_read;
+}
+int64_t CacheFileSystem::ReadForTesting(FileHandle &handle, void *buffer,
+                                        int64_t nr_bytes, idx_t location,
+                                        uint64_t block_size) {
+  return ReadImpl(handle, buffer, nr_bytes, location, block_size);
+}
+int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
+                                  int64_t nr_bytes, idx_t location,
+                                  uint64_t block_size) {
+  const auto file_size = handle.GetFileSize();
+
+  // No more bytes to read.
+  if (location == file_size) {
+    return 0;
+  }
+
+  const int64_t bytes_to_read =
+      std::min<int64_t>(nr_bytes, file_size - location);
+  ReadAndCache(handle, static_cast<char *>(buffer), location, bytes_to_read,
+               file_size, block_size);
+
+  return bytes_to_read;
+}
+
+} // namespace duckdb

--- a/src/include/base_cache_filesystem.hpp
+++ b/src/include/base_cache_filesystem.hpp
@@ -1,0 +1,201 @@
+// Base class for cache filesystem, including in-memory cache and on-disk cache.
+
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+
+namespace duckdb {
+
+// Forward declaration.
+class CacheFileSystem;
+
+// File handle used for cache filesystem.
+class CacheFileSystemHandle : public FileHandle {
+public:
+  CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p,
+                        CacheFileSystem &fs);
+  ~CacheFileSystemHandle() override = default;
+  void Close() override {}
+
+  unique_ptr<FileHandle> internal_file_handle;
+};
+
+class CacheFileSystem : public FileSystem {
+public:
+  explicit CacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
+      : internal_filesystem(std::move(internal_filesystem_p)) {}
+
+  void Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
+            idx_t location) override;
+  int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+
+  // Expose `Read` interface with testing property injected, underlying it uses
+  // the same implementation as production one.
+  int64_t ReadForTesting(FileHandle &handle, void *buffer, int64_t nr_bytes,
+                         idx_t location, uint64_t block_size);
+
+  // For other API calls, delegate to [internal_filesystem] to handle.
+  unique_ptr<FileHandle>
+  OpenFile(const string &path, FileOpenFlags flags,
+           optional_ptr<FileOpener> opener = nullptr) override {
+    auto file_handle = internal_filesystem->OpenFile(
+        path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
+    return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this);
+  }
+  unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle,
+                                            bool write) override {
+    auto file_handle =
+        internal_filesystem->OpenCompressedFile(std::move(handle), write);
+    return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this);
+  }
+  void Write(FileHandle &handle, void *buffer, int64_t nr_bytes,
+             idx_t location) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer,
+                               nr_bytes, location);
+  }
+  int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->Write(*disk_cache_handle.internal_file_handle,
+                                      buffer, nr_bytes);
+  }
+  bool Trim(FileHandle &handle, idx_t offset_bytes,
+            idx_t length_bytes) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle,
+                                     offset_bytes, length_bytes);
+  }
+  int64_t GetFileSize(FileHandle &handle) {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->GetFileSize(
+        *disk_cache_handle.internal_file_handle);
+  }
+  time_t GetLastModifiedTime(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->GetLastModifiedTime(
+        *disk_cache_handle.internal_file_handle);
+  }
+  FileType GetFileType(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->GetFileType(
+        *disk_cache_handle.internal_file_handle);
+  }
+  void Truncate(FileHandle &handle, int64_t new_size) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->Truncate(
+        *disk_cache_handle.internal_file_handle, new_size);
+  }
+  bool DirectoryExists(const string &directory,
+                       optional_ptr<FileOpener> opener = nullptr) override {
+    return internal_filesystem->DirectoryExists(directory, opener);
+  }
+  void CreateDirectory(const string &directory,
+                       optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->CreateDirectory(directory, opener);
+  }
+  void RemoveDirectory(const string &directory,
+                       optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->RemoveDirectory(directory, opener);
+  }
+  bool ListFiles(const string &directory,
+                 const std::function<void(const string &, bool)> &callback,
+                 FileOpener *opener = nullptr) override {
+    return internal_filesystem->ListFiles(directory, callback, opener);
+  }
+  void MoveFile(const string &source, const string &target,
+                optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->MoveFile(source, target, opener);
+  }
+  bool FileExists(const string &filename,
+                  optional_ptr<FileOpener> opener = nullptr) override {
+    return internal_filesystem->FileExists(filename, opener);
+  }
+  bool IsPipe(const string &filename,
+              optional_ptr<FileOpener> opener = nullptr) override {
+    return internal_filesystem->IsPipe(filename, opener);
+  }
+  void RemoveFile(const string &filename,
+                  optional_ptr<FileOpener> opener = nullptr) override {
+    internal_filesystem->RemoveFile(filename, opener);
+  }
+  void FileSync(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
+  }
+  string GetHomeDirectory() override {
+    return internal_filesystem->GetHomeDirectory();
+  }
+  string ExpandPath(const string &path) override {
+    return internal_filesystem->ExpandPath(path);
+  }
+  string PathSeparator(const string &path) override {
+    return internal_filesystem->PathSeparator(path);
+  }
+  vector<string> Glob(const string &path,
+                      FileOpener *opener = nullptr) override {
+    return internal_filesystem->Glob(path, opener);
+  }
+  void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
+    internal_filesystem->RegisterSubSystem(std::move(sub_fs));
+  }
+  void RegisterSubSystem(FileCompressionType compression_type,
+                         unique_ptr<FileSystem> fs) override {
+    internal_filesystem->RegisterSubSystem(compression_type, std::move(fs));
+  }
+  void UnregisterSubSystem(const string &name) override {
+    internal_filesystem->UnregisterSubSystem(name);
+  }
+  vector<string> ListSubSystems() override {
+    return internal_filesystem->ListSubSystems();
+  }
+  bool CanHandleFile(const string &fpath) override {
+    return internal_filesystem->CanHandleFile(fpath);
+  }
+  void Seek(FileHandle &handle, idx_t location) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    internal_filesystem->Seek(*disk_cache_handle.internal_file_handle,
+                              location);
+  }
+  void Reset(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    internal_filesystem->Reset(*disk_cache_handle.internal_file_handle);
+  }
+  idx_t SeekPosition(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->SeekPosition(
+        *disk_cache_handle.internal_file_handle);
+  }
+  // Mutual set acts partially as priority system, which means if multiple
+  // filesystem instance could handle a certain path, if mutual set true,
+  // first-fit fs instance will be selected. Set cached filesystem always
+  // mutually set, so it has higher priority than non-cached version.
+  bool IsManuallySet() override { return true; }
+  bool CanSeek() override { return internal_filesystem->CanSeek(); }
+  bool OnDiskFile(FileHandle &handle) override {
+    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+    return internal_filesystem->OnDiskFile(
+        *disk_cache_handle.internal_file_handle);
+  }
+  void SetDisabledFileSystems(const vector<string> &names) override {
+    internal_filesystem->SetDisabledFileSystems(names);
+  }
+
+protected:
+  // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
+  // to local filesystem and return to user.
+  virtual void ReadAndCache(FileHandle &handle, char *buffer,
+                            uint64_t requested_start_offset,
+                            uint64_t requested_bytes_to_read,
+                            uint64_t file_size, uint64_t block_size) = 0;
+
+  // Read from [location] on [nr_bytes] for the given [handle] into [buffer].
+  // Return the actual number of bytes to read.
+  int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes,
+                   idx_t location, uint64_t block_size);
+
+  // Used to access remote files.
+  unique_ptr<FileSystem> internal_filesystem;
+};
+
+} // namespace duckdb

--- a/src/include/disk_cache_filesystem.hpp
+++ b/src/include/disk_cache_filesystem.hpp
@@ -6,25 +6,11 @@
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "cache_filesystem_config.hpp"
+#include "base_cache_filesystem.hpp"
 
 namespace duckdb {
 
-// Forward declaration.
-class DiskCacheFileSystem;
-
-class DiskCacheFileHandle : public FileHandle {
-public:
-  DiskCacheFileHandle(unique_ptr<FileHandle> internal_file_handle_p,
-                      DiskCacheFileSystem &fs);
-  ~DiskCacheFileHandle() override = default;
-  void Close() override {}
-
-private:
-  friend class DiskCacheFileSystem;
-  unique_ptr<FileHandle> internal_file_handle;
-};
-
-class DiskCacheFileSystem : public FileSystem {
+class DiskCacheFileSystem final : public CacheFileSystem {
 public:
   explicit DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
       : DiskCacheFileSystem(std::move(internal_filesystem_p),
@@ -33,172 +19,13 @@ public:
                       OnDiskCacheConfig cache_directory_p);
   std::string GetName() const override { return "disk_cache_filesystem"; }
 
-  void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
-  int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
-
-  // Expose `Read` interface with testing property injected, underlying it uses
-  // the same implementation as production one.
-  int64_t ReadForTesting(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                         idx_t location, uint64_t block_size);
-
-  // For other API calls, delegate to [internal_filesystem] to handle.
-  unique_ptr<FileHandle>
-  OpenFile(const string &path, FileOpenFlags flags,
-           optional_ptr<FileOpener> opener = nullptr) override {
-    auto file_handle = internal_filesystem->OpenFile(
-        path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
-    return make_uniq<DiskCacheFileHandle>(std::move(file_handle), *this);
-  }
-  unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle,
-                                            bool write) override {
-    auto file_handle =
-        internal_filesystem->OpenCompressedFile(std::move(handle), write);
-    return make_uniq<DiskCacheFileHandle>(std::move(file_handle), *this);
-  }
-  void Write(FileHandle &handle, void *buffer, int64_t nr_bytes,
-             idx_t location) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer,
-                               nr_bytes, location);
-  }
-  int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->Write(*disk_cache_handle.internal_file_handle,
-                                      buffer, nr_bytes);
-  }
-  bool Trim(FileHandle &handle, idx_t offset_bytes,
-            idx_t length_bytes) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle,
-                                     offset_bytes, length_bytes);
-  }
-  int64_t GetFileSize(FileHandle &handle) {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->GetFileSize(
-        *disk_cache_handle.internal_file_handle);
-  }
-  time_t GetLastModifiedTime(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->GetLastModifiedTime(
-        *disk_cache_handle.internal_file_handle);
-  }
-  FileType GetFileType(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->GetFileType(
-        *disk_cache_handle.internal_file_handle);
-  }
-  void Truncate(FileHandle &handle, int64_t new_size) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->Truncate(
-        *disk_cache_handle.internal_file_handle, new_size);
-  }
-  bool DirectoryExists(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->DirectoryExists(directory, opener);
-  }
-  void CreateDirectory(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->CreateDirectory(directory, opener);
-  }
-  void RemoveDirectory(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->RemoveDirectory(directory, opener);
-  }
-  bool ListFiles(const string &directory,
-                 const std::function<void(const string &, bool)> &callback,
-                 FileOpener *opener = nullptr) override {
-    return internal_filesystem->ListFiles(directory, callback, opener);
-  }
-  void MoveFile(const string &source, const string &target,
-                optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->MoveFile(source, target, opener);
-  }
-  bool FileExists(const string &filename,
-                  optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->FileExists(filename, opener);
-  }
-  bool IsPipe(const string &filename,
-              optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->IsPipe(filename, opener);
-  }
-  void RemoveFile(const string &filename,
-                  optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->RemoveFile(filename, opener);
-  }
-  void FileSync(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
-  }
-  string GetHomeDirectory() override {
-    return internal_filesystem->GetHomeDirectory();
-  }
-  string ExpandPath(const string &path) override {
-    return internal_filesystem->ExpandPath(path);
-  }
-  string PathSeparator(const string &path) override {
-    return internal_filesystem->PathSeparator(path);
-  }
-  vector<string> Glob(const string &path,
-                      FileOpener *opener = nullptr) override {
-    return internal_filesystem->Glob(path, opener);
-  }
-  void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
-    internal_filesystem->RegisterSubSystem(std::move(sub_fs));
-  }
-  void RegisterSubSystem(FileCompressionType compression_type,
-                         unique_ptr<FileSystem> fs) override {
-    internal_filesystem->RegisterSubSystem(compression_type, std::move(fs));
-  }
-  void UnregisterSubSystem(const string &name) override {
-    internal_filesystem->UnregisterSubSystem(name);
-  }
-  vector<string> ListSubSystems() override {
-    return internal_filesystem->ListSubSystems();
-  }
-  bool CanHandleFile(const string &fpath) override {
-    return internal_filesystem->CanHandleFile(fpath);
-  }
-  void Seek(FileHandle &handle, idx_t location) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    internal_filesystem->Seek(*disk_cache_handle.internal_file_handle,
-                              location);
-  }
-  void Reset(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    internal_filesystem->Reset(*disk_cache_handle.internal_file_handle);
-  }
-  idx_t SeekPosition(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->SeekPosition(
-        *disk_cache_handle.internal_file_handle);
-  }
-  // Mutual set acts partially as priority system, which means if multiple
-  // filesystem instance could handle a certain path, if mutual set true,
-  // first-fit fs instance will be selected. Set cached filesystem always
-  // mutually set, so it has higher priority than non-cached version.
-  bool IsManuallySet() override { return true; }
-  bool CanSeek() override { return internal_filesystem->CanSeek(); }
-  bool OnDiskFile(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<DiskCacheFileHandle>();
-    return internal_filesystem->OnDiskFile(
-        *disk_cache_handle.internal_file_handle);
-  }
-  void SetDisabledFileSystems(const vector<string> &names) override {
-    internal_filesystem->SetDisabledFileSystems(names);
-  }
-
-private:
+protected:
   // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
   // to local filesystem and return to user.
   void ReadAndCache(FileHandle &handle, char *buffer,
                     uint64_t requested_start_offset,
                     uint64_t requested_bytes_to_read, uint64_t file_size,
-                    uint64_t block_size);
-
-  // Read from [location] on [nr_bytes] for the given [handle] into [buffer].
-  // Return the actual number of bytes to read.
-  int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                   idx_t location, uint64_t block_size);
+                    uint64_t block_size) override;
 
   // Read-cache filesystem configuration.
   OnDiskCacheConfig cache_config;
@@ -206,8 +33,6 @@ private:
   string cache_directory;
   // Used to access local cache files.
   unique_ptr<FileSystem> local_filesystem;
-  // Used to access remote files.
-  unique_ptr<FileSystem> internal_filesystem;
 };
 
 } // namespace duckdb

--- a/src/include/in_memory_cache_filesystem.hpp
+++ b/src/include/in_memory_cache_filesystem.hpp
@@ -11,25 +11,11 @@
 #include "cache_filesystem_config.hpp"
 #include "in_mem_cache_block.hpp"
 #include "lru_cache.hpp"
+#include "base_cache_filesystem.hpp"
 
 namespace duckdb {
 
-// Forward declaration.
-class InMemoryCacheFileSystem;
-
-class InMemoryCacheFileHandle : public FileHandle {
-public:
-  InMemoryCacheFileHandle(unique_ptr<FileHandle> internal_file_handle_p,
-                          InMemoryCacheFileSystem &fs);
-  ~InMemoryCacheFileHandle() override = default;
-  void Close() override {}
-
-private:
-  friend class InMemoryCacheFileSystem;
-  unique_ptr<FileHandle> internal_file_handle;
-};
-
-class InMemoryCacheFileSystem : public FileSystem {
+class InMemoryCacheFileSystem : public CacheFileSystem {
 public:
   explicit InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
       : InMemoryCacheFileSystem(std::move(internal_filesystem_p),
@@ -38,177 +24,16 @@ public:
                           InMemoryCacheConfig cache_config);
   std::string GetName() const override { return "in_mem_cache_filesystem"; }
 
-  void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
-  int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
-
-  // Expose `Read` interface with testing property injected, underlying it uses
-  // the same implementation as production one.
-  int64_t ReadForTesting(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                         idx_t location, uint64_t block_size);
-
-  // For other API calls, delegate to [internal_filesystem] to handle.
-  unique_ptr<FileHandle>
-  OpenFile(const string &path, FileOpenFlags flags,
-           optional_ptr<FileOpener> opener = nullptr) override {
-    auto file_handle = internal_filesystem->OpenFile(
-        path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
-    return make_uniq<InMemoryCacheFileHandle>(std::move(file_handle), *this);
-  }
-  unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle,
-                                            bool write) override {
-    auto file_handle =
-        internal_filesystem->OpenCompressedFile(std::move(handle), write);
-    return make_uniq<InMemoryCacheFileHandle>(std::move(file_handle), *this);
-  }
-  void Write(FileHandle &handle, void *buffer, int64_t nr_bytes,
-             idx_t location) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer,
-                               nr_bytes, location);
-  }
-  int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->Write(*disk_cache_handle.internal_file_handle,
-                                      buffer, nr_bytes);
-  }
-  bool Trim(FileHandle &handle, idx_t offset_bytes,
-            idx_t length_bytes) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle,
-                                     offset_bytes, length_bytes);
-  }
-  int64_t GetFileSize(FileHandle &handle) {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->GetFileSize(
-        *disk_cache_handle.internal_file_handle);
-  }
-  time_t GetLastModifiedTime(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->GetLastModifiedTime(
-        *disk_cache_handle.internal_file_handle);
-  }
-  FileType GetFileType(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->GetFileType(
-        *disk_cache_handle.internal_file_handle);
-  }
-  void Truncate(FileHandle &handle, int64_t new_size) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->Truncate(
-        *disk_cache_handle.internal_file_handle, new_size);
-  }
-  bool DirectoryExists(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->DirectoryExists(directory, opener);
-  }
-  void CreateDirectory(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->CreateDirectory(directory, opener);
-  }
-  void RemoveDirectory(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->RemoveDirectory(directory, opener);
-  }
-  bool ListFiles(const string &directory,
-                 const std::function<void(const string &, bool)> &callback,
-                 FileOpener *opener = nullptr) override {
-    return internal_filesystem->ListFiles(directory, callback, opener);
-  }
-  void MoveFile(const string &source, const string &target,
-                optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->MoveFile(source, target, opener);
-  }
-  bool FileExists(const string &filename,
-                  optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->FileExists(filename, opener);
-  }
-  bool IsPipe(const string &filename,
-              optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->IsPipe(filename, opener);
-  }
-  void RemoveFile(const string &filename,
-                  optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->RemoveFile(filename, opener);
-  }
-  void FileSync(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
-  }
-  string GetHomeDirectory() override {
-    return internal_filesystem->GetHomeDirectory();
-  }
-  string ExpandPath(const string &path) override {
-    return internal_filesystem->ExpandPath(path);
-  }
-  string PathSeparator(const string &path) override {
-    return internal_filesystem->PathSeparator(path);
-  }
-  vector<string> Glob(const string &path,
-                      FileOpener *opener = nullptr) override {
-    return internal_filesystem->Glob(path, opener);
-  }
-  void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
-    internal_filesystem->RegisterSubSystem(std::move(sub_fs));
-  }
-  void RegisterSubSystem(FileCompressionType compression_type,
-                         unique_ptr<FileSystem> fs) override {
-    internal_filesystem->RegisterSubSystem(compression_type, std::move(fs));
-  }
-  void UnregisterSubSystem(const string &name) override {
-    internal_filesystem->UnregisterSubSystem(name);
-  }
-  vector<string> ListSubSystems() override {
-    return internal_filesystem->ListSubSystems();
-  }
-  bool CanHandleFile(const string &fpath) override {
-    return internal_filesystem->CanHandleFile(fpath);
-  }
-  void Seek(FileHandle &handle, idx_t location) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    internal_filesystem->Seek(*disk_cache_handle.internal_file_handle,
-                              location);
-  }
-  void Reset(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    internal_filesystem->Reset(*disk_cache_handle.internal_file_handle);
-  }
-  idx_t SeekPosition(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->SeekPosition(
-        *disk_cache_handle.internal_file_handle);
-  }
-  // Mutual set acts partially as priority system, which means if multiple
-  // filesystem instance could handle a certain path, if mutual set true,
-  // first-fit fs instance will be selected. Set cached filesystem always
-  // mutually set, so it has higher priority than non-cached version.
-  bool IsManuallySet() override { return true; }
-  bool CanSeek() override { return internal_filesystem->CanSeek(); }
-  bool OnDiskFile(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<InMemoryCacheFileHandle>();
-    return internal_filesystem->OnDiskFile(
-        *disk_cache_handle.internal_file_handle);
-  }
-  void SetDisabledFileSystems(const vector<string> &names) override {
-    internal_filesystem->SetDisabledFileSystems(names);
-  }
-
-private:
+protected:
   // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
   // to local filesystem and return to user.
   void ReadAndCache(FileHandle &handle, char *buffer,
                     uint64_t requested_start_offset,
                     uint64_t requested_bytes_to_read, uint64_t file_size,
-                    uint64_t block_size);
-
-  // Read from [location] on [nr_bytes] for the given [handle] into [buffer].
-  // Return the actual number of bytes to read.
-  int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                   idx_t location, uint64_t block_size);
+                    uint64_t block_size) override;
 
   // Read-cache filesystem configuration.
   InMemoryCacheConfig cache_config;
-  // Used to access remote files.
-  unique_ptr<FileSystem> internal_filesystem;
   // LRU cache to store blocks.
   ThreadSafeSharedLruCache<InMemCacheBlock, string, InMemCacheBlockHash,
                            InMemCacheBlockEqual>


### PR DESCRIPTION
This PR is the first step to share between in-memory and on-disk cache filesystem, the only function to implement separately is `ReadAndCache`, which performs actual remote read and cache.

Next step to refactor is to extract a common logic for parallelism and cache, with two filesystem instances providing their own caching functor.