### PR TITLE
Set parallel IO thread name

### DIFF
--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <utility>
+#include <pthread.h>
 #include <utime.h>
 
 namespace duckdb {
@@ -222,6 +223,8 @@ void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
     io_threads.emplace_back([this, &handle, block_size,
                              cache_read_chunk =
                                  std::move(cache_read_chunk)]() mutable {
+      pthread_setname_np(pthread_self(), "RdCachRdThd");
+
       // Check local cache first, see if we could do a cached read.
       const auto local_cache_file = GetLocalCacheFile(
           cache_config.on_disk_cache_directory, handle.GetPath(),


### PR DESCRIPTION
... otherwise hard to debug in gdb, core, and other system tools