### PR TITLE
Update clang-format to use duckdb's

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,29 @@
+---
+BasedOnStyle: LLVM
+SortIncludes: false
+TabWidth: 4
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: false
+---
+UseTab: ForIndentation
+DerivePointerAlignment: false
+PointerAlignment: Right
+AlignConsecutiveMacros: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlignAfterOpenBracket: Align
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+IncludeBlocks: Regroup
+Language: Cpp
+AccessModifierOffset: -4

--- a/benchmark/read_s3_object.cpp
+++ b/benchmark/read_s3_object.cpp
@@ -14,95 +14,83 @@ namespace duckdb {
 namespace {
 
 // Set configuration in client context from env variables.
-void SetConfig(case_insensitive_map_t<Value> &setting, char *env_key,
-               char *secret_key) {
-  const char *env_val = getenv(env_key);
-  if (env_val == nullptr) {
-    return;
-  }
-  setting[secret_key] = Value(env_val);
+void SetConfig(case_insensitive_map_t<Value> &setting, char *env_key, char *secret_key) {
+	const char *env_val = getenv(env_key);
+	if (env_val == nullptr) {
+		return;
+	}
+	setting[secret_key] = Value(env_val);
 }
 
 // Baseline benchmark, which reads the whole file with no parallelism and
 // caching.
 void BaseLineRead() {
-  DuckDB db{};
-  StandardBufferManager buffer_manager{*db.instance,
-                                       "/tmp/cached_http_fs_benchmark"};
-  auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
+	DuckDB db {};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
 
-  auto client_context = make_shared_ptr<ClientContext>(db.instance);
-  auto &set_vars = client_context->config.set_variables;
-  SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
-  SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
-  SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
-  SetConfig(set_vars, "DUCKDB_S3_ENDPOINT", "s3_endpoint");
+	auto client_context = make_shared_ptr<ClientContext>(db.instance);
+	auto &set_vars = client_context->config.set_variables;
+	SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
+	SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
+	SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
+	SetConfig(set_vars, "DUCKDB_S3_ENDPOINT", "s3_endpoint");
 
-  ClientContextFileOpener file_opener{*client_context};
-  client_context->transaction.BeginTransaction();
-  auto file_handle = s3fs->OpenFile(
-      "s3://s3-bucket-user-2skzy8zuigonczyfiofztl0zbug--use1-az6--x-s3/"
-      "large-csv.csv",
-      FileOpenFlags::FILE_FLAGS_READ, &file_opener);
-  const uint64_t file_size = s3fs->GetFileSize(*file_handle);
-  std::string content(file_size, '\0');
+	ClientContextFileOpener file_opener {*client_context};
+	client_context->transaction.BeginTransaction();
+	auto file_handle = s3fs->OpenFile("s3://s3-bucket-user-2skzy8zuigonczyfiofztl0zbug--use1-az6--x-s3/"
+	                                  "large-csv.csv",
+	                                  FileOpenFlags::FILE_FLAGS_READ, &file_opener);
+	const uint64_t file_size = s3fs->GetFileSize(*file_handle);
+	std::string content(file_size, '\0');
 
-  const auto now = std::chrono::steady_clock::now();
-  s3fs->Read(*file_handle, const_cast<char *>(content.data()), file_size,
-             /*location=*/0);
-  const auto end = std::chrono::steady_clock::now();
-  const auto duration_sec =
-      std::chrono::duration_cast<std::chrono::duration<double>>(end - now)
-          .count();
-  std::cout << "Baseline S3 filesystem reads " << file_size << " bytes takes "
-            << duration_sec << " seconds" << std::endl;
+	const auto now = std::chrono::steady_clock::now();
+	s3fs->Read(*file_handle, const_cast<char *>(content.data()), file_size,
+	           /*location=*/0);
+	const auto end = std::chrono::steady_clock::now();
+	const auto duration_sec = std::chrono::duration_cast<std::chrono::duration<double>>(end - now).count();
+	std::cout << "Baseline S3 filesystem reads " << file_size << " bytes takes " << duration_sec << " seconds"
+	          << std::endl;
 }
 
 void ReadUncachedWholeFile(uint64_t block_size) {
-  DuckDB db{};
-  StandardBufferManager buffer_manager{*db.instance,
-                                       "/tmp/cached_http_fs_benchmark"};
-  auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
+	DuckDB db {};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
 
-  OnDiskCacheConfig cache_config;
-  cache_config.block_size = block_size;
-  FileSystem::CreateLocal()->RemoveDirectory(
-      cache_config.on_disk_cache_directory);
-  auto disk_cache_fs = make_uniq<DiskCacheFileSystem>(std::move(s3fs));
+	OnDiskCacheConfig cache_config;
+	cache_config.block_size = block_size;
+	FileSystem::CreateLocal()->RemoveDirectory(cache_config.on_disk_cache_directory);
+	auto disk_cache_fs = make_uniq<DiskCacheFileSystem>(std::move(s3fs));
 
-  auto client_context = make_shared_ptr<ClientContext>(db.instance);
-  auto &set_vars = client_context->config.set_variables;
-  SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
-  SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
-  SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
-  SetConfig(set_vars, "DUCKDB_S3_ENDPOINT", "s3_endpoint");
-  ClientContextFileOpener file_opener{*client_context};
-  client_context->transaction.BeginTransaction();
+	auto client_context = make_shared_ptr<ClientContext>(db.instance);
+	auto &set_vars = client_context->config.set_variables;
+	SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
+	SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
+	SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
+	SetConfig(set_vars, "DUCKDB_S3_ENDPOINT", "s3_endpoint");
+	ClientContextFileOpener file_opener {*client_context};
+	client_context->transaction.BeginTransaction();
 
-  auto file_handle = disk_cache_fs->OpenFile(
-      "s3://s3-bucket-user-2skzy8zuigonczyfiofztl0zbug--use1-az6--x-s3/"
-      "large-csv.csv",
-      FileOpenFlags::FILE_FLAGS_READ, &file_opener);
-  const uint64_t file_size = disk_cache_fs->GetFileSize(*file_handle);
-  std::string content(file_size, '\0');
+	auto file_handle = disk_cache_fs->OpenFile("s3://s3-bucket-user-2skzy8zuigonczyfiofztl0zbug--use1-az6--x-s3/"
+	                                           "large-csv.csv",
+	                                           FileOpenFlags::FILE_FLAGS_READ, &file_opener);
+	const uint64_t file_size = disk_cache_fs->GetFileSize(*file_handle);
+	std::string content(file_size, '\0');
 
-  auto read_whole_file = [&]() {
-    const auto now = std::chrono::steady_clock::now();
-    disk_cache_fs->Read(*file_handle, const_cast<char *>(content.data()),
-                        file_size, /*location=*/0);
-    const auto end = std::chrono::steady_clock::now();
-    const auto duration_sec =
-        std::chrono::duration_cast<std::chrono::duration<double>>(end - now)
-            .count();
-    std::cout << "Cached http filesystem reads " << file_size
-              << " bytes with block size " << block_size << " takes "
-              << duration_sec << " seconds" << std::endl;
-  };
+	auto read_whole_file = [&]() {
+		const auto now = std::chrono::steady_clock::now();
+		disk_cache_fs->Read(*file_handle, const_cast<char *>(content.data()), file_size, /*location=*/0);
+		const auto end = std::chrono::steady_clock::now();
+		const auto duration_sec = std::chrono::duration_cast<std::chrono::duration<double>>(end - now).count();
+		std::cout << "Cached http filesystem reads " << file_size << " bytes with block size " << block_size
+		          << " takes " << duration_sec << " seconds" << std::endl;
+	};
 
-  // Uncached but parallel read.
-  read_whole_file();
-  // Cached and parallel read.
-  read_whole_file();
+	// Uncached but parallel read.
+	read_whole_file();
+	// Cached and parallel read.
+	read_whole_file();
 }
 
 } // namespace
@@ -110,17 +98,17 @@ void ReadUncachedWholeFile(uint64_t block_size) {
 } // namespace duckdb
 
 int main(int argc, char **argv) {
-  constexpr std::array<uint64_t, 10> BLOCK_SIZE_ARR{
-      64ULL * 1024,        // 64KiB
-      256ULL * 1024,       // 256KiB
-      1ULL * 1024 * 1024,  // 1MiB
-      4ULL * 1024 * 1024,  // 4MiB
-      16ULL * 1024 * 1024, // 16MiB
-  };
+	constexpr std::array<uint64_t, 10> BLOCK_SIZE_ARR {
+	    64ULL * 1024,        // 64KiB
+	    256ULL * 1024,       // 256KiB
+	    1ULL * 1024 * 1024,  // 1MiB
+	    4ULL * 1024 * 1024,  // 4MiB
+	    16ULL * 1024 * 1024, // 16MiB
+	};
 
-  duckdb::BaseLineRead();
-  for (uint64_t cur_block_size : BLOCK_SIZE_ARR) {
-    duckdb::ReadUncachedWholeFile(cur_block_size);
-  }
-  return 0;
+	duckdb::BaseLineRead();
+	for (uint64_t cur_block_size : BLOCK_SIZE_ARR) {
+		duckdb::ReadUncachedWholeFile(cur_block_size);
+	}
+	return 0;
 }

--- a/src/base_cache_filesystem.cpp
+++ b/src/base_cache_filesystem.cpp
@@ -3,70 +3,63 @@
 
 namespace duckdb {
 
-CacheFileSystemHandle::CacheFileSystemHandle(
-    unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs)
-    : FileHandle(fs, internal_file_handle_p->GetPath(),
-                 internal_file_handle_p->GetFlags()),
-      internal_file_handle(std::move(internal_file_handle_p)) {}
+CacheFileSystemHandle::CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs)
+    : FileHandle(fs, internal_file_handle_p->GetPath(), internal_file_handle_p->GetFlags()),
+      internal_file_handle(std::move(internal_file_handle_p)) {
+}
 
 bool CacheFileSystem::CanHandleFile(const string &fpath) {
-  if (internal_filesystem->CanHandleFile(fpath)) {
-    return true;
-  }
+	if (internal_filesystem->CanHandleFile(fpath)) {
+		return true;
+	}
 
-  // Special handle cases where local filesystem is the internal filesystem.
-  //
-  // duckdb's implementation is `LocalFileSystem::CanHandle` always returns
-  // false, to enable cached local filesystem (i.e. make in-memory cache for
-  // disk access), we inherit the virtual filesystem's assumption that local
-  // filesystem is the fallback type, which could potentially handles
-  // everything.
-  //
-  // If it doesn't work with local filesystem, an error is returned anyway.
-  if (internal_filesystem->GetName() == "LocalFileSystem") {
-    return true;
-  }
+	// Special handle cases where local filesystem is the internal filesystem.
+	//
+	// duckdb's implementation is `LocalFileSystem::CanHandle` always returns
+	// false, to enable cached local filesystem (i.e. make in-memory cache for
+	// disk access), we inherit the virtual filesystem's assumption that local
+	// filesystem is the fallback type, which could potentially handles
+	// everything.
+	//
+	// If it doesn't work with local filesystem, an error is returned anyway.
+	if (internal_filesystem->GetName() == "LocalFileSystem") {
+		return true;
+	}
 
-  return false;
+	return false;
 }
 
 bool CacheFileSystem::IsManuallySet() {
-  // As documented at [CanHandleFile], local filesystem serves as the fallback
-  // filesystem for all given paths, return false in certain case so virtual
-  // filesystem could pick the most suitable one if exists.
-  if (internal_filesystem->GetName() == "LocalFileSystem") {
-    return false;
-  }
+	// As documented at [CanHandleFile], local filesystem serves as the fallback
+	// filesystem for all given paths, return false in certain case so virtual
+	// filesystem could pick the most suitable one if exists.
+	if (internal_filesystem->GetName() == "LocalFileSystem") {
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
-void CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                           idx_t location) {
-  ReadImpl(handle, buffer, nr_bytes, location);
+void CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	ReadImpl(handle, buffer, nr_bytes, location);
 }
-int64_t CacheFileSystem::Read(FileHandle &handle, void *buffer,
-                              int64_t nr_bytes) {
-  const int64_t bytes_read =
-      ReadImpl(handle, buffer, nr_bytes, handle.SeekPosition());
-  handle.Seek(handle.SeekPosition() + bytes_read);
-  return bytes_read;
+int64_t CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	const int64_t bytes_read = ReadImpl(handle, buffer, nr_bytes, handle.SeekPosition());
+	handle.Seek(handle.SeekPosition() + bytes_read);
+	return bytes_read;
 }
-int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer,
-                                  int64_t nr_bytes, idx_t location) {
-  const auto file_size = handle.GetFileSize();
+int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	const auto file_size = handle.GetFileSize();
 
-  // No more bytes to read.
-  if (location == file_size) {
-    return 0;
-  }
+	// No more bytes to read.
+	if (location == file_size) {
+		return 0;
+	}
 
-  const int64_t bytes_to_read =
-      MinValue<int64_t>(nr_bytes, file_size - location);
-  ReadAndCache(handle, static_cast<char *>(buffer), location, bytes_to_read,
-               file_size);
+	const int64_t bytes_to_read = MinValue<int64_t>(nr_bytes, file_size - location);
+	ReadAndCache(handle, static_cast<char *>(buffer), location, bytes_to_read, file_size);
 
-  return bytes_to_read;
+	return bytes_to_read;
 }
 
 } // namespace duckdb

--- a/src/disk_cache_filesystem.cpp
+++ b/src/disk_cache_filesystem.cpp
@@ -19,50 +19,48 @@ namespace {
 // A [CacheReadChunk] represents a chunked IO request and its corresponding
 // partial IO request.
 struct CacheReadChunk {
-  // Requested memory address and file offset to read from for current chunk.
-  char *requested_start_addr = nullptr;
-  idx_t requested_start_offset = 0;
-  // Block size aligned [requested_start_offset].
-  idx_t aligned_start_offset = 0;
+	// Requested memory address and file offset to read from for current chunk.
+	char *requested_start_addr = nullptr;
+	idx_t requested_start_offset = 0;
+	// Block size aligned [requested_start_offset].
+	idx_t aligned_start_offset = 0;
 
-  // Number of bytes for the chunk for IO operations, apart from the last chunk
-  // it's always cache block size.
-  idx_t chunk_size = 0;
+	// Number of bytes for the chunk for IO operations, apart from the last chunk
+	// it's always cache block size.
+	idx_t chunk_size = 0;
 
-  // Always allocate block size of memory for first and last chunk.
-  // For middle chunks, if local cache is not hit, we also allocate memory for
-  // [content] as intermediate buffer.
-  //
-  // TODO(hjiang): For middle chunks, the performance could be improved further:
-  // remote IO operation directly read into [requested_start_addr] then write to
-  // local cache file; but for code simplicity we also allocate here.
-  string content;
-  // Number of bytes to copy from [content] to requested memory address.
-  idx_t bytes_to_copy = 0;
+	// Always allocate block size of memory for first and last chunk.
+	// For middle chunks, if local cache is not hit, we also allocate memory for
+	// [content] as intermediate buffer.
+	//
+	// TODO(hjiang): For middle chunks, the performance could be improved further:
+	// remote IO operation directly read into [requested_start_addr] then write to
+	// local cache file; but for code simplicity we also allocate here.
+	string content;
+	// Number of bytes to copy from [content] to requested memory address.
+	idx_t bytes_to_copy = 0;
 
-  // Copy from [content] to application-provided buffer.
-  void CopyBufferToRequestedMemory() {
-    if (!content.empty()) {
-      const idx_t delta_offset = requested_start_offset - aligned_start_offset;
-      std::memmove(requested_start_addr,
-                   const_cast<char *>(content.data()) + delta_offset,
-                   bytes_to_copy);
-    }
-  }
+	// Copy from [content] to application-provided buffer.
+	void CopyBufferToRequestedMemory() {
+		if (!content.empty()) {
+			const idx_t delta_offset = requested_start_offset - aligned_start_offset;
+			std::memmove(requested_start_addr, const_cast<char *>(content.data()) + delta_offset, bytes_to_copy);
+		}
+	}
 };
 
 // Convert SHA256 value to hex string.
 string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
-  static constexpr char kHexChars[] = "0123456789abcdef";
-  std::string result;
-  // SHA256 has 32 byte, we encode 2 chars for each byte of SHA256.
-  result.reserve(64);
+	static constexpr char kHexChars[] = "0123456789abcdef";
+	std::string result;
+	// SHA256 has 32 byte, we encode 2 chars for each byte of SHA256.
+	result.reserve(64);
 
-  for (unsigned char byte : sha256) {
-    result += kHexChars[byte >> 4];  // Get high 4 bits
-    result += kHexChars[byte & 0xF]; // Get low 4 bits
-  }
-  return result;
+	for (unsigned char byte : sha256) {
+		result += kHexChars[byte >> 4];  // Get high 4 bits
+		result += kHexChars[byte & 0xF]; // Get low 4 bits
+	}
+	return result;
 }
 
 // Get local cache filename for the given [remote_file].
@@ -73,238 +71,204 @@ string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
 //
 // Considering the naming format, it's worth noting it might _NOT_ work for
 // local files, including mounted filesystems.
-string GetLocalCacheFile(const string &cache_directory,
-                         const string &remote_file, idx_t start_offset,
+string GetLocalCacheFile(const string &cache_directory, const string &remote_file, idx_t start_offset,
                          idx_t bytes_to_read) {
-  duckdb::hash_bytes remote_file_sha256_val;
-  duckdb::sha256(remote_file.data(), remote_file.length(),
-                 remote_file_sha256_val);
-  const string remote_file_sha256_str =
-      Sha256ToHexString(remote_file_sha256_val);
+	duckdb::hash_bytes remote_file_sha256_val;
+	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
+	const string remote_file_sha256_str = Sha256ToHexString(remote_file_sha256_val);
 
-  const string fname = StringUtil::GetFileName(remote_file);
-  return StringUtil::Format("%s/%s.%s-%llu-%llu", cache_directory,
-                            remote_file_sha256_str, fname, start_offset,
-                            bytes_to_read);
+	const string fname = StringUtil::GetFileName(remote_file);
+	return StringUtil::Format("%s/%s.%s-%llu-%llu", cache_directory, remote_file_sha256_str, fname, start_offset,
+	                          bytes_to_read);
 }
 
 // Attempt to cache [chunk] to local filesystem, if there's sufficient disk
 // space available.
 //
 // TODO(hjiang): Document local cache file pattern and its eviction policy.
-void CacheLocal(const CacheReadChunk &chunk, FileSystem &local_filesystem,
-                const FileHandle &handle, const string &cache_directory,
-                const string &local_cache_file) {
-  // Skip local cache if insufficient disk space.
-  // It's worth noting it's not a strict check since there could be concurrent
-  // check and write operation (RMW operation), but it's acceptable since min
-  // available disk space reservation is an order of magnitude bigger than cache
-  // chunk size.
-  auto disk_space = local_filesystem.GetAvailableDiskSpace(cache_directory);
-  if (!disk_space.IsValid() ||
-      disk_space.GetIndex() < MIN_DISK_SPACE_FOR_CACHE) {
-    EvictStaleCacheFiles(local_filesystem, cache_directory);
-    return;
-  }
+void CacheLocal(const CacheReadChunk &chunk, FileSystem &local_filesystem, const FileHandle &handle,
+                const string &cache_directory, const string &local_cache_file) {
+	// Skip local cache if insufficient disk space.
+	// It's worth noting it's not a strict check since there could be concurrent
+	// check and write operation (RMW operation), but it's acceptable since min
+	// available disk space reservation is an order of magnitude bigger than cache
+	// chunk size.
+	auto disk_space = local_filesystem.GetAvailableDiskSpace(cache_directory);
+	if (!disk_space.IsValid() || disk_space.GetIndex() < MIN_DISK_SPACE_FOR_CACHE) {
+		EvictStaleCacheFiles(local_filesystem, cache_directory);
+		return;
+	}
 
-  // Dump to a temporary location at local filesystem.
-  const auto fname = StringUtil::GetFileName(handle.GetPath());
-  const auto local_temp_file =
-      StringUtil::Format("%s%s.%s.httpfs_local_cache", cache_directory, fname,
-                         UUID::ToString(UUID::GenerateRandomUUID()));
-  {
-    auto file_handle = local_filesystem.OpenFile(
-        local_temp_file, FileOpenFlags::FILE_FLAGS_WRITE |
-                             FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-    local_filesystem.Write(*file_handle,
-                           const_cast<char *>(chunk.content.data()),
-                           /*nr_bytes=*/chunk.content.length(),
-                           /*location=*/0);
-    file_handle->Sync();
-  }
+	// Dump to a temporary location at local filesystem.
+	const auto fname = StringUtil::GetFileName(handle.GetPath());
+	const auto local_temp_file = StringUtil::Format("%s%s.%s.httpfs_local_cache", cache_directory, fname,
+	                                                UUID::ToString(UUID::GenerateRandomUUID()));
+	{
+		auto file_handle = local_filesystem.OpenFile(local_temp_file, FileOpenFlags::FILE_FLAGS_WRITE |
+		                                                                  FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		local_filesystem.Write(*file_handle, const_cast<char *>(chunk.content.data()),
+		                       /*nr_bytes=*/chunk.content.length(),
+		                       /*location=*/0);
+		file_handle->Sync();
+	}
 
-  // Then atomically move to the target postion to prevent data corruption due
-  // to concurrent write.
-  local_filesystem.MoveFile(/*source=*/local_temp_file,
-                            /*target=*/local_cache_file);
+	// Then atomically move to the target postion to prevent data corruption due
+	// to concurrent write.
+	local_filesystem.MoveFile(/*source=*/local_temp_file,
+	                          /*target=*/local_cache_file);
 }
 
 } // namespace
 
-DiskCacheFileSystem::DiskCacheFileSystem(
-    unique_ptr<FileSystem> internal_filesystem_p,
-    OnDiskCacheConfig cache_config_p)
-    : CacheFileSystem(std::move(internal_filesystem_p)),
-      cache_config(std::move(cache_config_p)),
+DiskCacheFileSystem::DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p, OnDiskCacheConfig cache_config_p)
+    : CacheFileSystem(std::move(internal_filesystem_p)), cache_config(std::move(cache_config_p)),
       local_filesystem(FileSystem::CreateLocal()) {
-  local_filesystem->CreateDirectory(cache_config.on_disk_cache_directory);
+	local_filesystem->CreateDirectory(cache_config.on_disk_cache_directory);
 }
 
 std::string DiskCacheFileSystem::GetName() const {
-  return StringUtil::Format("disk_cache_filesystem for %s",
-                            internal_filesystem->GetName());
+	return StringUtil::Format("disk_cache_filesystem for %s", internal_filesystem->GetName());
 }
 
-unique_ptr<FileHandle>
-DiskCacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
-                              optional_ptr<FileOpener> opener) {
-  if (opener != nullptr) {
-    Value val;
+unique_ptr<FileHandle> DiskCacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+                                                     optional_ptr<FileOpener> opener) {
+	if (opener != nullptr) {
+		Value val;
 
-    // Check and update cache block size if necessary.
-    FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_block_size",
-                                     val);
-    cache_config.block_size = val.GetValue<uint64_t>();
-    g_cache_block_size = cache_config.block_size;
+		// Check and update cache block size if necessary.
+		FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_block_size", val);
+		cache_config.block_size = val.GetValue<uint64_t>();
+		g_cache_block_size = cache_config.block_size;
 
-    // Check and update cache directory if necessary.
-    FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_directory",
-                                     val);
-    // Check and update global setting if updated.
-    cache_config.on_disk_cache_directory = val.ToString();
-    if (cache_config.on_disk_cache_directory != g_on_disk_cache_directory) {
-      g_on_disk_cache_directory = cache_config.on_disk_cache_directory;
-      local_filesystem->CreateDirectory(g_on_disk_cache_directory);
-    }
-  }
+		// Check and update cache directory if necessary.
+		FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_directory", val);
+		// Check and update global setting if updated.
+		cache_config.on_disk_cache_directory = val.ToString();
+		if (cache_config.on_disk_cache_directory != g_on_disk_cache_directory) {
+			g_on_disk_cache_directory = cache_config.on_disk_cache_directory;
+			local_filesystem->CreateDirectory(g_on_disk_cache_directory);
+		}
+	}
 
-  return CacheFileSystem::OpenFile(path, flags, opener);
+	return CacheFileSystem::OpenFile(path, flags, opener);
 }
-void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
-                                       idx_t requested_start_offset,
-                                       idx_t requested_bytes_to_read,
-                                       idx_t file_size) {
-  const idx_t block_size = cache_config.block_size;
-  const idx_t aligned_start_offset =
-      requested_start_offset / block_size * block_size;
-  const idx_t aligned_last_chunk_offset =
-      (requested_start_offset + requested_bytes_to_read) / block_size *
-      block_size;
+void DiskCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
+                                       idx_t requested_bytes_to_read, idx_t file_size) {
+	const idx_t block_size = cache_config.block_size;
+	const idx_t aligned_start_offset = requested_start_offset / block_size * block_size;
+	const idx_t aligned_last_chunk_offset =
+	    (requested_start_offset + requested_bytes_to_read) / block_size * block_size;
 
-  // Indicate the meory address to copy to for each IO operation
-  char *addr_to_write = buffer;
-  // Used to calculate bytes to copy for last chunk.
-  idx_t already_read_bytes = 0;
-  // Threads to parallelly perform IO.
-  vector<thread> io_threads;
+	// Indicate the meory address to copy to for each IO operation
+	char *addr_to_write = buffer;
+	// Used to calculate bytes to copy for last chunk.
+	idx_t already_read_bytes = 0;
+	// Threads to parallelly perform IO.
+	vector<thread> io_threads;
 
-  // To improve IO performance, we split requested bytes (after alignment) into
-  // multiple chunks and fetch them in parallel.
-  for (idx_t io_start_offset = aligned_start_offset;
-       io_start_offset <= aligned_last_chunk_offset;
-       io_start_offset += block_size) {
-    CacheReadChunk cache_read_chunk;
-    cache_read_chunk.requested_start_addr = addr_to_write;
-    cache_read_chunk.aligned_start_offset = io_start_offset;
-    cache_read_chunk.requested_start_offset = requested_start_offset;
+	// To improve IO performance, we split requested bytes (after alignment) into
+	// multiple chunks and fetch them in parallel.
+	for (idx_t io_start_offset = aligned_start_offset; io_start_offset <= aligned_last_chunk_offset;
+	     io_start_offset += block_size) {
+		CacheReadChunk cache_read_chunk;
+		cache_read_chunk.requested_start_addr = addr_to_write;
+		cache_read_chunk.aligned_start_offset = io_start_offset;
+		cache_read_chunk.requested_start_offset = requested_start_offset;
 
-    // Implementation-wise, middle chunks are easy to handle -- read in
-    // [block_size], and copy the whole chunk to the requested memory address;
-    // but the first and last chunk require special handling.
-    // For first chunk, requested start offset might not be aligned with block
-    // size; for the last chunk, we might not need to copy the whole
-    // [block_size] of memory.
-    //
-    // Case-1: If there's only one chunk, which serves as both the first chunk
-    // and the last one.
-    if (io_start_offset == aligned_start_offset &&
-        io_start_offset == aligned_last_chunk_offset) {
-      cache_read_chunk.chunk_size =
-          MinValue<idx_t>(block_size, file_size - io_start_offset);
-      cache_read_chunk.content =
-          CreateResizeUninitializedString(cache_read_chunk.chunk_size);
-      cache_read_chunk.bytes_to_copy = requested_bytes_to_read;
-    }
-    // Case-2: First chunk.
-    else if (io_start_offset == aligned_start_offset) {
-      const idx_t delta_offset = requested_start_offset - aligned_start_offset;
-      addr_to_write += block_size - delta_offset;
-      already_read_bytes += block_size - delta_offset;
+		// Implementation-wise, middle chunks are easy to handle -- read in
+		// [block_size], and copy the whole chunk to the requested memory address;
+		// but the first and last chunk require special handling.
+		// For first chunk, requested start offset might not be aligned with block
+		// size; for the last chunk, we might not need to copy the whole
+		// [block_size] of memory.
+		//
+		// Case-1: If there's only one chunk, which serves as both the first chunk
+		// and the last one.
+		if (io_start_offset == aligned_start_offset && io_start_offset == aligned_last_chunk_offset) {
+			cache_read_chunk.chunk_size = MinValue<idx_t>(block_size, file_size - io_start_offset);
+			cache_read_chunk.content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
+			cache_read_chunk.bytes_to_copy = requested_bytes_to_read;
+		}
+		// Case-2: First chunk.
+		else if (io_start_offset == aligned_start_offset) {
+			const idx_t delta_offset = requested_start_offset - aligned_start_offset;
+			addr_to_write += block_size - delta_offset;
+			already_read_bytes += block_size - delta_offset;
 
-      cache_read_chunk.chunk_size = block_size;
-      cache_read_chunk.content = CreateResizeUninitializedString(block_size);
-      cache_read_chunk.bytes_to_copy = block_size - delta_offset;
-    }
-    // Case-3: Last chunk.
-    else if (io_start_offset == aligned_last_chunk_offset) {
-      cache_read_chunk.chunk_size =
-          MinValue<idx_t>(block_size, file_size - io_start_offset);
-      cache_read_chunk.content =
-          CreateResizeUninitializedString(cache_read_chunk.chunk_size);
-      cache_read_chunk.bytes_to_copy =
-          requested_bytes_to_read - already_read_bytes;
-    }
-    // Case-4: Middle chunks.
-    else {
-      addr_to_write += block_size;
-      already_read_bytes += block_size;
+			cache_read_chunk.chunk_size = block_size;
+			cache_read_chunk.content = CreateResizeUninitializedString(block_size);
+			cache_read_chunk.bytes_to_copy = block_size - delta_offset;
+		}
+		// Case-3: Last chunk.
+		else if (io_start_offset == aligned_last_chunk_offset) {
+			cache_read_chunk.chunk_size = MinValue<idx_t>(block_size, file_size - io_start_offset);
+			cache_read_chunk.content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
+			cache_read_chunk.bytes_to_copy = requested_bytes_to_read - already_read_bytes;
+		}
+		// Case-4: Middle chunks.
+		else {
+			addr_to_write += block_size;
+			already_read_bytes += block_size;
 
-      cache_read_chunk.bytes_to_copy = block_size;
-      cache_read_chunk.chunk_size = block_size;
-    }
+			cache_read_chunk.bytes_to_copy = block_size;
+			cache_read_chunk.chunk_size = block_size;
+		}
 
-    // Update read offset for next chunk read.
-    requested_start_offset = io_start_offset + block_size;
+		// Update read offset for next chunk read.
+		requested_start_offset = io_start_offset + block_size;
 
-    // Perform read operation in parallel.
-    io_threads.emplace_back([this, &handle, block_size,
-                             cache_read_chunk =
-                                 std::move(cache_read_chunk)]() mutable {
-      SetThreadName("RdCachRdThd");
+		// Perform read operation in parallel.
+		io_threads.emplace_back([this, &handle, block_size, cache_read_chunk = std::move(cache_read_chunk)]() mutable {
+			SetThreadName("RdCachRdThd");
 
-      // Check local cache first, see if we could do a cached read.
-      const auto local_cache_file = GetLocalCacheFile(
-          cache_config.on_disk_cache_directory, handle.GetPath(),
-          cache_read_chunk.aligned_start_offset, cache_read_chunk.chunk_size);
+			// Check local cache first, see if we could do a cached read.
+			const auto local_cache_file =
+			    GetLocalCacheFile(cache_config.on_disk_cache_directory, handle.GetPath(),
+			                      cache_read_chunk.aligned_start_offset, cache_read_chunk.chunk_size);
 
-      // TODO(hjiang): Add documentation and implementation for stale cache
-      // eviction policy, before that it's safe to access cache file directly.
-      if (local_filesystem->FileExists(local_cache_file)) {
-        auto file_handle = local_filesystem->OpenFile(
-            local_cache_file, FileOpenFlags::FILE_FLAGS_READ);
-        void *addr = !cache_read_chunk.content.empty()
-                         ? const_cast<char *>(cache_read_chunk.content.data())
-                         : cache_read_chunk.requested_start_addr;
-        local_filesystem->Read(*file_handle, addr, cache_read_chunk.chunk_size,
-                               /*location=*/0);
-        cache_read_chunk.CopyBufferToRequestedMemory();
+			// TODO(hjiang): Add documentation and implementation for stale cache
+			// eviction policy, before that it's safe to access cache file directly.
+			if (local_filesystem->FileExists(local_cache_file)) {
+				auto file_handle = local_filesystem->OpenFile(local_cache_file, FileOpenFlags::FILE_FLAGS_READ);
+				void *addr = !cache_read_chunk.content.empty() ? const_cast<char *>(cache_read_chunk.content.data())
+				                                               : cache_read_chunk.requested_start_addr;
+				local_filesystem->Read(*file_handle, addr, cache_read_chunk.chunk_size,
+				                       /*location=*/0);
+				cache_read_chunk.CopyBufferToRequestedMemory();
 
-        // Update access and modification timestamp for the cache file, so it
-        // won't get evicted.
-        if (utime(local_cache_file.data(), /*times*/ nullptr) < 0) {
-          throw IOException("Fails to update %s's access and modification "
-                            "timestamp because %s",
-                            local_cache_file, strerror(errno));
-        }
+				// Update access and modification timestamp for the cache file, so it
+				// won't get evicted.
+				if (utime(local_cache_file.data(), /*times*/ nullptr) < 0) {
+					throw IOException("Fails to update %s's access and modification "
+					                  "timestamp because %s",
+					                  local_cache_file, strerror(errno));
+				}
 
-        return;
-      }
+				return;
+			}
 
-      // We suffer a cache loss, fallback to remote access then local filesystem
-      // write.
-      if (cache_read_chunk.content.empty()) {
-        cache_read_chunk.content =
-            CreateResizeUninitializedString(cache_read_chunk.chunk_size);
-      }
-      auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-      internal_filesystem->Read(
-          *disk_cache_handle.internal_file_handle,
-          const_cast<char *>(cache_read_chunk.content.data()),
-          cache_read_chunk.content.length(),
-          cache_read_chunk.aligned_start_offset);
+			// We suffer a cache loss, fallback to remote access then local filesystem
+			// write.
+			if (cache_read_chunk.content.empty()) {
+				cache_read_chunk.content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
+			}
+			auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+			internal_filesystem->Read(*disk_cache_handle.internal_file_handle,
+			                          const_cast<char *>(cache_read_chunk.content.data()),
+			                          cache_read_chunk.content.length(), cache_read_chunk.aligned_start_offset);
 
-      // Copy to destination buffer.
-      cache_read_chunk.CopyBufferToRequestedMemory();
+			// Copy to destination buffer.
+			cache_read_chunk.CopyBufferToRequestedMemory();
 
-      // Attempt to cache file locally.
-      CacheLocal(cache_read_chunk, *local_filesystem, handle,
-                 cache_config.on_disk_cache_directory, local_cache_file);
-    });
-  }
-  for (auto &cur_thd : io_threads) {
-    D_ASSERT(cur_thd.joinable());
-    cur_thd.join();
-  }
+			// Attempt to cache file locally.
+			CacheLocal(cache_read_chunk, *local_filesystem, handle, cache_config.on_disk_cache_directory,
+			           local_cache_file);
+		});
+	}
+	for (auto &cur_thd : io_threads) {
+		D_ASSERT(cur_thd.joinable());
+		cur_thd.join();
+	}
 }
 
 } // namespace duckdb

--- a/src/in_memory_cache_filesystem.cpp
+++ b/src/in_memory_cache_filesystem.cpp
@@ -18,177 +18,155 @@ namespace {
 // A [CacheReadChunk] represents a chunked IO request and its corresponding
 // partial IO request.
 struct CacheReadChunk {
-  // Requested memory address and file offset to read from for current chunk.
-  char *requested_start_addr = nullptr;
-  idx_t requested_start_offset = 0;
-  // Block size aligned [requested_start_offset].
-  idx_t aligned_start_offset = 0;
+	// Requested memory address and file offset to read from for current chunk.
+	char *requested_start_addr = nullptr;
+	idx_t requested_start_offset = 0;
+	// Block size aligned [requested_start_offset].
+	idx_t aligned_start_offset = 0;
 
-  // Number of bytes for the chunk for IO operations, apart from the last chunk
-  // it's always cache block size.
-  idx_t chunk_size = 0;
+	// Number of bytes for the chunk for IO operations, apart from the last chunk
+	// it's always cache block size.
+	idx_t chunk_size = 0;
 
-  // Number of bytes to copy from [content] to requested memory address.
-  idx_t bytes_to_copy = 0;
+	// Number of bytes to copy from [content] to requested memory address.
+	idx_t bytes_to_copy = 0;
 
-  // Copy from [content] to application-provided buffer.
-  void CopyBufferToRequestedMemory(const std::string &content) {
-    const idx_t delta_offset = requested_start_offset - aligned_start_offset;
-    std::memmove(requested_start_addr,
-                 const_cast<char *>(content.data()) + delta_offset,
-                 bytes_to_copy);
-  }
+	// Copy from [content] to application-provided buffer.
+	void CopyBufferToRequestedMemory(const std::string &content) {
+		const idx_t delta_offset = requested_start_offset - aligned_start_offset;
+		std::memmove(requested_start_addr, const_cast<char *>(content.data()) + delta_offset, bytes_to_copy);
+	}
 };
 
 } // namespace
 
-InMemoryCacheFileSystem::InMemoryCacheFileSystem(
-    unique_ptr<FileSystem> internal_filesystem_p,
-    InMemoryCacheConfig cache_config_p)
-    : CacheFileSystem(std::move(internal_filesystem_p)),
-      cache_config(std::move(cache_config_p)) {}
+InMemoryCacheFileSystem::InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
+                                                 InMemoryCacheConfig cache_config_p)
+    : CacheFileSystem(std::move(internal_filesystem_p)), cache_config(std::move(cache_config_p)) {
+}
 
 std::string InMemoryCacheFileSystem::GetName() const {
-  return StringUtil::Format("in_mem_cache_filesystem for %s",
-                            internal_filesystem->GetName());
+	return StringUtil::Format("in_mem_cache_filesystem for %s", internal_filesystem->GetName());
 }
 
-unique_ptr<FileHandle>
-InMemoryCacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
-                                  optional_ptr<FileOpener> opener) {
-  if (opener != nullptr && cache == nullptr) {
-    Value val;
+unique_ptr<FileHandle> InMemoryCacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+                                                         optional_ptr<FileOpener> opener) {
+	if (opener != nullptr && cache == nullptr) {
+		Value val;
 
-    // Check and update in-memory cache block size.
-    FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_block_size",
-                                     val);
-    cache_config.block_size = val.GetValue<uint64_t>();
-    g_cache_block_size = cache_config.block_size;
+		// Check and update in-memory cache block size.
+		FileOpener::TryGetCurrentSetting(opener, "cached_http_cache_block_size", val);
+		cache_config.block_size = val.GetValue<uint64_t>();
+		g_cache_block_size = cache_config.block_size;
 
-    // Check and update in-memory cache max block count.
-    FileOpener::TryGetCurrentSetting(
-        opener, "cached_http_max_in_mem_cache_block_count", val);
-    cache_config.block_count = val.GetValue<uint64_t>();
-    g_max_in_mem_cache_block_count = cache_config.block_count;
-  }
+		// Check and update in-memory cache max block count.
+		FileOpener::TryGetCurrentSetting(opener, "cached_http_max_in_mem_cache_block_count", val);
+		cache_config.block_count = val.GetValue<uint64_t>();
+		g_max_in_mem_cache_block_count = cache_config.block_count;
+	}
 
-  // Initialize LRU cache at first IO access.
-  if (cache == nullptr) {
-    cache = make_uniq<InMemCache>(cache_config.block_count);
-  }
+	// Initialize LRU cache at first IO access.
+	if (cache == nullptr) {
+		cache = make_uniq<InMemCache>(cache_config.block_count);
+	}
 
-  return CacheFileSystem::OpenFile(path, flags, opener);
+	return CacheFileSystem::OpenFile(path, flags, opener);
 }
 
-void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer,
-                                           idx_t requested_start_offset,
-                                           idx_t requested_bytes_to_read,
-                                           idx_t file_size) {
-  const idx_t block_size = cache_config.block_size;
-  const idx_t aligned_start_offset =
-      requested_start_offset / block_size * block_size;
-  const idx_t aligned_last_chunk_offset =
-      (requested_start_offset + requested_bytes_to_read) / block_size *
-      block_size;
+void InMemoryCacheFileSystem::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
+                                           idx_t requested_bytes_to_read, idx_t file_size) {
+	const idx_t block_size = cache_config.block_size;
+	const idx_t aligned_start_offset = requested_start_offset / block_size * block_size;
+	const idx_t aligned_last_chunk_offset =
+	    (requested_start_offset + requested_bytes_to_read) / block_size * block_size;
 
-  // Indicate the meory address to copy to for each IO operation
-  char *addr_to_write = buffer;
-  // Used to calculate bytes to copy for last chunk.
-  idx_t already_read_bytes = 0;
-  // Threads to parallelly perform IO.
-  vector<thread> io_threads;
+	// Indicate the meory address to copy to for each IO operation
+	char *addr_to_write = buffer;
+	// Used to calculate bytes to copy for last chunk.
+	idx_t already_read_bytes = 0;
+	// Threads to parallelly perform IO.
+	vector<thread> io_threads;
 
-  // To improve IO performance, we split requested bytes (after alignment) into
-  // multiple chunks and fetch them in parallel.
-  for (idx_t io_start_offset = aligned_start_offset;
-       io_start_offset <= aligned_last_chunk_offset;
-       io_start_offset += block_size) {
-    CacheReadChunk cache_read_chunk;
-    cache_read_chunk.requested_start_addr = addr_to_write;
-    cache_read_chunk.aligned_start_offset = io_start_offset;
-    cache_read_chunk.requested_start_offset = requested_start_offset;
+	// To improve IO performance, we split requested bytes (after alignment) into
+	// multiple chunks and fetch them in parallel.
+	for (idx_t io_start_offset = aligned_start_offset; io_start_offset <= aligned_last_chunk_offset;
+	     io_start_offset += block_size) {
+		CacheReadChunk cache_read_chunk;
+		cache_read_chunk.requested_start_addr = addr_to_write;
+		cache_read_chunk.aligned_start_offset = io_start_offset;
+		cache_read_chunk.requested_start_offset = requested_start_offset;
 
-    // Implementation-wise, middle chunks are easy to handle -- read in
-    // [block_size], and copy the whole chunk to the requested memory address;
-    // but the first and last chunk require special handling.
-    // For first chunk, requested start offset might not be aligned with block
-    // size; for the last chunk, we might not need to copy the whole
-    // [block_size] of memory.
-    //
-    // Case-1: If there's only one chunk, which serves as both the first chunk
-    // and the last one.
-    if (io_start_offset == aligned_start_offset &&
-        io_start_offset == aligned_last_chunk_offset) {
-      cache_read_chunk.chunk_size =
-          MinValue<idx_t>(block_size, file_size - io_start_offset);
-      cache_read_chunk.bytes_to_copy = requested_bytes_to_read;
-    }
-    // Case-2: First chunk.
-    else if (io_start_offset == aligned_start_offset) {
-      const idx_t delta_offset = requested_start_offset - aligned_start_offset;
-      addr_to_write += block_size - delta_offset;
-      already_read_bytes += block_size - delta_offset;
+		// Implementation-wise, middle chunks are easy to handle -- read in
+		// [block_size], and copy the whole chunk to the requested memory address;
+		// but the first and last chunk require special handling.
+		// For first chunk, requested start offset might not be aligned with block
+		// size; for the last chunk, we might not need to copy the whole
+		// [block_size] of memory.
+		//
+		// Case-1: If there's only one chunk, which serves as both the first chunk
+		// and the last one.
+		if (io_start_offset == aligned_start_offset && io_start_offset == aligned_last_chunk_offset) {
+			cache_read_chunk.chunk_size = MinValue<idx_t>(block_size, file_size - io_start_offset);
+			cache_read_chunk.bytes_to_copy = requested_bytes_to_read;
+		}
+		// Case-2: First chunk.
+		else if (io_start_offset == aligned_start_offset) {
+			const idx_t delta_offset = requested_start_offset - aligned_start_offset;
+			addr_to_write += block_size - delta_offset;
+			already_read_bytes += block_size - delta_offset;
 
-      cache_read_chunk.chunk_size = block_size;
-      cache_read_chunk.bytes_to_copy = block_size - delta_offset;
-    }
-    // Case-3: Last chunk.
-    else if (io_start_offset == aligned_last_chunk_offset) {
-      cache_read_chunk.chunk_size =
-          MinValue<idx_t>(block_size, file_size - io_start_offset);
-      cache_read_chunk.bytes_to_copy =
-          requested_bytes_to_read - already_read_bytes;
-    }
-    // Case-4: Middle chunks.
-    else {
-      addr_to_write += block_size;
-      already_read_bytes += block_size;
+			cache_read_chunk.chunk_size = block_size;
+			cache_read_chunk.bytes_to_copy = block_size - delta_offset;
+		}
+		// Case-3: Last chunk.
+		else if (io_start_offset == aligned_last_chunk_offset) {
+			cache_read_chunk.chunk_size = MinValue<idx_t>(block_size, file_size - io_start_offset);
+			cache_read_chunk.bytes_to_copy = requested_bytes_to_read - already_read_bytes;
+		}
+		// Case-4: Middle chunks.
+		else {
+			addr_to_write += block_size;
+			already_read_bytes += block_size;
 
-      cache_read_chunk.bytes_to_copy = block_size;
-      cache_read_chunk.chunk_size = block_size;
-    }
+			cache_read_chunk.bytes_to_copy = block_size;
+			cache_read_chunk.chunk_size = block_size;
+		}
 
-    // Update read offset for next chunk read.
-    requested_start_offset = io_start_offset + block_size;
+		// Update read offset for next chunk read.
+		requested_start_offset = io_start_offset + block_size;
 
-    // Perform read operation in parallel.
-    io_threads.emplace_back(
-        [this, &handle, block_size,
-         cache_read_chunk = std::move(cache_read_chunk)]() mutable {
-          // Check local cache first, see if we could do a cached read.
-          InMemCacheBlock block_key;
-          block_key.fname = handle.GetPath();
-          block_key.start_off = cache_read_chunk.aligned_start_offset;
-          block_key.blk_size = cache_read_chunk.chunk_size;
-          auto cache_block = cache->Get(block_key);
+		// Perform read operation in parallel.
+		io_threads.emplace_back([this, &handle, block_size, cache_read_chunk = std::move(cache_read_chunk)]() mutable {
+			// Check local cache first, see if we could do a cached read.
+			InMemCacheBlock block_key;
+			block_key.fname = handle.GetPath();
+			block_key.start_off = cache_read_chunk.aligned_start_offset;
+			block_key.blk_size = cache_read_chunk.chunk_size;
+			auto cache_block = cache->Get(block_key);
 
-          if (cache_block != nullptr) {
-            cache_read_chunk.CopyBufferToRequestedMemory(*cache_block);
-            return;
-          }
+			if (cache_block != nullptr) {
+				cache_read_chunk.CopyBufferToRequestedMemory(*cache_block);
+				return;
+			}
 
-          // We suffer a cache loss, fallback to remote access then local
-          // filesystem write.
-          auto content =
-              CreateResizeUninitializedString(cache_read_chunk.chunk_size);
-          auto &in_mem_cache_handle = handle.Cast<CacheFileSystemHandle>();
-          internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle,
-                                    const_cast<char *>(content.data()),
-                                    content.length(),
-                                    cache_read_chunk.aligned_start_offset);
+			// We suffer a cache loss, fallback to remote access then local
+			// filesystem write.
+			auto content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
+			auto &in_mem_cache_handle = handle.Cast<CacheFileSystemHandle>();
+			internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle, const_cast<char *>(content.data()),
+			                          content.length(), cache_read_chunk.aligned_start_offset);
 
-          // Copy to destination buffer.
-          cache_read_chunk.CopyBufferToRequestedMemory(content);
+			// Copy to destination buffer.
+			cache_read_chunk.CopyBufferToRequestedMemory(content);
 
-          // Attempt to cache file locally.
-          cache->Put(std::move(block_key),
-                     std::make_shared<std::string>(std::move(content)));
-        });
-  }
-  for (auto &cur_thd : io_threads) {
-    D_ASSERT(cur_thd.joinable());
-    cur_thd.join();
-  }
+			// Attempt to cache file locally.
+			cache->Put(std::move(block_key), std::make_shared<std::string>(std::move(content)));
+		});
+	}
+	for (auto &cur_thd : io_threads) {
+		D_ASSERT(cur_thd.joinable());
+		cur_thd.join();
+	}
 }
 
 } // namespace duckdb

--- a/src/include/base_cache_filesystem.hpp
+++ b/src/include/base_cache_filesystem.hpp
@@ -13,177 +13,152 @@ class CacheFileSystem;
 // File handle used for cache filesystem.
 class CacheFileSystemHandle : public FileHandle {
 public:
-  CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p,
-                        CacheFileSystem &fs);
-  ~CacheFileSystemHandle() override = default;
-  void Close() override {}
+	CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs);
+	~CacheFileSystemHandle() override = default;
+	void Close() override {
+	}
 
-  unique_ptr<FileHandle> internal_file_handle;
+	unique_ptr<FileHandle> internal_file_handle;
 };
 
 class CacheFileSystem : public FileSystem {
 public:
-  explicit CacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
-      : internal_filesystem(std::move(internal_filesystem_p)) {}
+	explicit CacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
+	    : internal_filesystem(std::move(internal_filesystem_p)) {
+	}
 
-  void Read(FileHandle &handle, void *buffer, int64_t nr_bytes,
-            idx_t location) override;
-  int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 
-  // For other API calls, delegate to [internal_filesystem] to handle.
-  unique_ptr<FileHandle>
-  OpenFile(const string &path, FileOpenFlags flags,
-           optional_ptr<FileOpener> opener = nullptr) override {
-    auto file_handle = internal_filesystem->OpenFile(
-        path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
-    return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this);
-  }
-  unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle,
-                                            bool write) override {
-    auto file_handle =
-        internal_filesystem->OpenCompressedFile(std::move(handle), write);
-    return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this);
-  }
-  void Write(FileHandle &handle, void *buffer, int64_t nr_bytes,
-             idx_t location) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer,
-                               nr_bytes, location);
-  }
-  int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->Write(*disk_cache_handle.internal_file_handle,
-                                      buffer, nr_bytes);
-  }
-  bool Trim(FileHandle &handle, idx_t offset_bytes,
-            idx_t length_bytes) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle,
-                                     offset_bytes, length_bytes);
-  }
-  int64_t GetFileSize(FileHandle &handle) {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->GetFileSize(
-        *disk_cache_handle.internal_file_handle);
-  }
-  time_t GetLastModifiedTime(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->GetLastModifiedTime(
-        *disk_cache_handle.internal_file_handle);
-  }
-  FileType GetFileType(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->GetFileType(
-        *disk_cache_handle.internal_file_handle);
-  }
-  void Truncate(FileHandle &handle, int64_t new_size) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->Truncate(
-        *disk_cache_handle.internal_file_handle, new_size);
-  }
-  bool DirectoryExists(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->DirectoryExists(directory, opener);
-  }
-  void CreateDirectory(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->CreateDirectory(directory, opener);
-  }
-  void RemoveDirectory(const string &directory,
-                       optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->RemoveDirectory(directory, opener);
-  }
-  bool ListFiles(const string &directory,
-                 const std::function<void(const string &, bool)> &callback,
-                 FileOpener *opener = nullptr) override {
-    return internal_filesystem->ListFiles(directory, callback, opener);
-  }
-  void MoveFile(const string &source, const string &target,
-                optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->MoveFile(source, target, opener);
-  }
-  bool FileExists(const string &filename,
-                  optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->FileExists(filename, opener);
-  }
-  bool IsPipe(const string &filename,
-              optional_ptr<FileOpener> opener = nullptr) override {
-    return internal_filesystem->IsPipe(filename, opener);
-  }
-  void RemoveFile(const string &filename,
-                  optional_ptr<FileOpener> opener = nullptr) override {
-    internal_filesystem->RemoveFile(filename, opener);
-  }
-  void FileSync(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
-  }
-  string GetHomeDirectory() override {
-    return internal_filesystem->GetHomeDirectory();
-  }
-  string ExpandPath(const string &path) override {
-    return internal_filesystem->ExpandPath(path);
-  }
-  string PathSeparator(const string &path) override {
-    return internal_filesystem->PathSeparator(path);
-  }
-  vector<string> Glob(const string &path,
-                      FileOpener *opener = nullptr) override {
-    return internal_filesystem->Glob(path, opener);
-  }
-  void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
-    internal_filesystem->RegisterSubSystem(std::move(sub_fs));
-  }
-  void RegisterSubSystem(FileCompressionType compression_type,
-                         unique_ptr<FileSystem> fs) override {
-    internal_filesystem->RegisterSubSystem(compression_type, std::move(fs));
-  }
-  void UnregisterSubSystem(const string &name) override {
-    internal_filesystem->UnregisterSubSystem(name);
-  }
-  vector<string> ListSubSystems() override {
-    return internal_filesystem->ListSubSystems();
-  }
-  bool CanHandleFile(const string &fpath) override;
-  void Seek(FileHandle &handle, idx_t location) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    internal_filesystem->Seek(*disk_cache_handle.internal_file_handle,
-                              location);
-  }
-  void Reset(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    internal_filesystem->Reset(*disk_cache_handle.internal_file_handle);
-  }
-  idx_t SeekPosition(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->SeekPosition(
-        *disk_cache_handle.internal_file_handle);
-  }
-  bool IsManuallySet() override;
-  bool CanSeek() override { return internal_filesystem->CanSeek(); }
-  bool OnDiskFile(FileHandle &handle) override {
-    auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-    return internal_filesystem->OnDiskFile(
-        *disk_cache_handle.internal_file_handle);
-  }
-  void SetDisabledFileSystems(const vector<string> &names) override {
-    internal_filesystem->SetDisabledFileSystems(names);
-  }
+	// For other API calls, delegate to [internal_filesystem] to handle.
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override {
+		auto file_handle =
+		    internal_filesystem->OpenFile(path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
+		return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this);
+	}
+	unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) override {
+		auto file_handle = internal_filesystem->OpenCompressedFile(std::move(handle), write);
+		return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this);
+	}
+	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes, location);
+	}
+	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes);
+	}
+	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle, offset_bytes, length_bytes);
+	}
+	int64_t GetFileSize(FileHandle &handle) {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->GetFileSize(*disk_cache_handle.internal_file_handle);
+	}
+	time_t GetLastModifiedTime(FileHandle &handle) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->GetLastModifiedTime(*disk_cache_handle.internal_file_handle);
+	}
+	FileType GetFileType(FileHandle &handle) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->GetFileType(*disk_cache_handle.internal_file_handle);
+	}
+	void Truncate(FileHandle &handle, int64_t new_size) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->Truncate(*disk_cache_handle.internal_file_handle, new_size);
+	}
+	bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener = nullptr) override {
+		return internal_filesystem->DirectoryExists(directory, opener);
+	}
+	void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override {
+		internal_filesystem->CreateDirectory(directory, opener);
+	}
+	void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override {
+		internal_filesystem->RemoveDirectory(directory, opener);
+	}
+	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
+	               FileOpener *opener = nullptr) override {
+		return internal_filesystem->ListFiles(directory, callback, opener);
+	}
+	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener = nullptr) override {
+		internal_filesystem->MoveFile(source, target, opener);
+	}
+	bool FileExists(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
+		return internal_filesystem->FileExists(filename, opener);
+	}
+	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
+		return internal_filesystem->IsPipe(filename, opener);
+	}
+	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
+		internal_filesystem->RemoveFile(filename, opener);
+	}
+	void FileSync(FileHandle &handle) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
+	}
+	string GetHomeDirectory() override {
+		return internal_filesystem->GetHomeDirectory();
+	}
+	string ExpandPath(const string &path) override {
+		return internal_filesystem->ExpandPath(path);
+	}
+	string PathSeparator(const string &path) override {
+		return internal_filesystem->PathSeparator(path);
+	}
+	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
+		return internal_filesystem->Glob(path, opener);
+	}
+	void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
+		internal_filesystem->RegisterSubSystem(std::move(sub_fs));
+	}
+	void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override {
+		internal_filesystem->RegisterSubSystem(compression_type, std::move(fs));
+	}
+	void UnregisterSubSystem(const string &name) override {
+		internal_filesystem->UnregisterSubSystem(name);
+	}
+	vector<string> ListSubSystems() override {
+		return internal_filesystem->ListSubSystems();
+	}
+	bool CanHandleFile(const string &fpath) override;
+	void Seek(FileHandle &handle, idx_t location) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		internal_filesystem->Seek(*disk_cache_handle.internal_file_handle, location);
+	}
+	void Reset(FileHandle &handle) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		internal_filesystem->Reset(*disk_cache_handle.internal_file_handle);
+	}
+	idx_t SeekPosition(FileHandle &handle) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->SeekPosition(*disk_cache_handle.internal_file_handle);
+	}
+	bool IsManuallySet() override;
+	bool CanSeek() override {
+		return internal_filesystem->CanSeek();
+	}
+	bool OnDiskFile(FileHandle &handle) override {
+		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		return internal_filesystem->OnDiskFile(*disk_cache_handle.internal_file_handle);
+	}
+	void SetDisabledFileSystems(const vector<string> &names) override {
+		internal_filesystem->SetDisabledFileSystems(names);
+	}
 
 protected:
-  // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
-  // to local filesystem and return to user.
-  virtual void ReadAndCache(FileHandle &handle, char *buffer,
-                            idx_t requested_start_offset,
-                            idx_t requested_bytes_to_read, idx_t file_size) = 0;
+	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache
+	// to local filesystem and return to user.
+	virtual void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
+	                          idx_t requested_bytes_to_read, idx_t file_size) = 0;
 
-  // Read from [location] on [nr_bytes] for the given [handle] into [buffer].
-  // Return the actual number of bytes to read.
-  int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes,
-                   idx_t location);
+	// Read from [location] on [nr_bytes] for the given [handle] into [buffer].
+	// Return the actual number of bytes to read.
+	int64_t ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location);
 
-  // Used to access remote files.
-  unique_ptr<FileSystem> internal_filesystem;
+	// Used to access remote files.
+	unique_ptr<FileSystem> internal_filesystem;
 };
 
 } // namespace duckdb

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -12,8 +12,7 @@ namespace duckdb {
 // Default configuration
 //===--------------------------------------------------------------------===//
 inline const idx_t DEFAULT_CACHE_BLOCK_SIZE = 64_KiB;
-inline const std::string DEFAULT_ON_DISK_CACHE_DIRECTORY =
-    "/tmp/duckdb_cached_http_cache";
+inline const std::string DEFAULT_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_cached_http_cache";
 
 // To prevent go out of disk space, we set a threshold to disable local caching
 // if insufficient.
@@ -31,24 +30,23 @@ inline constexpr idx_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
 //===--------------------------------------------------------------------===//
 inline idx_t g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
 inline std::string g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
-inline idx_t g_max_in_mem_cache_block_count =
-    DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
+inline idx_t g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
 
 //===--------------------------------------------------------------------===//
 // Configuration struct
 //===--------------------------------------------------------------------===//
 struct OnDiskCacheConfig {
-  // Cache block size.
-  idx_t block_size = g_cache_block_size;
-  // Cache storage location on local filesystem.
-  std::string on_disk_cache_directory = g_on_disk_cache_directory;
+	// Cache block size.
+	idx_t block_size = g_cache_block_size;
+	// Cache storage location on local filesystem.
+	std::string on_disk_cache_directory = g_on_disk_cache_directory;
 };
 
 struct InMemoryCacheConfig {
-  // Cache block size.
-  idx_t block_size = g_cache_block_size;
-  // Max cache size.
-  idx_t block_count = g_max_in_mem_cache_block_count;
+	// Cache block size.
+	idx_t block_size = g_cache_block_size;
+	// Max cache size.
+	idx_t block_count = g_max_in_mem_cache_block_count;
 };
 
 } // namespace duckdb

--- a/src/include/disk_cache_filesystem.hpp
+++ b/src/include/disk_cache_filesystem.hpp
@@ -13,30 +13,27 @@ namespace duckdb {
 
 class DiskCacheFileSystem final : public CacheFileSystem {
 public:
-  explicit DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
-      : DiskCacheFileSystem(std::move(internal_filesystem_p),
-                            OnDiskCacheConfig{}) {}
-  DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
-                      OnDiskCacheConfig cache_directory_p);
-  std::string GetName() const override;
+	explicit DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
+	    : DiskCacheFileSystem(std::move(internal_filesystem_p), OnDiskCacheConfig {}) {
+	}
+	DiskCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p, OnDiskCacheConfig cache_directory_p);
+	std::string GetName() const override;
 
-  unique_ptr<FileHandle>
-  OpenFile(const string &path, FileOpenFlags flags,
-           optional_ptr<FileOpener> opener = nullptr) override;
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override;
 
 protected:
-  // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
-  // to local filesystem and return to user.
-  void ReadAndCache(FileHandle &handle, char *buffer,
-                    idx_t requested_start_offset, idx_t requested_bytes_to_read,
-                    idx_t file_size) override;
+	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache
+	// to local filesystem and return to user.
+	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
+	                  idx_t file_size) override;
 
-  // Read-cache filesystem configuration.
-  OnDiskCacheConfig cache_config;
-  // Directory to store cache files.
-  string cache_directory;
-  // Used to access local cache files.
-  unique_ptr<FileSystem> local_filesystem;
+	// Read-cache filesystem configuration.
+	OnDiskCacheConfig cache_config;
+	// Directory to store cache files.
+	string cache_directory;
+	// Used to access local cache files.
+	unique_ptr<FileSystem> local_filesystem;
 };
 
 } // namespace duckdb

--- a/src/include/in_mem_cache_block.hpp
+++ b/src/include/in_mem_cache_block.hpp
@@ -14,23 +14,21 @@ namespace duckdb {
 // TODO(hjiang): Use customized hash and equal functor to store in cache,
 // temporarily unblock by using string as key.
 struct InMemCacheBlock {
-  std::string fname;
-  idx_t start_off = 0;
-  idx_t blk_size = 0;
+	std::string fname;
+	idx_t start_off = 0;
+	idx_t blk_size = 0;
 };
 
 struct InMemCacheBlockEqual {
-  bool operator()(const InMemCacheBlock &lhs,
-                  const InMemCacheBlock &rhs) const {
-    return std::tie(lhs.fname, lhs.start_off, lhs.blk_size) ==
-           std::tie(rhs.fname, rhs.start_off, rhs.blk_size);
-  }
+	bool operator()(const InMemCacheBlock &lhs, const InMemCacheBlock &rhs) const {
+		return std::tie(lhs.fname, lhs.start_off, lhs.blk_size) == std::tie(rhs.fname, rhs.start_off, rhs.blk_size);
+	}
 };
 struct InMemCacheBlockHash {
-  std::size_t operator()(const InMemCacheBlock &key) const {
-    return std::hash<std::string>{}(key.fname) ^
-           std::hash<idx_t>{}(key.start_off) ^ std::hash<idx_t>{}(key.blk_size);
-  }
+	std::size_t operator()(const InMemCacheBlock &key) const {
+		return std::hash<std::string> {}(key.fname) ^ std::hash<idx_t> {}(key.start_off) ^
+		       std::hash<idx_t> {}(key.blk_size);
+	}
 };
 
 } // namespace duckdb

--- a/src/include/in_memory_cache_filesystem.hpp
+++ b/src/include/in_memory_cache_filesystem.hpp
@@ -18,33 +18,27 @@ namespace duckdb {
 
 class InMemoryCacheFileSystem : public CacheFileSystem {
 public:
-  explicit InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
-      : InMemoryCacheFileSystem(std::move(internal_filesystem_p),
-                                InMemoryCacheConfig{}) {}
-  InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
-                          InMemoryCacheConfig cache_config);
-  std::string GetName() const override;
+	explicit InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
+	    : InMemoryCacheFileSystem(std::move(internal_filesystem_p), InMemoryCacheConfig {}) {
+	}
+	InMemoryCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p, InMemoryCacheConfig cache_config);
+	std::string GetName() const override;
 
-  unique_ptr<FileHandle>
-  OpenFile(const string &path, FileOpenFlags flags,
-           optional_ptr<FileOpener> opener = nullptr) override;
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override;
 
 protected:
-  using InMemCache =
-      ThreadSafeSharedLruCache<InMemCacheBlock, string, InMemCacheBlockHash,
-                               InMemCacheBlockEqual>;
+	using InMemCache = ThreadSafeSharedLruCache<InMemCacheBlock, string, InMemCacheBlockHash, InMemCacheBlockEqual>;
 
-  // Read from [handle] for an block-size aligned chunk into [start_addr]; cache
-  // to local filesystem and return to user.
-  void ReadAndCache(FileHandle &handle, char *buffer,
-                    uint64_t requested_start_offset,
-                    uint64_t requested_bytes_to_read,
-                    uint64_t file_size) override;
+	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache
+	// to local filesystem and return to user.
+	void ReadAndCache(FileHandle &handle, char *buffer, uint64_t requested_start_offset,
+	                  uint64_t requested_bytes_to_read, uint64_t file_size) override;
 
-  // Read-cache filesystem configuration.
-  InMemoryCacheConfig cache_config;
-  // LRU cache to store blocks; late initialized after first access.
-  unique_ptr<InMemCache> cache;
+	// Read-cache filesystem configuration.
+	InMemoryCacheConfig cache_config;
+	// LRU cache to store blocks; late initialized after first access.
+	unique_ptr<InMemCache> cache;
 };
 
 } // namespace duckdb

--- a/src/include/read_cache_fs_extension.hpp
+++ b/src/include/read_cache_fs_extension.hpp
@@ -8,9 +8,9 @@ namespace duckdb {
 
 class ReadCacheFsExtension : public Extension {
 public:
-  void Load(DuckDB &db) override;
-  std::string Name() override;
-  std::string Version() const override;
+	void Load(DuckDB &db) override;
+	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/src/read_cache_fs_extension.cpp
+++ b/src/read_cache_fs_extension.cpp
@@ -12,32 +12,27 @@
 
 namespace duckdb {
 
-static void ClearOnDiskCache(const DataChunk &args, ExpressionState &state,
-                             Vector &result) {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
-  local_filesystem->RemoveDirectory(g_on_disk_cache_directory);
-  // Create an empty directory, otherwise later read access errors.
-  local_filesystem->CreateDirectory(g_on_disk_cache_directory);
+static void ClearOnDiskCache(const DataChunk &args, ExpressionState &state, Vector &result) {
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	local_filesystem->RemoveDirectory(g_on_disk_cache_directory);
+	// Create an empty directory, otherwise later read access errors.
+	local_filesystem->CreateDirectory(g_on_disk_cache_directory);
 
-  constexpr int32_t SUCCESS = 1;
-  result.Reference(Value(SUCCESS));
+	constexpr int32_t SUCCESS = 1;
+	result.Reference(Value(SUCCESS));
 }
 
-static void GetOnDiskCacheSize(const DataChunk &args, ExpressionState &state,
-                               Vector &result) {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
+static void GetOnDiskCacheSize(const DataChunk &args, ExpressionState &state, Vector &result) {
+	auto local_filesystem = LocalFileSystem::CreateLocal();
 
-  int64_t total_cache_size = 0;
-  local_filesystem->ListFiles(
-      g_on_disk_cache_directory, [&local_filesystem, &total_cache_size](
-                                     const string &fname, bool /*unused*/) {
-        const string file_path =
-            StringUtil::Format("%s/%s", g_on_disk_cache_directory, fname);
-        auto file_handle = local_filesystem->OpenFile(
-            file_path, FileOpenFlags::FILE_FLAGS_READ);
-        total_cache_size += local_filesystem->GetFileSize(*file_handle);
-      });
-  result.Reference(Value(total_cache_size));
+	int64_t total_cache_size = 0;
+	local_filesystem->ListFiles(
+	    g_on_disk_cache_directory, [&local_filesystem, &total_cache_size](const string &fname, bool /*unused*/) {
+		    const string file_path = StringUtil::Format("%s/%s", g_on_disk_cache_directory, fname);
+		    auto file_handle = local_filesystem->OpenFile(file_path, FileOpenFlags::FILE_FLAGS_READ);
+		    total_cache_size += local_filesystem->GetFileSize(*file_handle);
+	    });
+	result.Reference(Value(total_cache_size));
 }
 
 // Cached httpfs cannot co-exist with non-cached version, because duckdb virtual
@@ -50,69 +45,63 @@ static void GetOnDiskCacheSize(const DataChunk &args, ExpressionState &state,
 // 2. If uncached filesystem is registered later somehow, cached version is set
 // mutual set so it has higher priority than uncached version.
 static void LoadInternal(DatabaseInstance &instance) {
-  // Register filesystem instance to instance.
-  auto &fs = instance.GetFileSystem();
-  fs.RegisterSubSystem(
-      make_uniq<DiskCacheFileSystem>(make_uniq<HTTPFileSystem>()));
-  fs.RegisterSubSystem(
-      make_uniq<DiskCacheFileSystem>(make_uniq<HuggingFaceFileSystem>()));
-  fs.RegisterSubSystem(make_uniq<DiskCacheFileSystem>(
-      make_uniq<S3FileSystem>(BufferManager::GetBufferManager(instance))));
+	// Register filesystem instance to instance.
+	auto &fs = instance.GetFileSystem();
+	fs.RegisterSubSystem(make_uniq<DiskCacheFileSystem>(make_uniq<HTTPFileSystem>()));
+	fs.RegisterSubSystem(make_uniq<DiskCacheFileSystem>(make_uniq<HuggingFaceFileSystem>()));
+	fs.RegisterSubSystem(
+	    make_uniq<DiskCacheFileSystem>(make_uniq<S3FileSystem>(BufferManager::GetBufferManager(instance))));
 
-  const std::array<string, 3> httpfs_names{"HTTPFileSystem", "S3FileSystem",
-                                           "HuggingFaceFileSystem"};
-  for (const auto &cur_http_fs : httpfs_names) {
-    try {
-      fs.UnregisterSubSystem(cur_http_fs);
-    } catch (...) {
-    }
-  }
+	const std::array<string, 3> httpfs_names {"HTTPFileSystem", "S3FileSystem", "HuggingFaceFileSystem"};
+	for (const auto &cur_http_fs : httpfs_names) {
+		try {
+			fs.UnregisterSubSystem(cur_http_fs);
+		} catch (...) {
+		}
+	}
 
-  // Register extension configuration.
-  //
-  // TODO(hjiang): We should have a way to set global configurations to decide
-  // cache mode.
-  auto &config = DBConfig::GetConfig(instance);
-  config.AddExtensionOption("cached_http_cache_directory",
-                            "The disk cache directory that stores cached data",
-                            LogicalType::VARCHAR,
-                            DEFAULT_ON_DISK_CACHE_DIRECTORY);
-  config.AddExtensionOption(
-      "cached_http_cache_block_size",
-      "Block size for cache, applies to both in-memory "
-      "cache filesystem and on-disk cache filesystem. It's worth noting for "
-      "on-disk filesystem, all existing cache files are invalidated after "
-      "config update.",
-      LogicalType::UBIGINT, Value::UBIGINT(DEFAULT_CACHE_BLOCK_SIZE));
-  config.AddExtensionOption(
-      "cached_http_max_in_mem_cache_block_count",
-      "Max in-memory cache block count for in-memory cache filesystem. It's "
-      "worth noting it should be set only once before all filesystem access, "
-      "otherwise there's no affect.",
-      LogicalType::UBIGINT,
-      Value::UBIGINT(DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT));
+	// Register extension configuration.
+	//
+	// TODO(hjiang): We should have a way to set global configurations to decide
+	// cache mode.
+	auto &config = DBConfig::GetConfig(instance);
+	config.AddExtensionOption("cached_http_cache_directory", "The disk cache directory that stores cached data",
+	                          LogicalType::VARCHAR, DEFAULT_ON_DISK_CACHE_DIRECTORY);
+	config.AddExtensionOption("cached_http_cache_block_size",
+	                          "Block size for cache, applies to both in-memory "
+	                          "cache filesystem and on-disk cache filesystem. It's worth noting for "
+	                          "on-disk filesystem, all existing cache files are invalidated after "
+	                          "config update.",
+	                          LogicalType::UBIGINT, Value::UBIGINT(DEFAULT_CACHE_BLOCK_SIZE));
+	config.AddExtensionOption("cached_http_max_in_mem_cache_block_count",
+	                          "Max in-memory cache block count for in-memory cache filesystem. It's "
+	                          "worth noting it should be set only once before all filesystem access, "
+	                          "otherwise there's no affect.",
+	                          LogicalType::UBIGINT, Value::UBIGINT(DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT));
 
-  // Register on-disk cache cleanup function.
-  ScalarFunction clear_cache_function(
-      "cache_httpfs_clear_cache", /*arguments=*/{},
-      /*return_type=*/LogicalType::INTEGER, ClearOnDiskCache);
-  ExtensionUtil::RegisterFunction(instance, clear_cache_function);
+	// Register on-disk cache cleanup function.
+	ScalarFunction clear_cache_function("cache_httpfs_clear_cache", /*arguments=*/ {},
+	                                    /*return_type=*/LogicalType::INTEGER, ClearOnDiskCache);
+	ExtensionUtil::RegisterFunction(instance, clear_cache_function);
 
-  // Register on-disk cache file size stat function.
-  ScalarFunction get_cache_size_function(
-      "cache_httpfs_get_cache_size", /*arguments=*/{},
-      /*return_type=*/LogicalType::BIGINT, GetOnDiskCacheSize);
-  ExtensionUtil::RegisterFunction(instance, get_cache_size_function);
+	// Register on-disk cache file size stat function.
+	ScalarFunction get_cache_size_function("cache_httpfs_get_cache_size", /*arguments=*/ {},
+	                                       /*return_type=*/LogicalType::BIGINT, GetOnDiskCacheSize);
+	ExtensionUtil::RegisterFunction(instance, get_cache_size_function);
 }
 
-void ReadCacheFsExtension::Load(DuckDB &db) { LoadInternal(*db.instance); }
-std::string ReadCacheFsExtension::Name() { return "read_cache_fs"; }
+void ReadCacheFsExtension::Load(DuckDB &db) {
+	LoadInternal(*db.instance);
+}
+std::string ReadCacheFsExtension::Name() {
+	return "read_cache_fs";
+}
 
 std::string ReadCacheFsExtension::Version() const {
 #ifdef EXT_VERSION_READ_CACHE_FS
-  return EXT_VERSION_READ_CACHE_FS;
+	return EXT_VERSION_READ_CACHE_FS;
 #else
-  return "";
+	return "";
 #endif
 }
 
@@ -121,12 +110,12 @@ std::string ReadCacheFsExtension::Version() const {
 extern "C" {
 
 DUCKDB_EXTENSION_API void read_cache_fs_init(duckdb::DatabaseInstance &db) {
-  duckdb::DuckDB db_wrapper(db);
-  db_wrapper.LoadExtension<duckdb::ReadCacheFsExtension>();
+	duckdb::DuckDB db_wrapper(db);
+	db_wrapper.LoadExtension<duckdb::ReadCacheFsExtension>();
 }
 
 DUCKDB_EXTENSION_API const char *read_cache_fs_version() {
-  return duckdb::DuckDB::LibraryVersion();
+	return duckdb::DuckDB::LibraryVersion();
 }
 }
 

--- a/src/utils/filesystem_utils.cpp
+++ b/src/utils/filesystem_utils.cpp
@@ -9,52 +9,42 @@
 
 namespace duckdb {
 
-void EvictStaleCacheFiles(FileSystem &local_filesystem,
-                          const string &cache_directory) {
-  const time_t now = std::time(nullptr);
-  local_filesystem.ListFiles(
-      cache_directory, [&local_filesystem, &cache_directory,
-                        now](const string &fname, bool /*unused*/) {
-        // Multiple threads could attempt to access and delete stale files,
-        // tolerate non-existent file.
-        const string full_name =
-            StringUtil::Format("%s/%s", cache_directory, fname);
-        auto file_handle = local_filesystem.OpenFile(
-            full_name, FileOpenFlags::FILE_FLAGS_READ |
-                           FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
-        if (file_handle == nullptr) {
-          return;
-        }
+void EvictStaleCacheFiles(FileSystem &local_filesystem, const string &cache_directory) {
+	const time_t now = std::time(nullptr);
+	local_filesystem.ListFiles(
+	    cache_directory, [&local_filesystem, &cache_directory, now](const string &fname, bool /*unused*/) {
+		    // Multiple threads could attempt to access and delete stale files,
+		    // tolerate non-existent file.
+		    const string full_name = StringUtil::Format("%s/%s", cache_directory, fname);
+		    auto file_handle = local_filesystem.OpenFile(full_name, FileOpenFlags::FILE_FLAGS_READ |
+		                                                                FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+		    if (file_handle == nullptr) {
+			    return;
+		    }
 
-        const time_t last_mod_time =
-            local_filesystem.GetLastModifiedTime(*file_handle);
-        const double diff =
-            std::difftime(/*time_end=*/now, /*time_beg=*/last_mod_time);
-        if (static_cast<uint64_t>(diff) >= CACHE_FILE_STALENESS_SECOND) {
-          if (std::remove(full_name.data()) < -1 && errno != EEXIST) {
-            throw IOException("Fails to delete stale cache file %s", full_name);
-          }
-        }
-      });
+		    const time_t last_mod_time = local_filesystem.GetLastModifiedTime(*file_handle);
+		    const double diff = std::difftime(/*time_end=*/now, /*time_beg=*/last_mod_time);
+		    if (static_cast<uint64_t>(diff) >= CACHE_FILE_STALENESS_SECOND) {
+			    if (std::remove(full_name.data()) < -1 && errno != EEXIST) {
+				    throw IOException("Fails to delete stale cache file %s", full_name);
+			    }
+		    }
+	    });
 }
 
 int GetFileCountUnder(const std::string &folder) {
-  int file_count = 0;
-  LocalFileSystem::CreateLocal()->ListFiles(
-      folder, [&file_count](const string & /*unused*/, bool /*unused*/) {
-        ++file_count;
-      });
-  return file_count;
+	int file_count = 0;
+	LocalFileSystem::CreateLocal()->ListFiles(
+	    folder, [&file_count](const string & /*unused*/, bool /*unused*/) { ++file_count; });
+	return file_count;
 }
 
 vector<std::string> GetSortedFilesUnder(const std::string &folder) {
-  vector<std::string> file_names;
-  LocalFileSystem::CreateLocal()->ListFiles(
-      folder, [&file_names](const string &fname, bool /*unused*/) {
-        file_names.emplace_back(fname);
-      });
-  std::sort(file_names.begin(), file_names.end());
-  return file_names;
+	vector<std::string> file_names;
+	LocalFileSystem::CreateLocal()->ListFiles(
+	    folder, [&file_names](const string &fname, bool /*unused*/) { file_names.emplace_back(fname); });
+	std::sort(file_names.begin(), file_names.end());
+	return file_names;
 }
 
 } // namespace duckdb

--- a/src/utils/include/filesystem_utils.hpp
+++ b/src/utils/include/filesystem_utils.hpp
@@ -12,8 +12,7 @@ namespace duckdb {
 // stat call on each of them, could be a performance bottleneck. But as the
 // initial implementation, cache eviction only happens when insufficient disk
 // space detected, which happens rarely thus not a big concern.
-void EvictStaleCacheFiles(FileSystem &local_filesystem,
-                          const string &cache_directory);
+void EvictStaleCacheFiles(FileSystem &local_filesystem, const string &cache_directory);
 
 // Get the number of files under the given local filesystem [folder].
 int GetFileCountUnder(const std::string &folder);

--- a/src/utils/include/lru_cache.hpp
+++ b/src/utils/include/lru_cache.hpp
@@ -18,159 +18,158 @@
 
 namespace duckdb {
 
-template <typename Key, typename Val, typename KeyHash = std::hash<Key>,
-          typename KeyEqual = std::equal_to<Key>>
+template <typename Key, typename Val, typename KeyHash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 class SharedLruCache {
 public:
-  using key_type = Key;
-  using mapped_type = Val;
-  using hasher = KeyHash;
-  using key_equal = KeyEqual;
+	using key_type = Key;
+	using mapped_type = Val;
+	using hasher = KeyHash;
+	using key_equal = KeyEqual;
 
-  // A `max_entries` of 0 means that there is no limit on the number of entries
-  // in the cache.
-  explicit SharedLruCache(size_t max_entries) : max_entries_(max_entries) {}
+	// A `max_entries` of 0 means that there is no limit on the number of entries
+	// in the cache.
+	explicit SharedLruCache(size_t max_entries) : max_entries_(max_entries) {
+	}
 
-  ~SharedLruCache() = default;
+	~SharedLruCache() = default;
 
-  // Insert `value` with key `key`. This will replace any previous entry with
-  // the same key.
-  void Put(Key key, std::shared_ptr<Val> value) {
-    lru_list_.emplace_front(key);
-    Entry new_entry{std::move(value), lru_list_.begin()};
-    auto key_cref = std::cref(lru_list_.front());
-    cache_[key_cref] = std::move(new_entry);
+	// Insert `value` with key `key`. This will replace any previous entry with
+	// the same key.
+	void Put(Key key, std::shared_ptr<Val> value) {
+		lru_list_.emplace_front(key);
+		Entry new_entry {std::move(value), lru_list_.begin()};
+		auto key_cref = std::cref(lru_list_.front());
+		cache_[key_cref] = std::move(new_entry);
 
-    if (max_entries_ > 0 && lru_list_.size() > max_entries_) {
-      const auto &stale_key = lru_list_.back();
-      cache_.erase(stale_key);
-      lru_list_.pop_back();
-    }
-  }
+		if (max_entries_ > 0 && lru_list_.size() > max_entries_) {
+			const auto &stale_key = lru_list_.back();
+			cache_.erase(stale_key);
+			lru_list_.pop_back();
+		}
+	}
 
-  // Delete the entry with key `key`. Return true if the entry was found for
-  // `key`, false if the entry was not found. In both cases, there is no entry
-  // with key `key` existed after the call.
-  bool Delete(const Key &key) {
-    auto it = cache_.find(key);
-    if (it == cache_.end()) {
-      return false;
-    }
-    lru_list_.erase(it->second.lru_iterator);
-    cache_.erase(it);
-    return true;
-  }
+	// Delete the entry with key `key`. Return true if the entry was found for
+	// `key`, false if the entry was not found. In both cases, there is no entry
+	// with key `key` existed after the call.
+	bool Delete(const Key &key) {
+		auto it = cache_.find(key);
+		if (it == cache_.end()) {
+			return false;
+		}
+		lru_list_.erase(it->second.lru_iterator);
+		cache_.erase(it);
+		return true;
+	}
 
-  // Look up the entry with key `key`.
-  // Return nullptr if `key` doesn't exist in cache.
-  std::shared_ptr<Val> Get(const Key &key) {
-    const auto cache_iter = cache_.find(key);
-    if (cache_iter == cache_.end()) {
-      return nullptr;
-    }
-    lru_list_.splice(lru_list_.begin(), lru_list_,
-                     cache_iter->second.lru_iterator);
-    return cache_iter->second.value;
-  }
+	// Look up the entry with key `key`.
+	// Return nullptr if `key` doesn't exist in cache.
+	std::shared_ptr<Val> Get(const Key &key) {
+		const auto cache_iter = cache_.find(key);
+		if (cache_iter == cache_.end()) {
+			return nullptr;
+		}
+		lru_list_.splice(lru_list_.begin(), lru_list_, cache_iter->second.lru_iterator);
+		return cache_iter->second.value;
+	}
 
-  // Clear the cache.
-  void Clear() {
-    cache_.clear();
-    lru_list_.clear();
-  }
+	// Clear the cache.
+	void Clear() {
+		cache_.clear();
+		lru_list_.clear();
+	}
 
-  // Accessors for cache parameters.
-  size_t max_entries() const { return max_entries_; }
+	// Accessors for cache parameters.
+	size_t max_entries() const {
+		return max_entries_;
+	}
 
 private:
-  struct Entry {
-    // The entry's value.
-    std::shared_ptr<Val> value;
+	struct Entry {
+		// The entry's value.
+		std::shared_ptr<Val> value;
 
-    // A list iterator pointing to the entry's position in the LRU list.
-    typename std::list<Key>::iterator lru_iterator;
-  };
+		// A list iterator pointing to the entry's position in the LRU list.
+		typename std::list<Key>::iterator lru_iterator;
+	};
 
-  using KeyConstRef = std::reference_wrapper<const Key>;
-  using EntryMap =
-      std::unordered_map<KeyConstRef, Entry, RefHash<KeyHash>, RefEq<KeyEqual>>;
+	using KeyConstRef = std::reference_wrapper<const Key>;
+	using EntryMap = std::unordered_map<KeyConstRef, Entry, RefHash<KeyHash>, RefEq<KeyEqual>>;
 
-  // The maximum number of entries in the cache. A value of 0 means there is no
-  // limit on entry count.
-  const size_t max_entries_;
+	// The maximum number of entries in the cache. A value of 0 means there is no
+	// limit on entry count.
+	const size_t max_entries_;
 
-  // All keys are stored as refernce (`std::reference_wrapper`), and the
-  // ownership lies in `lru_list_`.
-  EntryMap cache_;
+	// All keys are stored as refernce (`std::reference_wrapper`), and the
+	// ownership lies in `lru_list_`.
+	EntryMap cache_;
 
-  // The LRU list of entries. The front of the list identifies the most
-  // recently accessed entry.
-  std::list<Key> lru_list_;
+	// The LRU list of entries. The front of the list identifies the most
+	// recently accessed entry.
+	std::list<Key> lru_list_;
 };
 
 // Same interfaces as `SharedLruCache`, but all cached values are
 // `const` specified to avoid concurrent updates.
-template <typename K, typename V, typename KeyHash = std::hash<K>,
-          typename KeyEqual = std::equal_to<K>>
+template <typename K, typename V, typename KeyHash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
 using SharedLruConstCache = SharedLruCache<K, const V, KeyHash, KeyEqual>;
 
 // Thread-safe implementation.
-template <typename Key, typename Val, typename KeyHash = std::hash<Key>,
-          typename KeyEqual = std::equal_to<Key>>
+template <typename Key, typename Val, typename KeyHash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>>
 class ThreadSafeSharedLruCache {
 public:
-  using key_type = Key;
-  using mapped_type = Val;
-  using hasher = KeyHash;
-  using key_equal = KeyEqual;
+	using key_type = Key;
+	using mapped_type = Val;
+	using hasher = KeyHash;
+	using key_equal = KeyEqual;
 
-  // A `max_entries` of 0 means that there is no limit on the number of entries
-  // in the cache.
-  explicit ThreadSafeSharedLruCache(size_t max_entries) : cache_(max_entries) {}
+	// A `max_entries` of 0 means that there is no limit on the number of entries
+	// in the cache.
+	explicit ThreadSafeSharedLruCache(size_t max_entries) : cache_(max_entries) {
+	}
 
-  ~ThreadSafeSharedLruCache() = default;
+	~ThreadSafeSharedLruCache() = default;
 
-  // Insert `value` with key `key`. This will replace any previous entry with
-  // the same key.
-  void Put(Key key, std::shared_ptr<Val> value) {
-    std::lock_guard<std::mutex> lock(mu_);
-    cache_.Put(std::move(key), std::move(value));
-  }
+	// Insert `value` with key `key`. This will replace any previous entry with
+	// the same key.
+	void Put(Key key, std::shared_ptr<Val> value) {
+		std::lock_guard<std::mutex> lock(mu_);
+		cache_.Put(std::move(key), std::move(value));
+	}
 
-  // Delete the entry with key `key`. Return true if the entry was found for
-  // `key`, false if the entry was not found. In both cases, there is no entry
-  // with key `key` existed after the call.
-  bool Delete(const Key &key) {
-    std::lock_guard<std::mutex> lock(mu_);
-    return cache_.Delete(key);
-  }
+	// Delete the entry with key `key`. Return true if the entry was found for
+	// `key`, false if the entry was not found. In both cases, there is no entry
+	// with key `key` existed after the call.
+	bool Delete(const Key &key) {
+		std::lock_guard<std::mutex> lock(mu_);
+		return cache_.Delete(key);
+	}
 
-  // Look up the entry with key `key`.
-  // Return nullptr if `key` doesn't exist in cache.
-  std::shared_ptr<Val> Get(const Key &key) {
-    std::unique_lock<std::mutex> lock(mu_);
-    return cache_.Get(key);
-  }
+	// Look up the entry with key `key`.
+	// Return nullptr if `key` doesn't exist in cache.
+	std::shared_ptr<Val> Get(const Key &key) {
+		std::unique_lock<std::mutex> lock(mu_);
+		return cache_.Get(key);
+	}
 
-  // Clear the cache.
-  void Clear() {
-    std::lock_guard<std::mutex> lock(mu_);
-    cache_.Clear();
-  }
+	// Clear the cache.
+	void Clear() {
+		std::lock_guard<std::mutex> lock(mu_);
+		cache_.Clear();
+	}
 
-  // Accessors for cache parameters.
-  size_t max_entries() const { return cache_.max_entries_; }
+	// Accessors for cache parameters.
+	size_t max_entries() const {
+		return cache_.max_entries_;
+	}
 
 private:
-  std::mutex mu_;
-  SharedLruCache<Key, Val, KeyHash, KeyEqual> cache_;
+	std::mutex mu_;
+	SharedLruCache<Key, Val, KeyHash, KeyEqual> cache_;
 };
 
 // Same interfaces as `SharedLruCache`, but all cached values are
 // `const` specified to avoid concurrent updates.
-template <typename K, typename V, typename KeyHash = std::hash<K>,
-          typename KeyEqual = std::equal_to<K>>
-using ThreadSafeSharedLruConstCache =
-    ThreadSafeSharedLruCache<K, const V, KeyHash, KeyEqual>;
+template <typename K, typename V, typename KeyHash = std::hash<K>, typename KeyEqual = std::equal_to<K>>
+using ThreadSafeSharedLruConstCache = ThreadSafeSharedLruCache<K, const V, KeyHash, KeyEqual>;
 
 } // namespace duckdb

--- a/src/utils/include/map_utils.hpp
+++ b/src/utils/include/map_utils.hpp
@@ -6,52 +6,57 @@
 namespace duckdb {
 
 // A hash wrapper made for `std::reference_wrapper`.
-template <typename Hash> struct RefHash : Hash {
-  RefHash() = default;
-  template <typename H> RefHash(H &&h) : Hash(std::forward<H>(h)) {} // NOLINT
+template <typename Hash>
+struct RefHash : Hash {
+	RefHash() = default;
+	template <typename H>
+	RefHash(H &&h) : Hash(std::forward<H>(h)) {
+	} // NOLINT
 
-  RefHash(const RefHash &) = default;
-  RefHash(RefHash &&) noexcept = default;
-  RefHash &operator=(const RefHash &) = default;
-  RefHash &operator=(RefHash &&) noexcept = default;
+	RefHash(const RefHash &) = default;
+	RefHash(RefHash &&) noexcept = default;
+	RefHash &operator=(const RefHash &) = default;
+	RefHash &operator=(RefHash &&) noexcept = default;
 
-  template <typename T>
-  size_t operator()(std::reference_wrapper<const T> val) const {
-    return Hash::operator()(val.get());
-  }
-  template <typename T> size_t operator()(const T &val) const {
-    return Hash::operator()(val);
-  }
+	template <typename T>
+	size_t operator()(std::reference_wrapper<const T> val) const {
+		return Hash::operator()(val.get());
+	}
+	template <typename T>
+	size_t operator()(const T &val) const {
+		return Hash::operator()(val);
+	}
 };
 
 // A hash equal wrapper made for `std::reference_wrapper`.
-template <typename Equal> struct RefEq : Equal {
-  RefEq() = default;
-  template <typename Eq>
-  RefEq(Eq &&eq) : Equal(std::forward<Eq>(eq)) {} // NOLINT
+template <typename Equal>
+struct RefEq : Equal {
+	RefEq() = default;
+	template <typename Eq>
+	RefEq(Eq &&eq) : Equal(std::forward<Eq>(eq)) {
+	} // NOLINT
 
-  RefEq(const RefEq &) = default;
-  RefEq(RefEq &&) noexcept = default;
-  RefEq &operator=(const RefEq &) = default;
-  RefEq &operator=(RefEq &&) noexcept = default;
+	RefEq(const RefEq &) = default;
+	RefEq(RefEq &&) noexcept = default;
+	RefEq &operator=(const RefEq &) = default;
+	RefEq &operator=(RefEq &&) noexcept = default;
 
-  template <typename T1, typename T2>
-  bool operator()(std::reference_wrapper<const T1> lhs,
-                  std::reference_wrapper<const T2> rhs) const {
-    return Equal::operator()(lhs.get(), rhs.get());
-  }
-  template <typename T1, typename T2>
-  bool operator()(const T1 &lhs, std::reference_wrapper<const T2> rhs) const {
-    return Equal::operator()(lhs, rhs.get());
-  }
-  template <typename T1, typename T2>
-  bool operator()(std::reference_wrapper<const T1> lhs, const T2 &rhs) const {
-    return Equal::operator()(lhs.get(), rhs);
-  }
-  template <typename T1, typename T2>
-  bool operator()(const T1 &lhs, const T2 &rhs) const {
-    return Equal::operator()(lhs, rhs);
-  }
+	template <typename T1, typename T2>
+	bool operator()(std::reference_wrapper<const T1> lhs, std::reference_wrapper<const T2> rhs) const {
+		return Equal::operator()(lhs.get(), rhs.get());
+	}
+	template <typename T1, typename T2>
+	bool operator()(const T1 &lhs, std::reference_wrapper<const T2> rhs) const {
+		return Equal::operator()(lhs, rhs.get());
+	}
+	template <typename T1, typename T2>
+	bool operator()(std::reference_wrapper<const T1> lhs, const T2 &rhs) const {
+		return Equal::operator()(lhs.get(), rhs);
+	}
+	template <typename T1, typename T2>
+	bool operator()(const T1 &lhs, const T2 &rhs) const {
+		return Equal::operator()(lhs, rhs);
+	}
 };
 
 } // namespace duckdb

--- a/src/utils/include/resize_uninitialized.hpp
+++ b/src/utils/include/resize_uninitialized.hpp
@@ -31,19 +31,20 @@ namespace internal {
 // indicate whether __resize_default_init is present.
 template <typename string_type, typename = void>
 struct ResizeUninitializedTraits {
-  using HasMember = std::false_type;
-  static void Resize(string_type *s, size_t new_size) { s->resize(new_size); }
+	using HasMember = std::false_type;
+	static void Resize(string_type *s, size_t new_size) {
+		s->resize(new_size);
+	}
 };
 
 // __resize_default_init is provided by libc++ >= 8.0
 template <typename string_type>
-struct ResizeUninitializedTraits<
-    string_type, void_t<decltype(std::declval<string_type &>()
-                                     .__resize_default_init(237))>> {
-  using HasMember = std::true_type;
-  static void Resize(string_type *s, size_t new_size) {
-    s->__resize_default_init(new_size);
-  }
+struct ResizeUninitializedTraits<string_type,
+                                 void_t<decltype(std::declval<string_type &>().__resize_default_init(237))>> {
+	using HasMember = std::true_type;
+	static void Resize(string_type *s, size_t new_size) {
+		s->__resize_default_init(new_size);
+	}
 };
 
 } // namespace internal
@@ -54,15 +55,15 @@ struct ResizeUninitializedTraits<
 // store of the std::string with known data.
 template <typename string_type, typename = void>
 inline void STLStringResizeUninitialized(string_type *s, size_t new_size) {
-  internal::ResizeUninitializedTraits<string_type>::Resize(s, new_size);
+	internal::ResizeUninitializedTraits<string_type>::Resize(s, new_size);
 }
 
 // Create a string with the given size, with all bytes uninitialized. Useful to
 // use as a buffer.
 inline std::string CreateResizeUninitializedString(size_t size) {
-  std::string content;
-  STLStringResizeUninitialized(&content, size);
-  return content;
+	std::string content;
+	STLStringResizeUninitialized(&content, size);
+	return content;
 }
 
 } // namespace duckdb

--- a/src/utils/include/size_literals.hpp
+++ b/src/utils/include/size_literals.hpp
@@ -5,83 +5,85 @@
 #include <cstdint>
 
 inline unsigned long long operator""_PiB(unsigned long long sz) {
-  return sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+	return sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
 }
 inline unsigned long long operator""_PB(unsigned long long sz) {
-  return sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
+	return sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
 }
 
 inline unsigned long long operator""_TiB(unsigned long long sz) {
-  return sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+	return sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
 }
 inline unsigned long long operator""_TB(unsigned long long sz) {
-  return sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
+	return sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
 }
 
 inline unsigned long long operator""_GiB(unsigned long long sz) {
-  return sz * 1024ULL * 1024ULL * 1024ULL;
+	return sz * 1024ULL * 1024ULL * 1024ULL;
 }
 inline unsigned long long operator""_GB(unsigned long long sz) {
-  return sz * 1000ULL * 1000ULL * 1000ULL;
+	return sz * 1000ULL * 1000ULL * 1000ULL;
 }
 
 inline unsigned long long operator""_MiB(unsigned long long sz) {
-  return sz * 1024ULL * 1024ULL;
+	return sz * 1024ULL * 1024ULL;
 }
 inline unsigned long long operator""_MB(unsigned long long sz) {
-  return sz * 1000ULL * 1000ULL;
+	return sz * 1000ULL * 1000ULL;
 }
 
 inline unsigned long long operator""_KiB(unsigned long long sz) {
-  return sz * 1024ULL;
+	return sz * 1024ULL;
 }
 inline unsigned long long operator""_KB(unsigned long long sz) {
-  return sz * 1000ULL;
+	return sz * 1000ULL;
 }
 
 inline unsigned long long operator""_PiB(long double sz) {
-  const long double res = sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+	return static_cast<unsigned long long>(res);
 }
 inline unsigned long long operator""_PB(long double sz) {
-  const long double res = sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
+	return static_cast<unsigned long long>(res);
 }
 
 inline unsigned long long operator""_TiB(long double sz) {
-  const long double res = sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1024ULL * 1024ULL * 1024ULL * 1024ULL;
+	return static_cast<unsigned long long>(res);
 }
 inline unsigned long long operator""_TB(long double sz) {
-  const long double res = sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1000ULL * 1000ULL * 1000ULL * 1000ULL;
+	return static_cast<unsigned long long>(res);
 }
 
 inline unsigned long long operator""_GiB(long double sz) {
-  const long double res = sz * 1024ULL * 1024ULL * 1024ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1024ULL * 1024ULL * 1024ULL;
+	return static_cast<unsigned long long>(res);
 }
 inline unsigned long long operator""_GB(long double sz) {
-  const long double res = sz * 1000ULL * 1000ULL * 1000ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1000ULL * 1000ULL * 1000ULL;
+	return static_cast<unsigned long long>(res);
 }
 
 inline unsigned long long operator""_MiB(long double sz) {
-  const long double res = sz * 1024ULL * 1024ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1024ULL * 1024ULL;
+	return static_cast<unsigned long long>(res);
 }
 inline unsigned long long operator""_MB(long double sz) {
-  const long double res = sz * 1000ULL * 1000ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1000ULL * 1000ULL;
+	return static_cast<unsigned long long>(res);
 }
 
 inline unsigned long long operator""_KiB(long double sz) {
-  const long double res = sz * 1024ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1024ULL;
+	return static_cast<unsigned long long>(res);
 }
 inline unsigned long long operator""_KB(long double sz) {
-  const long double res = sz * 1000ULL;
-  return static_cast<unsigned long long>(res);
+	const long double res = sz * 1000ULL;
+	return static_cast<unsigned long long>(res);
 }
 
-inline unsigned long long operator""_B(unsigned long long sz) { return sz; }
+inline unsigned long long operator""_B(unsigned long long sz) {
+	return sz;
+}

--- a/src/utils/include/type_traits.hpp
+++ b/src/utils/include/type_traits.hpp
@@ -2,8 +2,12 @@
 
 namespace duckdb {
 
-template <typename... Ts> struct VoidTImpl { using type = void; };
+template <typename... Ts>
+struct VoidTImpl {
+	using type = void;
+};
 
-template <typename... Ts> using void_t = typename VoidTImpl<Ts...>::type;
+template <typename... Ts>
+using void_t = typename VoidTImpl<Ts...>::type;
 
 } // namespace duckdb

--- a/src/utils/thread_utils.cpp
+++ b/src/utils/thread_utils.cpp
@@ -6,10 +6,10 @@ namespace duckdb {
 
 void SetThreadName(const std::string &thread_name) {
 #if defined(__APPLE__)
-  pthread_setname_np(thread_name.c_str());
+	pthread_setname_np(thread_name.c_str());
 #elif defined(__linux__)
-  // Restricted to 16 characters, include terminator.
-  pthread_setname_np(pthread_self(), thread_name.substr(0, 15).c_str());
+	// Restricted to 16 characters, include terminator.
+	pthread_setname_np(pthread_self(), thread_name.substr(0, 15).c_str());
 #endif
 }
 

--- a/unit/test_base_cache_filesystem.cpp
+++ b/unit/test_base_cache_filesystem.cpp
@@ -14,16 +14,15 @@ namespace {
 const std::string TEST_CONTENT = "helloworld";
 const std::string TEST_FILEPATH = "/tmp/testfile";
 void CreateTestFile() {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
-  auto file_handle = local_filesystem->OpenFile(
-      TEST_FILEPATH, FileOpenFlags::FILE_FLAGS_WRITE |
-                         FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-  local_filesystem->Write(*file_handle, const_cast<char *>(TEST_CONTENT.data()),
-                          TEST_CONTENT.length(), /*location=*/0);
-  file_handle->Sync();
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	auto file_handle = local_filesystem->OpenFile(TEST_FILEPATH, FileOpenFlags::FILE_FLAGS_WRITE |
+	                                                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	local_filesystem->Write(*file_handle, const_cast<char *>(TEST_CONTENT.data()), TEST_CONTENT.length(),
+	                        /*location=*/0);
+	file_handle->Sync();
 }
 void DeleteTestFile() {
-  LocalFileSystem::CreateLocal()->RemoveFile(TEST_FILEPATH);
+	LocalFileSystem::CreateLocal()->RemoveFile(TEST_FILEPATH);
 }
 
 } // namespace
@@ -31,24 +30,20 @@ void DeleteTestFile() {
 // A more ideal unit test would be, we could check hugging face filesystem will
 // be used for certains files.
 TEST_CASE("Test cached filesystem CanHandle", "[base cache filesystem]") {
-  unique_ptr<FileSystem> vfs = make_uniq<VirtualFileSystem>();
-  vfs->RegisterSubSystem(
-      make_uniq<DiskCacheFileSystem>(make_uniq<HuggingFaceFileSystem>()));
-  vfs->RegisterSubSystem(
-      make_uniq<DiskCacheFileSystem>(make_uniq<LocalFileSystem>()));
+	unique_ptr<FileSystem> vfs = make_uniq<VirtualFileSystem>();
+	vfs->RegisterSubSystem(make_uniq<DiskCacheFileSystem>(make_uniq<HuggingFaceFileSystem>()));
+	vfs->RegisterSubSystem(make_uniq<DiskCacheFileSystem>(make_uniq<LocalFileSystem>()));
 
-  // VFS can handle local files with cached local filesystem.
-  auto file_handle =
-      vfs->OpenFile(TEST_FILEPATH, FileOpenFlags::FILE_FLAGS_READ);
-  // Check casting success to make sure disk cache filesystem is selected,
-  // rather than the fallback local filesystem within virtual filesystem.
-  [[maybe_unused]] auto &cached_file_handle =
-      file_handle->Cast<CacheFileSystemHandle>();
+	// VFS can handle local files with cached local filesystem.
+	auto file_handle = vfs->OpenFile(TEST_FILEPATH, FileOpenFlags::FILE_FLAGS_READ);
+	// Check casting success to make sure disk cache filesystem is selected,
+	// rather than the fallback local filesystem within virtual filesystem.
+	[[maybe_unused]] auto &cached_file_handle = file_handle->Cast<CacheFileSystemHandle>();
 }
 
 int main(int argc, char **argv) {
-  CreateTestFile();
-  int result = Catch::Session().run(argc, argv);
-  DeleteTestFile();
-  return result;
+	CreateTestFile();
+	int result = Catch::Session().run(argc, argv);
+	DeleteTestFile();
+	return result;
 }

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -24,14 +24,13 @@ namespace {
 
 constexpr uint64_t TEST_FILE_SIZE = 26;
 const auto TEST_FILE_CONTENT = []() {
-  string content(TEST_FILE_SIZE, '\0');
-  for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
-    content[idx] = 'a' + idx;
-  }
-  return content;
+	string content(TEST_FILE_SIZE, '\0');
+	for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
+		content[idx] = 'a' + idx;
+	}
+	return content;
 }();
-const auto TEST_FILENAME =
-    StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
+const auto TEST_FILENAME = StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
 const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
 } // namespace
 
@@ -39,315 +38,268 @@ const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
 TEST_CASE("Test on disk cache filesystem with requested chunk the first "
           "meanwhile last chunk",
           "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  const uint64_t test_block_size = 26;
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  cache_config.block_size = test_block_size;
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    cache_config};
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	const uint64_t test_block_size = 26;
+	OnDiskCacheConfig cache_config;
+	cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	cache_config.block_size = test_block_size;
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), cache_config};
 
-  // First uncached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 1;
-    const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 1;
+		const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Second cached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 1;
-    const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 1;
+		const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 }
 
 // Two chunks are involved, which include both first and last chunks.
 TEST_CASE("Test on disk cache filesystem with requested chunk the first and "
           "last chunk",
           "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  const uint64_t test_block_size = 5;
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  cache_config.block_size = test_block_size;
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    cache_config};
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	const uint64_t test_block_size = 5;
+	OnDiskCacheConfig cache_config;
+	cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	cache_config.block_size = test_block_size;
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), cache_config};
 
-  // First uncached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 2;
-    const uint64_t bytes_to_read = 5;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 2;
+		const uint64_t bytes_to_read = 5;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Second cached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 3;
-    const uint64_t bytes_to_read = 4;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 3;
+		const uint64_t bytes_to_read = 4;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 }
 
 // Three blocks involved, which include first, last and middle chunk.
 TEST_CASE("Test on disk cache filesystem with requested chunk the first, "
           "middle and last chunk",
           "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  const uint64_t test_block_size = 5;
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  cache_config.block_size = test_block_size;
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    cache_config};
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	const uint64_t test_block_size = 5;
+	OnDiskCacheConfig cache_config;
+	cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	cache_config.block_size = test_block_size;
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), cache_config};
 
-  // First uncached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 2;
-    const uint64_t bytes_to_read = 11;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 2;
+		const uint64_t bytes_to_read = 11;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Second cached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 3;
-    const uint64_t bytes_to_read = 10;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 3;
+		const uint64_t bytes_to_read = 10;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 }
 
 // One block involved, it's the first meanwhile last block; requested content
 // doesn't involve the end of the file.
-TEST_CASE(
-    "Test on disk cache filesystem with requested chunk first and last one",
-    "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  const uint64_t test_block_size = 5;
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  cache_config.block_size = test_block_size;
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    cache_config};
+TEST_CASE("Test on disk cache filesystem with requested chunk first and last one", "[on-disk cache filesystem test]") {
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	const uint64_t test_block_size = 5;
+	OnDiskCacheConfig cache_config;
+	cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	cache_config.block_size = test_block_size;
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), cache_config};
 
-  // First uncached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 2;
-    const uint64_t bytes_to_read = 2;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 2;
+		const uint64_t bytes_to_read = 2;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Second cached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 3;
-    const uint64_t bytes_to_read = 2;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 3;
+		const uint64_t bytes_to_read = 2;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 }
 
 // Requested chunk involves the end of the file.
-TEST_CASE("Test on disk cache filesystem with requested chunk at last of file",
-          "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  const uint64_t test_block_size = 5;
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  cache_config.block_size = test_block_size;
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    cache_config};
+TEST_CASE("Test on disk cache filesystem with requested chunk at last of file", "[on-disk cache filesystem test]") {
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	const uint64_t test_block_size = 5;
+	OnDiskCacheConfig cache_config;
+	cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	cache_config.block_size = test_block_size;
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), cache_config};
 
-  // First uncached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 23;
-    const uint64_t bytes_to_read = 10;
-    string content(3, '\0'); // effective offset range: [23, 25]
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 23;
+		const uint64_t bytes_to_read = 10;
+		string content(3, '\0'); // effective offset range: [23, 25]
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Check cache files count.
-  REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 2);
+	// Check cache files count.
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 2);
 
-  // Second cached read, partial cached and another part uncached.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 15;
-    const uint64_t bytes_to_read = 15;
-    string content(11, '\0'); // effective offset range: [15, 25]
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read, partial cached and another part uncached.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 15;
+		const uint64_t bytes_to_read = 15;
+		string content(11, '\0'); // effective offset range: [15, 25]
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Get all cache files and check file count.
-  REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 3);
+	// Get all cache files and check file count.
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 3);
 }
 
 // Requested chunk involves the middle of the file.
-TEST_CASE(
-    "Test on disk cache filesystem with requested chunk at middle of file",
-    "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  const uint64_t test_block_size = 5;
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  cache_config.block_size = test_block_size;
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    cache_config};
+TEST_CASE("Test on disk cache filesystem with requested chunk at middle of file", "[on-disk cache filesystem test]") {
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	const uint64_t test_block_size = 5;
+	OnDiskCacheConfig cache_config;
+	cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	cache_config.block_size = test_block_size;
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), cache_config};
 
-  // First uncached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 16;
-    const uint64_t bytes_to_read = 3;
-    string content(bytes_to_read, '\0'); // effective offset range: [16, 18]
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 16;
+		const uint64_t bytes_to_read = 3;
+		string content(bytes_to_read, '\0'); // effective offset range: [16, 18]
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Get all cache files and check file count.
-  REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
+	// Get all cache files and check file count.
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
 
-  // Second cached read, partial cached and another part uncached.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 8;
-    const uint64_t bytes_to_read = 14;
-    string content(bytes_to_read, '\0'); // effective offset range: [8, 21]
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read, partial cached and another part uncached.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 8;
+		const uint64_t bytes_to_read = 14;
+		string content(bytes_to_read, '\0'); // effective offset range: [8, 21]
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Get all cache files and check file count.
-  REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 4);
+	// Get all cache files and check file count.
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 4);
 }
 
 // All chunks cached locally, later access shouldn't create new cache file.
-TEST_CASE("Test on disk cache filesystem no new cache file after a full cache",
-          "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  const uint64_t test_block_size = 5;
-  OnDiskCacheConfig cache_config;
-  cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
-  cache_config.block_size = test_block_size;
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    cache_config};
+TEST_CASE("Test on disk cache filesystem no new cache file after a full cache", "[on-disk cache filesystem test]") {
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	const uint64_t test_block_size = 5;
+	OnDiskCacheConfig cache_config;
+	cache_config.on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	cache_config.block_size = test_block_size;
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), cache_config};
 
-  // First uncached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 0;
-    const uint64_t bytes_to_read = TEST_FILE_SIZE;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 0;
+		const uint64_t bytes_to_read = TEST_FILE_SIZE;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Get all cache files.
-  auto cache_files1 = GetSortedFilesUnder(TEST_ON_DISK_CACHE_DIRECTORY);
+	// Get all cache files.
+	auto cache_files1 = GetSortedFilesUnder(TEST_ON_DISK_CACHE_DIRECTORY);
 
-  // Second cached read.
-  {
-    auto handle =
-        disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 3;
-    const uint64_t bytes_to_read = 10;
-    string content(bytes_to_read, '\0');
-    disk_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read.
+	{
+		auto handle = disk_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 3;
+		const uint64_t bytes_to_read = 10;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                   start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Get all cache files and check unchanged.
-  auto cache_files2 = GetSortedFilesUnder(TEST_ON_DISK_CACHE_DIRECTORY);
-  REQUIRE(cache_files1 == cache_files2);
+	// Get all cache files and check unchanged.
+	auto cache_files2 = GetSortedFilesUnder(TEST_ON_DISK_CACHE_DIRECTORY);
+	REQUIRE(cache_files1 == cache_files2);
 }
 
-TEST_CASE("Test on reading non-existent file",
-          "[on-disk cache filesystem test]") {
-  LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  DiskCacheFileSystem disk_cache_fs{LocalFileSystem::CreateLocal(),
-                                    OnDiskCacheConfig{}};
-  REQUIRE_THROWS(disk_cache_fs.OpenFile("non-existent-file",
-                                        FileOpenFlags::FILE_FLAGS_READ));
+TEST_CASE("Test on reading non-existent file", "[on-disk cache filesystem test]") {
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	DiskCacheFileSystem disk_cache_fs {LocalFileSystem::CreateLocal(), OnDiskCacheConfig {}};
+	REQUIRE_THROWS(disk_cache_fs.OpenFile("non-existent-file", FileOpenFlags::FILE_FLAGS_READ));
 }
 
 int main(int argc, char **argv) {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
-  auto file_handle = local_filesystem->OpenFile(
-      TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
-                         FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-  local_filesystem->Write(
-      *file_handle,
-      const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
-      TEST_FILE_SIZE, /*location=*/0);
-  file_handle->Sync();
-  file_handle->Close();
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
+	                                                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
+	                        TEST_FILE_SIZE, /*location=*/0);
+	file_handle->Sync();
+	file_handle->Close();
 
-  int result = Catch::Session().run(argc, argv);
-  local_filesystem->RemoveFile(TEST_FILENAME);
-  return result;
+	int result = Catch::Session().run(argc, argv);
+	local_filesystem->RemoveFile(TEST_FILENAME);
+	return result;
 }

--- a/unit/test_in_memory_cache_filesystem.cpp
+++ b/unit/test_in_memory_cache_filesystem.cpp
@@ -14,67 +14,57 @@ using namespace duckdb; // NOLINT
 namespace {
 constexpr uint64_t TEST_FILE_SIZE = 26;
 const auto TEST_FILE_CONTENT = []() {
-  string content(TEST_FILE_SIZE, '\0');
-  for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
-    content[idx] = 'a' + idx;
-  }
-  return content;
+	string content(TEST_FILE_SIZE, '\0');
+	for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
+		content[idx] = 'a' + idx;
+	}
+	return content;
 }();
-const auto TEST_FILENAME =
-    StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
+const auto TEST_FILENAME = StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
 const InMemoryCacheConfig TEST_CACHE_CONFIG = []() {
-  InMemoryCacheConfig cache_config;
-  return cache_config;
+	InMemoryCacheConfig cache_config;
+	return cache_config;
 }();
 } // namespace
 
-TEST_CASE("Test on in-memory cache filesystem",
-          "[in-memory cache filesystem test]") {
-  InMemoryCacheFileSystem in_mem_cache_fs{LocalFileSystem::CreateLocal(),
-                                          TEST_CACHE_CONFIG};
+TEST_CASE("Test on in-memory cache filesystem", "[in-memory cache filesystem test]") {
+	InMemoryCacheFileSystem in_mem_cache_fs {LocalFileSystem::CreateLocal(), TEST_CACHE_CONFIG};
 
-  // First uncached read.
-  {
-    auto handle =
-        in_mem_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 1;
-    const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
-    string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 26;
-    in_mem_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// First uncached read.
+	{
+		auto handle = in_mem_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 1;
+		const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
+		string content(bytes_to_read, '\0');
+		const uint64_t test_block_size = 26;
+		in_mem_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                     start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 
-  // Second cached read.
-  {
-    auto handle =
-        in_mem_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
-    const uint64_t start_offset = 1;
-    const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
-    string content(bytes_to_read, '\0');
-    const uint64_t test_block_size = 26;
-    in_mem_cache_fs.Read(
-        *handle, const_cast<void *>(static_cast<const void *>(content.data())),
-        bytes_to_read, start_offset);
-    REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-  }
+	// Second cached read.
+	{
+		auto handle = in_mem_cache_fs.OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 1;
+		const uint64_t bytes_to_read = TEST_FILE_SIZE - 2;
+		string content(bytes_to_read, '\0');
+		const uint64_t test_block_size = 26;
+		in_mem_cache_fs.Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                     start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 }
 
 int main(int argc, char **argv) {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
-  auto file_handle = local_filesystem->OpenFile(
-      TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
-                         FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-  local_filesystem->Write(
-      *file_handle,
-      const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
-      TEST_FILE_SIZE, /*location=*/0);
-  file_handle->Sync();
-  file_handle->Close();
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
+	                                                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
+	                        TEST_FILE_SIZE, /*location=*/0);
+	file_handle->Sync();
+	file_handle->Close();
 
-  int result = Catch::Session().run(argc, argv);
-  local_filesystem->RemoveFile(TEST_FILENAME);
-  return result;
+	int result = Catch::Session().run(argc, argv);
+	local_filesystem->RemoveFile(TEST_FILENAME);
+	return result;
 }

--- a/unit/test_set_extension_config.cpp
+++ b/unit/test_set_extension_config.cpp
@@ -15,108 +15,95 @@
 using namespace duckdb; // NOLINT
 
 namespace {
-const std::string TEST_ON_DISK_CACHE_DIRECTORY =
-    "/tmp/duckdb_test_cached_http_cache";
-const std::string TEST_SECOND_ON_DISK_CACHE_DIRECTORY =
-    "/tmp/duckdb_test_cached_http_cache_second";
+const std::string TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
+const std::string TEST_SECOND_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache_second";
 const std::string TEST_ON_DISK_CACHE_FILE = "/tmp/test-config.parquet";
 
 void CleanupTestDirectory() {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
-  if (local_filesystem->DirectoryExists(TEST_ON_DISK_CACHE_DIRECTORY)) {
-    local_filesystem->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  }
-  if (local_filesystem->DirectoryExists(TEST_SECOND_ON_DISK_CACHE_DIRECTORY)) {
-    local_filesystem->RemoveDirectory(TEST_SECOND_ON_DISK_CACHE_DIRECTORY);
-  }
-  if (local_filesystem->FileExists(TEST_ON_DISK_CACHE_FILE)) {
-    local_filesystem->RemoveFile(TEST_ON_DISK_CACHE_FILE);
-  }
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	if (local_filesystem->DirectoryExists(TEST_ON_DISK_CACHE_DIRECTORY)) {
+		local_filesystem->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	}
+	if (local_filesystem->DirectoryExists(TEST_SECOND_ON_DISK_CACHE_DIRECTORY)) {
+		local_filesystem->RemoveDirectory(TEST_SECOND_ON_DISK_CACHE_DIRECTORY);
+	}
+	if (local_filesystem->FileExists(TEST_ON_DISK_CACHE_FILE)) {
+		local_filesystem->RemoveFile(TEST_ON_DISK_CACHE_FILE);
+	}
 }
 } // namespace
 
 TEST_CASE("Test on incorrect config", "[extension config test]") {
-  DuckDB db(nullptr);
-  Connection con(db);
+	DuckDB db(nullptr);
+	Connection con(db);
 
-  // Set non-existent config parameter.
-  auto result = con.Query(
-      StringUtil::Format("SET wrong_cached_http_cache_directory ='%s'",
-                         TEST_ON_DISK_CACHE_DIRECTORY));
-  REQUIRE(result->HasError());
+	// Set non-existent config parameter.
+	auto result =
+	    con.Query(StringUtil::Format("SET wrong_cached_http_cache_directory ='%s'", TEST_ON_DISK_CACHE_DIRECTORY));
+	REQUIRE(result->HasError());
 
-  // Set existent config parameter to incorrect type.
-  result =
-      con.Query(StringUtil::Format("SET cached_http_cache_block_size='hello'"));
-  REQUIRE(result->HasError());
+	// Set existent config parameter to incorrect type.
+	result = con.Query(StringUtil::Format("SET cached_http_cache_block_size='hello'"));
+	REQUIRE(result->HasError());
 }
 
 TEST_CASE("Test on correct config", "[extension config test]") {
-  DuckDB db(nullptr);
-  Connection con(db);
+	DuckDB db(nullptr);
+	Connection con(db);
 
-  // On-disk cache directory.
-  auto result = con.Query(
-      StringUtil::Format("SET cached_http_cache_directory='helloworld'"));
-  REQUIRE(!result->HasError());
+	// On-disk cache directory.
+	auto result = con.Query(StringUtil::Format("SET cached_http_cache_directory='helloworld'"));
+	REQUIRE(!result->HasError());
 
-  // Cache block size.
-  result = con.Query(StringUtil::Format("SET cached_http_cache_block_size=10"));
-  REQUIRE(!result->HasError());
+	// Cache block size.
+	result = con.Query(StringUtil::Format("SET cached_http_cache_block_size=10"));
+	REQUIRE(!result->HasError());
 
-  // In-memory cache block count.
-  result = con.Query(
-      StringUtil::Format("SET cached_http_max_in_mem_cache_block_count=10"));
-  REQUIRE(!result->HasError());
+	// In-memory cache block count.
+	result = con.Query(StringUtil::Format("SET cached_http_max_in_mem_cache_block_count=10"));
+	REQUIRE(!result->HasError());
 }
 
 TEST_CASE("Test on changing extension config"
           "change defaul cache dir path setting",
           "[extension config test]") {
-  DuckDB db(nullptr);
-  auto &instance = db.instance;
-  auto &fs = instance->GetFileSystem();
-  fs.RegisterSubSystem(
-      make_uniq<DiskCacheFileSystem>(LocalFileSystem::CreateLocal()));
+	DuckDB db(nullptr);
+	auto &instance = db.instance;
+	auto &fs = instance->GetFileSystem();
+	fs.RegisterSubSystem(make_uniq<DiskCacheFileSystem>(LocalFileSystem::CreateLocal()));
 
-  Connection con(db);
-  con.Query(StringUtil::Format("SET cached_http_cache_directory ='%s'",
-                               TEST_ON_DISK_CACHE_DIRECTORY));
-  con.Query("CREATE TABLE integers AS SELECT i, i+1 as j FROM range(10) r(i)");
-  con.Query(
-      StringUtil::Format("COPY integers TO '%s'", TEST_ON_DISK_CACHE_FILE));
+	Connection con(db);
+	con.Query(StringUtil::Format("SET cached_http_cache_directory ='%s'", TEST_ON_DISK_CACHE_DIRECTORY));
+	con.Query("CREATE TABLE integers AS SELECT i, i+1 as j FROM range(10) r(i)");
+	con.Query(StringUtil::Format("COPY integers TO '%s'", TEST_ON_DISK_CACHE_FILE));
 
-  // Ensure the cache directory is empty before executing the query.
-  const int files = GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY);
-  REQUIRE(files == 0);
+	// Ensure the cache directory is empty before executing the query.
+	const int files = GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY);
+	REQUIRE(files == 0);
 
-  // After executing the query, the cache directory should have one cache file.
-  auto result = con.Query(
-      StringUtil::Format("SELECT * FROM '%s'", TEST_ON_DISK_CACHE_FILE));
-  REQUIRE(!result->HasError());
+	// After executing the query, the cache directory should have one cache file.
+	auto result = con.Query(StringUtil::Format("SELECT * FROM '%s'", TEST_ON_DISK_CACHE_FILE));
+	REQUIRE(!result->HasError());
 
-  const int files_after_query = GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY);
-  const auto files_in_cache = GetSortedFilesUnder(TEST_ON_DISK_CACHE_DIRECTORY);
-  REQUIRE(files_after_query == 1);
+	const int files_after_query = GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY);
+	const auto files_in_cache = GetSortedFilesUnder(TEST_ON_DISK_CACHE_DIRECTORY);
+	REQUIRE(files_after_query == 1);
 
-  // Change the cache directory path and execute the query again.
-  con.Query(StringUtil::Format("SET cached_http_cache_directory ='%s'",
-                               TEST_SECOND_ON_DISK_CACHE_DIRECTORY));
-  con.Query(StringUtil::Format("SELECT * FROM '%s'", TEST_ON_DISK_CACHE_FILE));
+	// Change the cache directory path and execute the query again.
+	con.Query(StringUtil::Format("SET cached_http_cache_directory ='%s'", TEST_SECOND_ON_DISK_CACHE_DIRECTORY));
+	con.Query(StringUtil::Format("SELECT * FROM '%s'", TEST_ON_DISK_CACHE_FILE));
 
-  // After executing the query, the NEW directory should have one cache file.
-  // Both directories should have the same cache file.
-  const int files_after_query_second =
-      GetFileCountUnder(TEST_SECOND_ON_DISK_CACHE_DIRECTORY);
-  const auto files_in_cache_second =
-      GetSortedFilesUnder(TEST_SECOND_ON_DISK_CACHE_DIRECTORY);
-  REQUIRE(files_after_query_second == 1);
-  REQUIRE(files_in_cache == files_in_cache_second);
+	// After executing the query, the NEW directory should have one cache file.
+	// Both directories should have the same cache file.
+	const int files_after_query_second = GetFileCountUnder(TEST_SECOND_ON_DISK_CACHE_DIRECTORY);
+	const auto files_in_cache_second = GetSortedFilesUnder(TEST_SECOND_ON_DISK_CACHE_DIRECTORY);
+	REQUIRE(files_after_query_second == 1);
+	REQUIRE(files_in_cache == files_in_cache_second);
 };
 
 int main(int argc, char **argv) {
-  CleanupTestDirectory();
-  int result = Catch::Session().run(argc, argv);
-  CleanupTestDirectory();
-  return result;
+	CleanupTestDirectory();
+	int result = Catch::Session().run(argc, argv);
+	CleanupTestDirectory();
+	return result;
 }

--- a/unit/test_shared_lru_cache.cpp
+++ b/unit/test_shared_lru_cache.cpp
@@ -10,66 +10,65 @@ using namespace duckdb; // NOLINT
 
 namespace {
 struct MapKey {
-  std::string fname;
-  uint64_t off;
+	std::string fname;
+	uint64_t off;
 };
 struct MapKeyEqual {
-  bool operator()(const MapKey &lhs, const MapKey &rhs) const {
-    return std::tie(lhs.fname, lhs.off) == std::tie(rhs.fname, rhs.off);
-  }
+	bool operator()(const MapKey &lhs, const MapKey &rhs) const {
+		return std::tie(lhs.fname, lhs.off) == std::tie(rhs.fname, rhs.off);
+	}
 };
 struct MapKeyHash {
-  std::size_t operator()(const MapKey &key) const {
-    return std::hash<std::string>{}(key.fname) ^ std::hash<uint64_t>{}(key.off);
-  }
+	std::size_t operator()(const MapKey &key) const {
+		return std::hash<std::string> {}(key.fname) ^ std::hash<uint64_t> {}(key.off);
+	}
 };
 } // namespace
 
 TEST_CASE("PutAndGetSameKey", "[shared lru test]") {
-  ThreadSafeSharedLruCache<std::string, std::string> cache{1};
+	ThreadSafeSharedLruCache<std::string, std::string> cache {1};
 
-  // No value initially.
-  auto val = cache.Get("1");
-  REQUIRE(val == nullptr);
+	// No value initially.
+	auto val = cache.Get("1");
+	REQUIRE(val == nullptr);
 
-  // Check put and get.
-  cache.Put("1", std::make_shared<std::string>("1"));
-  val = cache.Get("1");
-  REQUIRE(val != nullptr);
-  REQUIRE(*val == "1");
+	// Check put and get.
+	cache.Put("1", std::make_shared<std::string>("1"));
+	val = cache.Get("1");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "1");
 
-  // Check key eviction.
-  cache.Put("2", std::make_shared<std::string>("2"));
-  val = cache.Get("1");
-  REQUIRE(val == nullptr);
-  val = cache.Get("2");
-  REQUIRE(val != nullptr);
-  REQUIRE(*val == "2");
+	// Check key eviction.
+	cache.Put("2", std::make_shared<std::string>("2"));
+	val = cache.Get("1");
+	REQUIRE(val == nullptr);
+	val = cache.Get("2");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "2");
 
-  // Check deletion.
-  REQUIRE(!cache.Delete("1"));
-  REQUIRE(cache.Delete("2"));
-  val = cache.Get("2");
-  REQUIRE(val == nullptr);
+	// Check deletion.
+	REQUIRE(!cache.Delete("1"));
+	REQUIRE(cache.Delete("2"));
+	val = cache.Get("2");
+	REQUIRE(val == nullptr);
 }
 
 TEST_CASE("CustomizedStruct", "[shared lru test]") {
-  ThreadSafeSharedLruCache<MapKey, std::string, MapKeyHash, MapKeyEqual> cache{
-      1};
-  MapKey key;
-  key.fname = "hello";
-  key.off = 10;
-  cache.Put(key, std::make_shared<std::string>("world"));
+	ThreadSafeSharedLruCache<MapKey, std::string, MapKeyHash, MapKeyEqual> cache {1};
+	MapKey key;
+	key.fname = "hello";
+	key.off = 10;
+	cache.Put(key, std::make_shared<std::string>("world"));
 
-  MapKey lookup_key;
-  lookup_key.fname = key.fname;
-  lookup_key.off = key.off;
-  auto val = cache.Get(lookup_key);
-  REQUIRE(val != nullptr);
-  REQUIRE(*val == "world");
+	MapKey lookup_key;
+	lookup_key.fname = key.fname;
+	lookup_key.off = key.off;
+	auto val = cache.Get(lookup_key);
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "world");
 }
 
 int main(int argc, char **argv) {
-  int result = Catch::Session().run(argc, argv);
-  return result;
+	int result = Catch::Session().run(argc, argv);
+	return result;
 }

--- a/unit/test_size_literals.cpp
+++ b/unit/test_size_literals.cpp
@@ -4,12 +4,12 @@
 #include "size_literals.hpp"
 
 TEST_CASE("Size literals test", "[size literals]") {
-  REQUIRE(2_MiB == 2 * 1024 * 1024);
-  REQUIRE(2.5_KB == 2500);
-  REQUIRE(4_GB == 4000000000);
+	REQUIRE(2_MiB == 2 * 1024 * 1024);
+	REQUIRE(2.5_KB == 2500);
+	REQUIRE(4_GB == 4000000000);
 }
 
 int main(int argc, char **argv) {
-  int result = Catch::Session().run(argc, argv);
-  return result;
+	int result = Catch::Session().run(argc, argv);
+	return result;
 }

--- a/unit/test_stale_deletion.cpp
+++ b/unit/test_stale_deletion.cpp
@@ -16,46 +16,40 @@ const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
 } // namespace
 
 TEST_CASE("Stale file deletion", "[utils test]") {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
-  const string fname1 =
-      StringUtil::Format("%s/file1", TEST_ON_DISK_CACHE_DIRECTORY);
-  const string fname2 =
-      StringUtil::Format("%s/file2", TEST_ON_DISK_CACHE_DIRECTORY);
-  const std::string CONTENT = "helloworld";
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	const string fname1 = StringUtil::Format("%s/file1", TEST_ON_DISK_CACHE_DIRECTORY);
+	const string fname2 = StringUtil::Format("%s/file2", TEST_ON_DISK_CACHE_DIRECTORY);
+	const std::string CONTENT = "helloworld";
 
-  {
-    auto file_handle = local_filesystem->OpenFile(
-        fname1, FileOpenFlags::FILE_FLAGS_WRITE |
-                    FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-  }
-  {
-    auto file_handle = local_filesystem->OpenFile(
-        fname2, FileOpenFlags::FILE_FLAGS_WRITE |
-                    FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-  }
+	{
+		auto file_handle = local_filesystem->OpenFile(fname1, FileOpenFlags::FILE_FLAGS_WRITE |
+		                                                          FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	}
+	{
+		auto file_handle = local_filesystem->OpenFile(fname2, FileOpenFlags::FILE_FLAGS_WRITE |
+		                                                          FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	}
 
-  const time_t now = std::time(nullptr);
-  const time_t one_day_ago = now - 24 * 60 * 60;
-  struct utimbuf updated_time;
-  updated_time.actime = one_day_ago;
-  updated_time.modtime = one_day_ago;
-  REQUIRE(utime(fname2.data(), &updated_time) == 0);
+	const time_t now = std::time(nullptr);
+	const time_t one_day_ago = now - 24 * 60 * 60;
+	struct utimbuf updated_time;
+	updated_time.actime = one_day_ago;
+	updated_time.modtime = one_day_ago;
+	REQUIRE(utime(fname2.data(), &updated_time) == 0);
 
-  EvictStaleCacheFiles(*local_filesystem, TEST_ON_DISK_CACHE_DIRECTORY);
-  vector<string> fresh_files;
-  REQUIRE(local_filesystem->ListFiles(
-      TEST_ON_DISK_CACHE_DIRECTORY,
-      [&fresh_files](const string &fname, bool /*unused*/) {
-        fresh_files.emplace_back(
-            StringUtil::Format("%s/%s", TEST_ON_DISK_CACHE_DIRECTORY, fname));
-      }));
-  REQUIRE(fresh_files == vector<string>{fname1});
+	EvictStaleCacheFiles(*local_filesystem, TEST_ON_DISK_CACHE_DIRECTORY);
+	vector<string> fresh_files;
+	REQUIRE(
+	    local_filesystem->ListFiles(TEST_ON_DISK_CACHE_DIRECTORY, [&fresh_files](const string &fname, bool /*unused*/) {
+		    fresh_files.emplace_back(StringUtil::Format("%s/%s", TEST_ON_DISK_CACHE_DIRECTORY, fname));
+	    }));
+	REQUIRE(fresh_files == vector<string> {fname1});
 }
 
 int main(int argc, char **argv) {
-  auto local_filesystem = LocalFileSystem::CreateLocal();
-  local_filesystem->CreateDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  int result = Catch::Session().run(argc, argv);
-  local_filesystem->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
-  return result;
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	local_filesystem->CreateDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	int result = Catch::Session().run(argc, argv);
+	local_filesystem->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	return result;
 }


### PR DESCRIPTION
This PR updates clang-format configuration file to use duckdb's.
Ref: https://github.com/duckdb/duckdb/blob/main/.clang-format