### PR TITLE
Cleanup unnecessary read interface for testing

### DIFF
--- a/src/base_cache_filesystem.cpp
+++ b/src/base_cache_filesystem.cpp
@@ -11,23 +11,17 @@ CacheFileSystemHandle::CacheFileSystemHandle(
 
 void CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
                            idx_t location) {
-  ReadImpl(handle, buffer, nr_bytes, location, DEFAULT_BLOCK_SIZE);
+  ReadImpl(handle, buffer, nr_bytes, location);
 }
 int64_t CacheFileSystem::Read(FileHandle &handle, void *buffer,
                               int64_t nr_bytes) {
-  const int64_t bytes_read = ReadImpl(
-      handle, buffer, nr_bytes, handle.SeekPosition(), DEFAULT_BLOCK_SIZE);
+  const int64_t bytes_read =
+      ReadImpl(handle, buffer, nr_bytes, handle.SeekPosition());
   handle.Seek(handle.SeekPosition() + bytes_read);
   return bytes_read;
 }
-int64_t CacheFileSystem::ReadForTesting(FileHandle &handle, void *buffer,
-                                        int64_t nr_bytes, idx_t location,
-                                        uint64_t block_size) {
-  return ReadImpl(handle, buffer, nr_bytes, location, block_size);
-}
 int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
-                                  int64_t nr_bytes, idx_t location,
-                                  uint64_t block_size) {
+                                  int64_t nr_bytes, idx_t location) {
   const auto file_size = handle.GetFileSize();
 
   // No more bytes to read.
@@ -38,7 +32,7 @@ int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
   const int64_t bytes_to_read =
       std::min<int64_t>(nr_bytes, file_size - location);
   ReadAndCache(handle, static_cast<char *>(buffer), location, bytes_to_read,
-               file_size, block_size);
+               file_size);
 
   return bytes_to_read;
 }

--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -144,8 +144,8 @@ DiskCacheFileSystem::DiskCacheFileSystem(
 void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
                                        uint64_t requested_start_offset,
                                        uint64_t requested_bytes_to_read,
-                                       uint64_t file_size,
-                                       uint64_t block_size) {
+                                       uint64_t file_size) {
+  const uint64_t block_size = cache_config.block_size;
   const uint64_t aligned_start_offset =
       requested_start_offset / block_size * block_size;
   const uint64_t aligned_last_chunk_offset =

--- a/src/in_memory_cache_filesystem.cpp
+++ b/src/in_memory_cache_filesystem.cpp
@@ -52,8 +52,8 @@ InMemoryCacheFileSystem::InMemoryCacheFileSystem(
 void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
                                            uint64_t requested_start_offset,
                                            uint64_t requested_bytes_to_read,
-                                           uint64_t file_size,
-                                           uint64_t block_size) {
+                                           uint64_t file_size) {
+  const uint64_t block_size = cache_config.block_size;
   const uint64_t aligned_start_offset =
       requested_start_offset / block_size * block_size;
   const uint64_t aligned_last_chunk_offset =

--- a/src/include/base_cache_filesystem.hpp
+++ b/src/include/base_cache_filesystem.hpp
@@ -30,11 +30,6 @@ public:
             idx_t location) override;
   int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 
-  // Expose `Read` interface with testing property injected, underlying it uses
-  // the same implementation as production one.
-  int64_t ReadForTesting(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                         idx_t location, uint64_t block_size);
-
   // For other API calls, delegate to [internal_filesystem] to handle.
   unique_ptr<FileHandle>
   OpenFile(const string &path, FileOpenFlags flags,
@@ -187,12 +182,12 @@ protected:
   virtual void ReadAndCache(FileHandle &handle, char *buffer,
                             uint64_t requested_start_offset,
                             uint64_t requested_bytes_to_read,
-                            uint64_t file_size, uint64_t block_size) = 0;
+                            uint64_t file_size) = 0;
 
   // Read from [location] on [nr_bytes] for the given [handle] into [buffer].
   // Return the actual number of bytes to read.
   int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                   idx_t location, uint64_t block_size);
+                   idx_t location);
 
   // Used to access remote files.
   unique_ptr<FileSystem> internal_filesystem;

--- a/src/include/disk_cache_filesystem.hpp
+++ b/src/include/disk_cache_filesystem.hpp
@@ -24,8 +24,8 @@ protected:
   // to local filesystem and return to user.
   void ReadAndCache(FileHandle &handle, char *buffer,
                     uint64_t requested_start_offset,
-                    uint64_t requested_bytes_to_read, uint64_t file_size,
-                    uint64_t block_size) override;
+                    uint64_t requested_bytes_to_read,
+                    uint64_t file_size) override;
 
   // Read-cache filesystem configuration.
   OnDiskCacheConfig cache_config;

--- a/src/include/in_memory_cache_filesystem.hpp
+++ b/src/include/in_memory_cache_filesystem.hpp
@@ -29,8 +29,8 @@ protected:
   // to local filesystem and return to user.
   void ReadAndCache(FileHandle &handle, char *buffer,
                     uint64_t requested_start_offset,
-                    uint64_t requested_bytes_to_read, uint64_t file_size,
-                    uint64_t block_size) override;
+                    uint64_t requested_bytes_to_read,
+                    uint64_t file_size) override;
 
   // Read-cache filesystem configuration.
   InMemoryCacheConfig cache_config;

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -32,11 +32,6 @@ const auto TEST_FILE_CONTENT = []() {
 const auto TEST_FILENAME =
     StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
 const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
-const OnDiskCacheConfig TEST_CACHE_CONFIG = []() {
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  return cache_config;
-}();
 } // namespace
 
 // One chunk is involved, requested bytes include only "first and last chunk".
@@ -44,8 +39,12 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first "
           "meanwhile last chunk",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+  const uint64_t test_block_size = 26;
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  cache_config.block_size = test_block_size;
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    cache_config};
 
   // First uncached read.
   {
@@ -54,11 +53,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first "
     const uint64_t start_offset = 1;
     const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 26;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -69,11 +66,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first "
     const uint64_t start_offset = 1;
     const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 26;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 }
@@ -83,8 +78,12 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first and "
           "last chunk",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+  const uint64_t test_block_size = 5;
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  cache_config.block_size = test_block_size;
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    cache_config};
 
   // First uncached read.
   {
@@ -93,11 +92,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first and "
     const uint64_t start_offset = 2;
     const uint64_t bytes_to_read = 5;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -108,11 +105,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first and "
     const uint64_t start_offset = 3;
     const uint64_t bytes_to_read = 4;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 }
@@ -122,8 +117,12 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first, "
           "middle and last chunk",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+  const uint64_t test_block_size = 5;
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  cache_config.block_size = test_block_size;
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    cache_config};
 
   // First uncached read.
   {
@@ -132,11 +131,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first, "
     const uint64_t start_offset = 2;
     const uint64_t bytes_to_read = 11;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -147,11 +144,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first, "
     const uint64_t start_offset = 3;
     const uint64_t bytes_to_read = 10;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 }
@@ -162,8 +157,12 @@ TEST_CASE(
     "Test on disk cache filesystem with requested chunk first and last one",
     "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+  const uint64_t test_block_size = 5;
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  cache_config.block_size = test_block_size;
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    cache_config};
 
   // First uncached read.
   {
@@ -172,11 +171,9 @@ TEST_CASE(
     const uint64_t start_offset = 2;
     const uint64_t bytes_to_read = 2;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -187,11 +184,9 @@ TEST_CASE(
     const uint64_t start_offset = 3;
     const uint64_t bytes_to_read = 2;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 }
@@ -200,8 +195,12 @@ TEST_CASE(
 TEST_CASE("Test on disk cache filesystem with requested chunk at last of file",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+  const uint64_t test_block_size = 5;
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  cache_config.block_size = test_block_size;
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    cache_config};
 
   // First uncached read.
   {
@@ -210,11 +209,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk at last of file",
     const uint64_t start_offset = 23;
     const uint64_t bytes_to_read = 10;
     string content(3, '\0'); // effective offset range: [23, 25]
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == 3);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -234,11 +231,9 @@ TEST_CASE("Test on disk cache filesystem with requested chunk at last of file",
     const uint64_t start_offset = 15;
     const uint64_t bytes_to_read = 15;
     string content(11, '\0'); // effective offset range: [15, 25]
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == 11);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -257,8 +252,12 @@ TEST_CASE(
     "Test on disk cache filesystem with requested chunk at middle of file",
     "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+  const uint64_t test_block_size = 5;
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  cache_config.block_size = test_block_size;
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    cache_config};
 
   // First uncached read.
   {
@@ -267,11 +266,9 @@ TEST_CASE(
     const uint64_t start_offset = 16;
     const uint64_t bytes_to_read = 3;
     string content(bytes_to_read, '\0'); // effective offset range: [16, 18]
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -291,11 +288,9 @@ TEST_CASE(
     const uint64_t start_offset = 8;
     const uint64_t bytes_to_read = 14;
     string content(bytes_to_read, '\0'); // effective offset range: [8, 21]
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -313,8 +308,12 @@ TEST_CASE(
 TEST_CASE("Test on disk cache filesystem no new cache file after a full cache",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+  const uint64_t test_block_size = 5;
+  OnDiskCacheConfig cache_config;
+  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+  cache_config.block_size = test_block_size;
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    cache_config};
 
   // First uncached read.
   {
@@ -323,11 +322,9 @@ TEST_CASE("Test on disk cache filesystem no new cache file after a full cache",
     const uint64_t start_offset = 0;
     const uint64_t bytes_to_read = TEST_FILE_SIZE;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -346,11 +343,9 @@ TEST_CASE("Test on disk cache filesystem no new cache file after a full cache",
     const uint64_t start_offset = 3;
     const uint64_t bytes_to_read = 10;
     string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 5;
-    const uint64_t bytes_read = disk_cache_fs.ReadForTesting(
+    disk_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -364,28 +359,11 @@ TEST_CASE("Test on disk cache filesystem no new cache file after a full cache",
   REQUIRE(cache_files1 == cache_files2);
 }
 
-TEST_CASE("Test on disk cache filesystem read from end of file",
-          "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
-
-  auto handle =
-      disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-  const uint64_t start_offset = TEST_FILE_SIZE;
-  const uint64_t bytes_to_read = TEST_FILE_SIZE;
-  const uint64_t test_block_size = 5;
-  const int64_t bytes_read =
-      disk_cache_fs.ReadForTesting(*handle, /*buffer=*/nullptr, bytes_to_read,
-                                   start_offset, test_block_size);
-  REQUIRE(bytes_read == 0);
-}
-
 TEST_CASE("Test on reading non-existent file",
           "[on-disk cache filesystem test]") {
   LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
   DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    TEST_CACHE_CONFIG};
+                                    OnDiskCacheConfig{}};
   REQUIRE_THROWS(disk_cache_fs.OpenFile("non-existent-file",
                                         FileOpenFlags::FILE_FLAGS_READ));
 }

--- a/unit/test_in_memory_cache_filesystem.cpp
+++ b/unit/test_in_memory_cache_filesystem.cpp
@@ -41,10 +41,9 @@ TEST_CASE("Test on in-memory cache filesystem",
     const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
     string content(bytes_to_read, '\0');
     const uint64_t test_block_size = 26;
-    const uint64_t bytes_read = in_mem_cache_fs.ReadForTesting(
+    in_mem_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 
@@ -56,10 +55,9 @@ TEST_CASE("Test on in-memory cache filesystem",
     const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
     string content(bytes_to_read, '\0');
     const uint64_t test_block_size = 26;
-    const uint64_t bytes_read = in_mem_cache_fs.ReadForTesting(
+    in_mem_cache_fs.Read(
         *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset, test_block_size);
-    REQUIRE(bytes_read == bytes_to_read);
+        bytes_to_read, start_offset);
     REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
   }
 }


### PR DESCRIPTION
There's no need to expose an extra read interface to take block size, which could be contained filesystem config.