### PR TITLE
Use duckdb native type and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ It provides two options:
 - In-memory cache, which caches read block in memory, and is only accessible within in single duckdb process;
 - On-disk cache, which caches blocks on disk, and could be shared among all duckdb instances.
 
-On-disk cache files are stored under `<cache-directory>/<filename-sha256>.<filename>`, the default cache directory is `/tmp/duckdb_cached_http_cache`.
-There're also temporary cache files stored locally for write atomicity, named as `<filename>.<uuid>.httpfs_local_cache.tmp`, also placed under the above cache directory.
+
+Local cache file storage:
+- On-disk cache files are stored under `<cache-directory>/<filename-sha256>.<filename>`, the default cache directory is `/tmp/duckdb_cached_http_cache`.
+  + There're also temporary cache files stored locally for write atomicity, named as `<filename>.<uuid>.httpfs_local_cache.tmp`, also placed under the above cache directory.
+- An naive cache file eviction for stale files is triggered when left space on local filesystem is less than a threshold.
 
 ## Build
 ```sh

--- a/src/base_cache_filesystem.cpp
+++ b/src/base_cache_filesystem.cpp
@@ -30,7 +30,7 @@ int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
   }
 
   const int64_t bytes_to_read =
-      std::min<int64_t>(nr_bytes, file_size - location);
+      MinValue<int64_t>(nr_bytes, file_size - location);
   ReadAndCache(handle, static_cast<char *>(buffer), location, bytes_to_read,
                file_size);
 

--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -21,13 +21,13 @@ namespace {
 struct CacheReadChunk {
   // Requested memory address and file offset to read from for current chunk.
   char *requested_start_addr = nullptr;
-  uint64_t requested_start_offset = 0;
+  idx_t requested_start_offset = 0;
   // Block size aligned [requested_start_offset].
-  uint64_t aligned_start_offset = 0;
+  idx_t aligned_start_offset = 0;
 
   // Number of bytes for the chunk for IO operations, apart from the last chunk
   // it's always cache block size.
-  uint64_t chunk_size = 0;
+  idx_t chunk_size = 0;
 
   // Always allocate block size of memory for first and last chunk.
   // For middle chunks, if local cache is not hit, we also allocate memory for
@@ -38,13 +38,12 @@ struct CacheReadChunk {
   // local cache file; but for code simplicity we also allocate here.
   string content;
   // Number of bytes to copy from [content] to requested memory address.
-  uint64_t bytes_to_copy = 0;
+  idx_t bytes_to_copy = 0;
 
   // Copy from [content] to application-provided buffer.
   void CopyBufferToRequestedMemory() {
     if (!content.empty()) {
-      const uint64_t delta_offset =
-          requested_start_offset - aligned_start_offset;
+      const idx_t delta_offset = requested_start_offset - aligned_start_offset;
       std::memmove(requested_start_addr,
                    const_cast<char *>(content.data()) + delta_offset,
                    bytes_to_copy);
@@ -75,8 +74,8 @@ string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
 // Considering the naming format, it's worth noting it might _NOT_ work for
 // local files, including mounted filesystems.
 string GetLocalCacheFile(const string &cache_directory,
-                         const string &remote_file, uint64_t start_offset,
-                         uint64_t bytes_to_read) {
+                         const string &remote_file, idx_t start_offset,
+                         idx_t bytes_to_read) {
   duckdb::hash_bytes remote_file_sha256_val;
   duckdb::sha256(remote_file.data(), remote_file.length(),
                  remote_file_sha256_val);
@@ -143,26 +142,26 @@ DiskCacheFileSystem::DiskCacheFileSystem(
 }
 
 void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
-                                       uint64_t requested_start_offset,
-                                       uint64_t requested_bytes_to_read,
-                                       uint64_t file_size) {
-  const uint64_t block_size = cache_config.block_size;
-  const uint64_t aligned_start_offset =
+                                       idx_t requested_start_offset,
+                                       idx_t requested_bytes_to_read,
+                                       idx_t file_size) {
+  const idx_t block_size = cache_config.block_size;
+  const idx_t aligned_start_offset =
       requested_start_offset / block_size * block_size;
-  const uint64_t aligned_last_chunk_offset =
+  const idx_t aligned_last_chunk_offset =
       (requested_start_offset + requested_bytes_to_read) / block_size *
       block_size;
 
   // Indicate the meory address to copy to for each IO operation
   char *addr_to_write = buffer;
   // Used to calculate bytes to copy for last chunk.
-  uint64_t already_read_bytes = 0;
+  idx_t already_read_bytes = 0;
   // Threads to parallelly perform IO.
   vector<thread> io_threads;
 
   // To improve IO performance, we split requested bytes (after alignment) into
   // multiple chunks and fetch them in parallel.
-  for (uint64_t io_start_offset = aligned_start_offset;
+  for (idx_t io_start_offset = aligned_start_offset;
        io_start_offset <= aligned_last_chunk_offset;
        io_start_offset += block_size) {
     CacheReadChunk cache_read_chunk;
@@ -182,15 +181,14 @@ void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
     if (io_start_offset == aligned_start_offset &&
         io_start_offset == aligned_last_chunk_offset) {
       cache_read_chunk.chunk_size =
-          std::min<uint64_t>(block_size, file_size - io_start_offset);
+          MinValue<idx_t>(block_size, file_size - io_start_offset);
       cache_read_chunk.content =
           CreateResizeUninitializedString(cache_read_chunk.chunk_size);
       cache_read_chunk.bytes_to_copy = requested_bytes_to_read;
     }
     // Case-2: First chunk.
     else if (io_start_offset == aligned_start_offset) {
-      const uint64_t delta_offset =
-          requested_start_offset - aligned_start_offset;
+      const idx_t delta_offset = requested_start_offset - aligned_start_offset;
       addr_to_write += block_size - delta_offset;
       already_read_bytes += block_size - delta_offset;
 
@@ -201,7 +199,7 @@ void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
     // Case-3: Last chunk.
     else if (io_start_offset == aligned_last_chunk_offset) {
       cache_read_chunk.chunk_size =
-          std::min<uint64_t>(block_size, file_size - io_start_offset);
+          MinValue<idx_t>(block_size, file_size - io_start_offset);
       cache_read_chunk.content =
           CreateResizeUninitializedString(cache_read_chunk.chunk_size);
       cache_read_chunk.bytes_to_copy =

--- a/src/in_memory_cache_filesystem.cpp
+++ b/src/in_memory_cache_filesystem.cpp
@@ -20,20 +20,20 @@ namespace {
 struct CacheReadChunk {
   // Requested memory address and file offset to read from for current chunk.
   char *requested_start_addr = nullptr;
-  uint64_t requested_start_offset = 0;
+  idx_t requested_start_offset = 0;
   // Block size aligned [requested_start_offset].
-  uint64_t aligned_start_offset = 0;
+  idx_t aligned_start_offset = 0;
 
   // Number of bytes for the chunk for IO operations, apart from the last chunk
   // it's always cache block size.
-  uint64_t chunk_size = 0;
+  idx_t chunk_size = 0;
 
   // Number of bytes to copy from [content] to requested memory address.
-  uint64_t bytes_to_copy = 0;
+  idx_t bytes_to_copy = 0;
 
   // Copy from [content] to application-provided buffer.
   void CopyBufferToRequestedMemory(const std::string &content) {
-    const uint64_t delta_offset = requested_start_offset - aligned_start_offset;
+    const idx_t delta_offset = requested_start_offset - aligned_start_offset;
     std::memmove(requested_start_addr,
                  const_cast<char *>(content.data()) + delta_offset,
                  bytes_to_copy);
@@ -50,26 +50,26 @@ InMemoryCacheFileSystem::InMemoryCacheFileSystem(
 }
 
 void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
-                                           uint64_t requested_start_offset,
-                                           uint64_t requested_bytes_to_read,
-                                           uint64_t file_size) {
-  const uint64_t block_size = cache_config.block_size;
-  const uint64_t aligned_start_offset =
+                                           idx_t requested_start_offset,
+                                           idx_t requested_bytes_to_read,
+                                           idx_t file_size) {
+  const idx_t block_size = cache_config.block_size;
+  const idx_t aligned_start_offset =
       requested_start_offset / block_size * block_size;
-  const uint64_t aligned_last_chunk_offset =
+  const idx_t aligned_last_chunk_offset =
       (requested_start_offset + requested_bytes_to_read) / block_size *
       block_size;
 
   // Indicate the meory address to copy to for each IO operation
   char *addr_to_write = buffer;
   // Used to calculate bytes to copy for last chunk.
-  uint64_t already_read_bytes = 0;
+  idx_t already_read_bytes = 0;
   // Threads to parallelly perform IO.
   vector<thread> io_threads;
 
   // To improve IO performance, we split requested bytes (after alignment) into
   // multiple chunks and fetch them in parallel.
-  for (uint64_t io_start_offset = aligned_start_offset;
+  for (idx_t io_start_offset = aligned_start_offset;
        io_start_offset <= aligned_last_chunk_offset;
        io_start_offset += block_size) {
     CacheReadChunk cache_read_chunk;
@@ -89,13 +89,12 @@ void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
     if (io_start_offset == aligned_start_offset &&
         io_start_offset == aligned_last_chunk_offset) {
       cache_read_chunk.chunk_size =
-          std::min<uint64_t>(block_size, file_size - io_start_offset);
+          MinValue<idx_t>(block_size, file_size - io_start_offset);
       cache_read_chunk.bytes_to_copy = requested_bytes_to_read;
     }
     // Case-2: First chunk.
     else if (io_start_offset == aligned_start_offset) {
-      const uint64_t delta_offset =
-          requested_start_offset - aligned_start_offset;
+      const idx_t delta_offset = requested_start_offset - aligned_start_offset;
       addr_to_write += block_size - delta_offset;
       already_read_bytes += block_size - delta_offset;
 
@@ -105,7 +104,7 @@ void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
     // Case-3: Last chunk.
     else if (io_start_offset == aligned_last_chunk_offset) {
       cache_read_chunk.chunk_size =
-          std::min<uint64_t>(block_size, file_size - io_start_offset);
+          MinValue<idx_t>(block_size, file_size - io_start_offset);
       cache_read_chunk.bytes_to_copy =
           requested_bytes_to_read - already_read_bytes;
     }
@@ -132,9 +131,6 @@ void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
           block_key.blk_size = cache_read_chunk.chunk_size;
           auto cache_block = cache.Get(block_key);
 
-          // TODO(hjiang): Add documentation and implementation for stale cache
-          // eviction policy, before that it's safe to access cache file
-          // directly.
           if (cache_block != nullptr) {
             cache_read_chunk.CopyBufferToRequestedMemory(*cache_block);
             return;

--- a/src/include/base_cache_filesystem.hpp
+++ b/src/include/base_cache_filesystem.hpp
@@ -180,9 +180,8 @@ protected:
   // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
   // to local filesystem and return to user.
   virtual void ReadAndCache(FileHandle &handle, char *buffer,
-                            uint64_t requested_start_offset,
-                            uint64_t requested_bytes_to_read,
-                            uint64_t file_size) = 0;
+                            idx_t requested_start_offset,
+                            idx_t requested_bytes_to_read, idx_t file_size) = 0;
 
   // Read from [location] on [nr_bytes] for the given [handle] into [buffer].
   // Return the actual number of bytes to read.

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -4,39 +4,40 @@
 #include <cstdint>
 
 #include "size_literals.hpp"
+#include "duckdb/common/typedefs.hpp"
 
 namespace duckdb {
 
 // TODO(hjiang): Hard code block size for now, in the future we should allow
 // global configuration via `SET GLOBAL`.
-inline const uint64_t DEFAULT_BLOCK_SIZE = 64_KiB;
+inline const idx_t DEFAULT_BLOCK_SIZE = 64_KiB;
 inline const std::string ON_DISK_CACHE_DIRECTORY =
     "/tmp/duckdb_cached_http_cache";
 
 // To prevent go out of disk space, we set a threshold to disable local caching
 // if insufficient.
-inline const uint64_t MIN_DISK_SPACE_FOR_CACHE = 1_MiB;
+inline const idx_t MIN_DISK_SPACE_FOR_CACHE = 1_MiB;
 
 // Maximum in-memory cache block number, which caps the overall memory
 // consumption as (block size * max block count).
-inline const uint64_t MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
+inline const idx_t MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
 
 // Number of seconds which we define as the threshold of staleness.
-inline constexpr uint64_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
+inline constexpr idx_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
 
 // TODO(hjiang): Add constraint on largest thread number.
 struct OnDiskCacheConfig {
   // Cache block size.
-  uint64_t block_size = DEFAULT_BLOCK_SIZE;
+  idx_t block_size = DEFAULT_BLOCK_SIZE;
   // Cache storage location on local filesystem.
   std::string on_disk_cache_directory = ON_DISK_CACHE_DIRECTORY;
 };
 
 struct InMemoryCacheConfig {
   // Cache block size.
-  uint64_t block_size = DEFAULT_BLOCK_SIZE;
+  idx_t block_size = DEFAULT_BLOCK_SIZE;
   // Max cache size.
-  uint64_t block_count = MAX_IN_MEM_CACHE_BLOCK_COUNT;
+  idx_t block_count = MAX_IN_MEM_CACHE_BLOCK_COUNT;
 };
 
 } // namespace duckdb

--- a/src/include/disk_cache_filesystem.hpp
+++ b/src/include/disk_cache_filesystem.hpp
@@ -23,9 +23,8 @@ protected:
   // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
   // to local filesystem and return to user.
   void ReadAndCache(FileHandle &handle, char *buffer,
-                    uint64_t requested_start_offset,
-                    uint64_t requested_bytes_to_read,
-                    uint64_t file_size) override;
+                    idx_t requested_start_offset, idx_t requested_bytes_to_read,
+                    idx_t file_size) override;
 
   // Read-cache filesystem configuration.
   OnDiskCacheConfig cache_config;

--- a/src/include/in_mem_cache_block.hpp
+++ b/src/include/in_mem_cache_block.hpp
@@ -15,8 +15,8 @@ namespace duckdb {
 // temporarily unblock by using string as key.
 struct InMemCacheBlock {
   std::string fname;
-  uint64_t start_off = 0;
-  uint64_t blk_size = 0;
+  idx_t start_off = 0;
+  idx_t blk_size = 0;
 };
 
 struct InMemCacheBlockEqual {
@@ -29,8 +29,7 @@ struct InMemCacheBlockEqual {
 struct InMemCacheBlockHash {
   std::size_t operator()(const InMemCacheBlock &key) const {
     return std::hash<std::string>{}(key.fname) ^
-           std::hash<uint64_t>{}(key.start_off) ^
-           std::hash<uint64_t>{}(key.blk_size);
+           std::hash<idx_t>{}(key.start_off) ^ std::hash<idx_t>{}(key.blk_size);
   }
 };
 


### PR DESCRIPTION
duckdb uses `idx_t` to represent unsigned integers (i.e. offset, file size, indexes, etc).
Also update documentation to reflect local cache file eviction policy.