### PR TITLE
Fix cache filesystem for local filesystem inside

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ target_link_libraries(test_shared_lru_cache ${EXTENSION_NAME})
 add_executable(test_size_literals unit/test_size_literals.cpp)
 target_link_libraries(test_size_literals ${EXTENSION_NAME})
 
+add_executable(test_base_cache_filesystem unit/test_base_cache_filesystem)
+target_link_libraries(test_base_cache_filesystem ${EXTENSION_NAME})
+
 # Benchmark
 add_executable(read_s3_object benchmark/read_s3_object.cpp)
 target_link_libraries(read_s3_object ${EXTENSION_NAME})

--- a/src/base_cache_filesystem.cpp
+++ b/src/base_cache_filesystem.cpp
@@ -9,6 +9,38 @@ CacheFileSystemHandle::CacheFileSystemHandle(
                  internal_file_handle_p->GetFlags()),
       internal_file_handle(std::move(internal_file_handle_p)) {}
 
+bool CacheFileSystem::CanHandleFile(const string &fpath) {
+  if (internal_filesystem->CanHandleFile(fpath)) {
+    return true;
+  }
+
+  // Special handle cases where local filesystem is the internal filesystem.
+  //
+  // duckdb's implementation is `LocalFileSystem::CanHandle` always returns
+  // false, to enable cached local filesystem (i.e. make in-memory cache for
+  // disk access), we inherit the virtual filesystem's assumption that local
+  // filesystem is the fallback type, which could potentially handles
+  // everything.
+  //
+  // If it doesn't work with local filesystem, an error is returned anyway.
+  if (internal_filesystem->GetName() == "LocalFileSystem") {
+    return true;
+  }
+
+  return false;
+}
+
+bool CacheFileSystem::IsManuallySet() {
+  // As documented at [CanHandleFile], local filesystem serves as the fallback
+  // filesystem for all given paths, return false in certain case so virtual
+  // filesystem could pick the most suitable one if exists.
+  if (internal_filesystem->GetName() == "LocalFileSystem") {
+    return false;
+  }
+
+  return true;
+}
+
 void CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
                            idx_t location) {
   ReadImpl(handle, buffer, nr_bytes, location);

--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -141,6 +141,11 @@ DiskCacheFileSystem::DiskCacheFileSystem(
   local_filesystem->CreateDirectory(cache_config.on_disk_cache_directory);
 }
 
+std::string DiskCacheFileSystem::GetName() const {
+  return StringUtil::Format("disk_cache_filesystem for %s",
+                            internal_filesystem->GetName());
+}
+
 void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
                                        idx_t requested_start_offset,
                                        idx_t requested_bytes_to_read,

--- a/src/in_memory_cache_filesystem.cpp
+++ b/src/in_memory_cache_filesystem.cpp
@@ -49,6 +49,11 @@ InMemoryCacheFileSystem::InMemoryCacheFileSystem(
       cache_config(std::move(cache_config_p)), cache(cache_config.block_count) {
 }
 
+std::string InMemoryCacheFileSystem::GetName() const {
+  return StringUtil::Format("in_mem_cache_filesystem for %s",
+                            internal_filesystem->GetName());
+}
+
 void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
                                            idx_t requested_start_offset,
                                            idx_t requested_bytes_to_read,

--- a/src/include/base_cache_filesystem.hpp
+++ b/src/include/base_cache_filesystem.hpp
@@ -144,9 +144,7 @@ public:
   vector<string> ListSubSystems() override {
     return internal_filesystem->ListSubSystems();
   }
-  bool CanHandleFile(const string &fpath) override {
-    return internal_filesystem->CanHandleFile(fpath);
-  }
+  bool CanHandleFile(const string &fpath) override;
   void Seek(FileHandle &handle, idx_t location) override {
     auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
     internal_filesystem->Seek(*disk_cache_handle.internal_file_handle,
@@ -161,11 +159,7 @@ public:
     return internal_filesystem->SeekPosition(
         *disk_cache_handle.internal_file_handle);
   }
-  // Mutual set acts partially as priority system, which means if multiple
-  // filesystem instance could handle a certain path, if mutual set true,
-  // first-fit fs instance will be selected. Set cached filesystem always
-  // mutually set, so it has higher priority than non-cached version.
-  bool IsManuallySet() override { return true; }
+  bool IsManuallySet() override;
   bool CanSeek() override { return internal_filesystem->CanSeek(); }
   bool OnDiskFile(FileHandle &handle) override {
     auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();

--- a/src/include/disk_cache_filesystem.hpp
+++ b/src/include/disk_cache_filesystem.hpp
@@ -17,7 +17,7 @@ public:
                             OnDiskCacheConfig{}) {}
   DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
                       OnDiskCacheConfig cache_directory_p);
-  std::string GetName() const override { return "disk_cache_filesystem"; }
+  std::string GetName() const override;
 
 protected:
   // Read from [handle] for an block-size aligned chunk into [start_addr]; cache

--- a/src/include/in_memory_cache_filesystem.hpp
+++ b/src/include/in_memory_cache_filesystem.hpp
@@ -22,7 +22,7 @@ public:
                                 InMemoryCacheConfig{}) {}
   InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
                           InMemoryCacheConfig cache_config);
-  std::string GetName() const override { return "in_mem_cache_filesystem"; }
+  std::string GetName() const override;
 
 protected:
   // Read from [handle] for an block-size aligned chunk into [start_addr]; cache

--- a/unit/test_base_cache_filesystem.cpp
+++ b/unit/test_base_cache_filesystem.cpp
@@ -1,0 +1,54 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include <string>
+
+#include "disk_cache_filesystem.hpp"
+#include "duckdb/common/virtual_file_system.hpp"
+#include "hffs.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+
+const std::string TEST_CONTENT = "helloworld";
+const std::string TEST_FILEPATH = "/tmp/testfile";
+void CreateTestFile() {
+  auto local_filesystem = LocalFileSystem::CreateLocal();
+  auto file_handle = local_filesystem->OpenFile(
+      TEST_FILEPATH, FileOpenFlags::FILE_FLAGS_WRITE |
+                         FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+  local_filesystem->Write(*file_handle, const_cast<char *>(TEST_CONTENT.data()),
+                          TEST_CONTENT.length(), /*location=*/0);
+  file_handle->Sync();
+}
+void DeleteTestFile() {
+  LocalFileSystem::CreateLocal()->RemoveFile(TEST_FILEPATH);
+}
+
+} // namespace
+
+// A more ideal unit test would be, we could check hugging face filesystem will
+// be used for certains files.
+TEST_CASE("Test cached filesystem CanHandle", "[base cache filesystem]") {
+  unique_ptr<FileSystem> vfs = make_uniq<VirtualFileSystem>();
+  vfs->RegisterSubSystem(
+      make_uniq<DiskCacheFileSystem>(make_uniq<HuggingFaceFileSystem>()));
+  vfs->RegisterSubSystem(
+      make_uniq<DiskCacheFileSystem>(make_uniq<LocalFileSystem>()));
+
+  // VFS can handle local files with cached local filesystem.
+  auto file_handle =
+      vfs->OpenFile(TEST_FILEPATH, FileOpenFlags::FILE_FLAGS_READ);
+  // Check casting success to make sure disk cache filesystem is selected,
+  // rather than the fallback local filesystem within virtual filesystem.
+  [[maybe_unused]] auto &cached_file_handle =
+      file_handle->Cast<CacheFileSystemHandle>();
+}
+
+int main(int argc, char **argv) {
+  CreateTestFile();
+  int result = Catch::Session().run(argc, argv);
+  DeleteTestFile();
+  return result;
+}


### PR DESCRIPTION
This PR does two things:
- Allow cache filesystem to wrap around local filesystem, previously it doesn't work because local filesystem `CanHandle` returns false at all times;
- Update `GetName` implementation for cached filesystem instances to include internal filesystem name.