### PR TITLE
Fix pthread issue on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(EXTENSION_SOURCES
     src/disk_cache_filesystem.cpp
     src/in_memory_cache_filesystem.cpp
     src/utils/filesystem_utils.cpp
+    src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp
     duckdb-httpfs/extension/httpfs/crypto.cpp
     duckdb-httpfs/extension/httpfs/hffs.cpp

--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -5,10 +5,10 @@
 #include "duckdb/common/types/uuid.hpp"
 #include "utils/include/resize_uninitialized.hpp"
 #include "utils/include/filesystem_utils.hpp"
+#include "utils/include/thread_utils.hpp"
 
 #include <cstdint>
 #include <utility>
-#include <pthread.h>
 #include <utime.h>
 
 namespace duckdb {
@@ -221,7 +221,7 @@ void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
     io_threads.emplace_back([this, &handle, block_size,
                              cache_read_chunk =
                                  std::move(cache_read_chunk)]() mutable {
-      pthread_setname_np(pthread_self(), "RdCachRdThd");
+      SetThreadName("RdCachRdThd");
 
       // Check local cache first, see if we could do a cached read.
       const auto local_cache_file = GetLocalCacheFile(

--- a/src/utils/include/thread_utils.hpp
+++ b/src/utils/include/thread_utils.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace duckdb {
+
+// Set thread name to current thread; fail silently if an error happens.
+void SetThreadName(const std::string &thread_name);
+
+} // namespace duckdb

--- a/src/utils/thread_utils.cpp
+++ b/src/utils/thread_utils.cpp
@@ -1,0 +1,16 @@
+#include "thread_utils.hpp"
+
+#include <pthread.h>
+
+namespace duckdb {
+
+void SetThreadName(const std::string &thread_name) {
+#if defined(__APPLE__)
+  pthread_setname_np(thread_name.c_str());
+#elif defined(__linux__)
+  // Restricted to 16 characters, include terminator.
+  pthread_setname_np(pthread_self(), thread_name.substr(0, 15).c_str());
+#endif
+}
+
+} // namespace duckdb


### PR DESCRIPTION
`pthread_setname_np` has different declaration on macos and linux platform.