### PR TITLE
Add testcases for concurrent access for both cache filesystem

### DIFF
--- a/unit/test_in_memory_cache_filesystem.cpp
+++ b/unit/test_in_memory_cache_filesystem.cpp
@@ -6,6 +6,7 @@
 #include "cache_filesystem_config.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "in_memory_cache_filesystem.hpp"
 #include "scope_guard.hpp"
@@ -52,6 +53,37 @@ TEST_CASE("Test on in-memory cache filesystem", "[in-memory cache filesystem tes
 		in_mem_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
 		                      start_offset);
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+}
+
+TEST_CASE("Test on concurrent access", "[in-memory cache filesystem test]") {
+	g_cache_block_size = 5;
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+
+	auto in_mem_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	auto handle = in_mem_cache_fs->OpenFile(TEST_FILENAME,
+	                                        FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	const uint64_t start_offset = 0;
+	const uint64_t bytes_to_read = TEST_FILE_SIZE;
+
+	// Spawn multiple threads to read through in-memory cache filesystem.
+	constexpr idx_t THREAD_NUM = 200;
+	vector<thread> reader_threads;
+	reader_threads.reserve(THREAD_NUM);
+	for (idx_t idx = 0; idx < THREAD_NUM; ++idx) {
+		reader_threads.emplace_back([&]() {
+			string content(bytes_to_read, '\0');
+			in_mem_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+			                      start_offset);
+			REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+		});
+	}
+	for (auto &cur_thd : reader_threads) {
+		D_ASSERT(cur_thd.joinable());
+		cur_thd.join();
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/dentiny/duck-read-cache-fs/issues/35, to add more testcases to cover concurrent accesses.