### PR TITLE
Add other configs for cache filesystem

### DIFF
--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -148,12 +148,24 @@ std::string DiskCacheFileSystem::GetName() const {
 unique_ptr<FileHandle>
 DiskCacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                               optional_ptr<FileOpener> opener) {
-  Value val;
-  if (opener) {
+  if (opener != nullptr) {
+    Value val;
+
+    // Check and update cache block size if necessary.
+    FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_block_size",
+                                     val);
+    cache_config.block_size = val.GetValue<uint64_t>();
+    g_cache_block_size = cache_config.block_size;
+
+    // Check and update cache directory if necessary.
     FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_directory",
                                      val);
+    // Check and update global setting if updated.
     cache_config.on_disk_cache_directory = val.ToString();
-    local_filesystem->CreateDirectory(cache_config.on_disk_cache_directory);
+    if (cache_config.on_disk_cache_directory != g_on_disk_cache_directory) {
+      g_on_disk_cache_directory = cache_config.on_disk_cache_directory;
+      local_filesystem->CreateDirectory(g_on_disk_cache_directory);
+    }
   }
 
   return CacheFileSystem::OpenFile(path, flags, opener);

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -8,10 +8,11 @@
 
 namespace duckdb {
 
-// TODO(hjiang): Hard code block size for now, in the future we should allow
-// global configuration via `SET GLOBAL`.
-inline const idx_t DEFAULT_BLOCK_SIZE = 64_KiB;
-inline const std::string ON_DISK_CACHE_DIRECTORY =
+//===--------------------------------------------------------------------===//
+// Default configuration
+//===--------------------------------------------------------------------===//
+inline const idx_t DEFAULT_CACHE_BLOCK_SIZE = 64_KiB;
+inline const std::string DEFAULT_ON_DISK_CACHE_DIRECTORY =
     "/tmp/duckdb_cached_http_cache";
 
 // To prevent go out of disk space, we set a threshold to disable local caching
@@ -20,24 +21,34 @@ inline const idx_t MIN_DISK_SPACE_FOR_CACHE = 1_MiB;
 
 // Maximum in-memory cache block number, which caps the overall memory
 // consumption as (block size * max block count).
-inline const idx_t MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
+inline const idx_t DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
 
 // Number of seconds which we define as the threshold of staleness.
 inline constexpr idx_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
 
-// TODO(hjiang): Add constraint on largest thread number.
+//===--------------------------------------------------------------------===//
+// Global configuration
+//===--------------------------------------------------------------------===//
+inline idx_t g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
+inline std::string g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
+inline idx_t g_max_in_mem_cache_block_count =
+    DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
+
+//===--------------------------------------------------------------------===//
+// Configuration struct
+//===--------------------------------------------------------------------===//
 struct OnDiskCacheConfig {
   // Cache block size.
-  idx_t block_size = DEFAULT_BLOCK_SIZE;
+  idx_t block_size = g_cache_block_size;
   // Cache storage location on local filesystem.
-  std::string on_disk_cache_directory = ON_DISK_CACHE_DIRECTORY;
+  std::string on_disk_cache_directory = g_on_disk_cache_directory;
 };
 
 struct InMemoryCacheConfig {
   // Cache block size.
-  idx_t block_size = DEFAULT_BLOCK_SIZE;
+  idx_t block_size = g_cache_block_size;
   // Max cache size.
-  idx_t block_count = MAX_IN_MEM_CACHE_BLOCK_COUNT;
+  idx_t block_count = g_max_in_mem_cache_block_count;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
This PR does two things:
- Add more configurations to cache filesystem, including cache block size and in-memory max block count;
- Add more unit test for config settings.