### PR TITLE
Fix data race for in-memory cache reader

### DIFF
--- a/src/base_cache_filesystem.cpp
+++ b/src/base_cache_filesystem.cpp
@@ -67,7 +67,7 @@ unique_ptr<FileHandle> CacheFileSystem::OpenFile(const string &path, FileOpenFla
 	SetAndGetCacheReader();
 	D_ASSERT(internal_cache_reader != nullptr);
 
-	// TODO(hjiang): We need to make sure all reader should be thread-safe.
+	// TODO(hjiang): We need to add unit test to make sure all reader should be thread-safe.
 	auto file_handle = internal_filesystem->OpenFile(path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
 	return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this);
 }

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -57,7 +57,7 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 }
 
 void ResetGlobalConfig() {
-    // Intentionally not set [g_test_cache_type].
+	// Intentionally not set [g_test_cache_type].
 	g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
 	g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
 	g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;

--- a/src/in_memory_cache_filesystem.cpp
+++ b/src/in_memory_cache_filesystem.cpp
@@ -42,9 +42,7 @@ struct CacheReadChunk {
 
 void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
                                        idx_t requested_bytes_to_read, idx_t file_size) {
-	if (cache == nullptr) {
-		cache = make_uniq<InMemCache>(g_max_in_mem_cache_block_count);
-	}
+	std::call_once(cache_init_flag, [this]() { cache = make_uniq<InMemCache>(g_max_in_mem_cache_block_count); });
 
 	const idx_t block_size = g_cache_block_size;
 	const idx_t aligned_start_offset = requested_start_offset / block_size * block_size;

--- a/src/include/in_mem_cache_block.hpp
+++ b/src/include/in_mem_cache_block.hpp
@@ -2,10 +2,11 @@
 
 #pragma once
 
-#include <string>
-#include <tuple>
 #include <cstdint>
 #include <functional>
+#include <mutex>
+#include <string>
+#include <tuple>
 
 #include "duckdb/common/string_util.hpp"
 

--- a/src/include/in_memory_cache_filesystem.hpp
+++ b/src/include/in_memory_cache_filesystem.hpp
@@ -2,15 +2,15 @@
 
 #pragma once
 
+#include "base_cache_filesystem.hpp"
+#include "base_cache_reader.hpp"
+#include "cache_filesystem_config.hpp"
+#include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/unique_ptr.hpp"
-#include "cache_filesystem_config.hpp"
 #include "in_mem_cache_block.hpp"
 #include "lru_cache.hpp"
-#include "base_cache_filesystem.hpp"
-#include "duckdb/common/file_opener.hpp"
-#include "base_cache_reader.hpp"
 
 namespace duckdb {
 
@@ -32,6 +32,8 @@ public:
 private:
 	using InMemCache = ThreadSafeSharedLruCache<InMemCacheBlock, string, InMemCacheBlockHash, InMemCacheBlockEqual>;
 
+	// Once flag to guard against cache's initialization.
+	std::once_flag cache_init_flag;
 	// LRU cache to store blocks; late initialized after first access.
 	unique_ptr<InMemCache> cache;
 };


### PR DESCRIPTION
Cache reader could be accessed from multiple threads, so need to make sure it's thread-safety.