### PR TITLE
Initial implementation for cache filesystem profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,12 @@ include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 
 set(EXTENSION_SOURCES
-    src/cache_filesystem_config.cpp
-    src/read_cache_fs_extension.cpp
     src/base_cache_filesystem.cpp
+    src/cache_filesystem_config.cpp
     src/disk_cache_filesystem.cpp
     src/in_memory_cache_filesystem.cpp
+    src/read_cache_fs_extension.cpp
+    src/temp_profile_collector.cpp
     src/utils/filesystem_utils.cpp
     src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -25,16 +25,22 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 
 	// Check and update cache type if necessary, only assign if setting valid.
 	FileOpener::TryGetCurrentSetting(opener, "cached_http_type", val);
-	auto type_string = val.ToString();
-	if (type_string == ON_DISK_CACHE_TYPE) {
-		g_cache_type = std::move(type_string);
-	} else if (type_string == IN_MEM_CACHE_TYPE) {
-		g_cache_type = IN_MEM_CACHE_TYPE;
+	auto cache_type_string = val.ToString();
+	if (cache_type_string == ON_DISK_CACHE_TYPE || cache_type_string == IN_MEM_CACHE_TYPE) {
+		g_cache_type = std::move(cache_type_string);
 	}
 
 	// Testing cache type has higher priority than [g_cache_type].
 	if (!g_test_cache_type.empty()) {
 		g_cache_type = g_test_cache_type;
+	}
+
+	// Check and update profile collector type if necessary, only assign if valid.
+	FileOpener::TryGetCurrentSetting(opener, "cached_http_profile_type", val);
+	auto profile_type_string = val.ToString();
+	if (profile_type_string == NOOP_PROFILE_TYPE || profile_type_string == TEMP_PROFILE_TYPE ||
+	    profile_type_string == PERSISTENT_PROFILE_TYPE) {
+		g_profile_type = std::move(profile_type_string);
 	}
 
 	// Check and update configurations for on-disk cache type.
@@ -62,6 +68,7 @@ void ResetGlobalConfig() {
 	g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
 	g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
 	g_cache_type = DEFAULT_CACHE_TYPE;
+	g_profile_type = DEFAULT_PROFILE_TYPE;
 }
 
 } // namespace duckdb

--- a/src/in_memory_cache_filesystem.cpp
+++ b/src/in_memory_cache_filesystem.cpp
@@ -114,16 +114,21 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 			auto cache_block = cache->Get(block_key);
 
 			if (cache_block != nullptr) {
+				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheAccess::kCacheHit);
 				cache_read_chunk.CopyBufferToRequestedMemory(*cache_block);
 				return;
 			}
 
-			// We suffer a cache loss, fallback to remote access then local
-			// filesystem write.
+			// We suffer a cache loss, fallback to remote access then local filesystem write.
+			profile_collector->RecordCacheAccess(BaseProfileCollector::CacheAccess::kCacheMiss);
 			auto content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
 			auto &in_mem_cache_handle = handle.Cast<CacheFileSystemHandle>();
+
+			const string cur_oper = StringUtil::Format("%d", cache_read_chunk.aligned_start_offset);
+			profile_collector->RecordOperationStart(cur_oper);
 			internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle, const_cast<char *>(content.data()),
 			                          content.length(), cache_read_chunk.aligned_start_offset);
+			profile_collector->RecordOperationEnd(cur_oper);
 
 			// Copy to destination buffer.
 			cache_read_chunk.CopyBufferToRequestedMemory(content);

--- a/src/include/base_cache_filesystem.hpp
+++ b/src/include/base_cache_filesystem.hpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "base_cache_reader.hpp"
+#include "base_profile_collector.hpp"
 
 namespace duckdb {
 
@@ -33,6 +34,9 @@ public:
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
 	std::string GetName() const override;
+	BaseProfileCollector *GetProfileCollector() const {
+		return profile_collector.get();
+	}
 
 	// For other API calls, delegate to [internal_filesystem] to handle.
 	unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) override {
@@ -153,6 +157,9 @@ protected:
 	// Initialize cache reader data member, and set to [internal_cache_reader].
 	void SetAndGetCacheReader();
 
+	// Initialize profile collector data member.
+	void SetProfileCollector();
+
 	// Used to access remote files.
 	unique_ptr<FileSystem> internal_filesystem;
 	// In-memory and on-disk cache reader.
@@ -161,6 +168,8 @@ protected:
 	// Either in-memory or on-disk cache reader, whichever is actively being used, ownership lies the above cache
 	// reader.
 	BaseCacheReader *internal_cache_reader = nullptr;
+	// Used to profile operations.
+	unique_ptr<BaseProfileCollector> profile_collector;
 };
 
 } // namespace duckdb

--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "base_cache_reader.hpp"
+#include "base_profile_collector.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 
@@ -23,9 +25,16 @@ public:
 		throw NotImplementedException("Base cache reader doesn't implement GetName.");
 	}
 
+	void SetProfileCollector(BaseProfileCollector *profile_collector_p) {
+		profile_collector = profile_collector_p;
+		profile_collector->SetCacheReaderType(GetName());
+	}
+
 protected:
 	// Ownership lies in cache filesystem.
 	FileSystem *internal_filesystem = nullptr;
+	// Ownership lies in cache filesystem.
+	BaseProfileCollector *profile_collector = nullptr;
 };
 
 } // namespace duckdb

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "cache_filesystem_config.hpp"
+
+namespace duckdb {
+
+// A commonly seen way to lay filesystem features is decorator pattern, with each feature as a new class and layer.
+// In the ideal world, profiler should be achieved as another layer, just like how we implement cache filesystem; but
+// that requires us to implant more config settings and global variables. For simplicity (since we only target cache
+// filesystem in the extension), profiler collector is used as a data member for cache filesystem.
+class BaseProfileCollector {
+public:
+	enum class CacheAccess {
+		kCacheHit,
+		kCacheMiss,
+	};
+
+	BaseProfileCollector() = default;
+	virtual ~BaseProfileCollector() = default;
+
+	// Record the start of operation [oper].
+	virtual void RecordOperationStart(const std::string &oper) = 0;
+	// Record the finish of operation [oper].
+	virtual void RecordOperationEnd(const std::string &oper) = 0;
+	// Record cache access condition.
+	virtual void RecordCacheAccess(CacheAccess cache_access) = 0;
+	// Get profiler type.
+	virtual std::string GetProfilerType() = 0;
+	// Set cache reader type.
+	void SetCacheReaderType(std::string cache_reader_type_p) {
+		cache_reader_type = std::move(cache_reader_type_p);
+	}
+	// Reset profile stats.
+	virtual void Reset() = 0;
+	// Get human-readable aggregated profile collection, and its latest completed IO operation timestamp.
+	virtual std::pair<std::string /*stats*/, uint64_t /*timestamp*/> GetHumanReadableStats() = 0;
+
+protected:
+	std::string cache_reader_type = "";
+};
+
+class NoopProfileCollector final : public BaseProfileCollector {
+public:
+	NoopProfileCollector() = default;
+	~NoopProfileCollector() override = default;
+
+	void RecordOperationStart(const std::string &oper) override {
+	}
+	void RecordOperationEnd(const std::string &oper) override {
+	}
+	void RecordCacheAccess(CacheAccess cache_access) override {
+	}
+	std::string GetProfilerType() override {
+		return NOOP_PROFILE_TYPE;
+	}
+	void Reset() override {};
+	std::pair<std::string, uint64_t> GetHumanReadableStats() override {
+		return std::make_pair("(noop profile collector)", /*timestamp=*/0);
+	}
+};
+
+} // namespace duckdb

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -16,6 +16,13 @@ namespace duckdb {
 inline const std::string ON_DISK_CACHE_TYPE = "on_disk";
 inline const std::string IN_MEM_CACHE_TYPE = "in_mem";
 
+// Default profile option, which performs no-op.
+inline const std::string NOOP_PROFILE_TYPE = "noop";
+// Store the latest IO operation profiling result, which potentially suffers concurrent updates.
+inline const std::string TEMP_PROFILE_TYPE = "temp";
+// Store the IO operation profiling results into duckdb table, which unblocks advanced analysis.
+inline const std::string PERSISTENT_PROFILE_TYPE = "duckdb";
+
 //===--------------------------------------------------------------------===//
 // Default configuration
 //===--------------------------------------------------------------------===//
@@ -25,16 +32,17 @@ inline const std::string DEFAULT_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_cached_h
 // Default to use on-disk cache filesystem.
 inline std::string DEFAULT_CACHE_TYPE = ON_DISK_CACHE_TYPE;
 
-// To prevent go out of disk space, we set a threshold to disable local caching
-// if insufficient.
+// To prevent go out of disk space, we set a threshold to disable local caching if insufficient.
 inline const idx_t MIN_DISK_SPACE_FOR_CACHE = 1_MiB;
 
-// Maximum in-memory cache block number, which caps the overall memory
-// consumption as (block size * max block count).
+// Maximum in-memory cache block number, which caps the overall memory consumption as (block size * max block count).
 inline const idx_t DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
 
 // Number of seconds which we define as the threshold of staleness.
 inline constexpr idx_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
+
+// Default option for profile type.
+inline std::string DEFAULT_PROFILE_TYPE = NOOP_PROFILE_TYPE;
 
 //===--------------------------------------------------------------------===//
 // Global configuration
@@ -43,6 +51,7 @@ inline idx_t g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
 inline std::string g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
 inline idx_t g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
 inline std::string g_cache_type = DEFAULT_CACHE_TYPE;
+inline std::string g_profile_type = DEFAULT_PROFILE_TYPE;
 
 // Used for testing purpose, which has a higher priority over [g_cache_type], and won't be reset.
 // TODO(hjiang): A better is bake configuration into `FileOpener`.

--- a/src/include/in_mem_cache_block.hpp
+++ b/src/include/in_mem_cache_block.hpp
@@ -12,8 +12,6 @@
 
 namespace duckdb {
 
-// TODO(hjiang): Use customized hash and equal functor to store in cache,
-// temporarily unblock by using string as key.
 struct InMemCacheBlock {
 	std::string fname;
 	idx_t start_off = 0;

--- a/src/include/temp_profile_collector.hpp
+++ b/src/include/temp_profile_collector.hpp
@@ -1,0 +1,41 @@
+// Profile collector, which profiles and stores the latest result in memory.
+
+#pragma once
+
+#include "base_profile_collector.hpp"
+#include "duckdb/common/profiler.hpp"
+
+#include <mutex>
+
+namespace duckdb {
+
+class TempProfileCollector final : public BaseProfileCollector {
+public:
+	TempProfileCollector() = default;
+	~TempProfileCollector() override = default;
+
+	void RecordOperationStart(const std::string &oper) override;
+	void RecordOperationEnd(const std::string &oper) override;
+	void RecordCacheAccess(CacheAccess cache_access) override;
+	std::string GetProfilerType() override {
+		return TEMP_PROFILE_TYPE;
+	}
+	void Reset() override;
+	std::pair<std::string, uint64_t> GetHumanReadableStats() override;
+
+private:
+	struct OperationStats {
+		// Accounted as time elapsed since unix epoch in milliseconds.
+		int64_t start_timestamp = 0;
+		int64_t end_timestamp = 0;
+	};
+
+	// Maps from operation name to its stats.
+	unordered_map<string, OperationStats> operation_events;
+	// Aggregated cache access condition.
+	uint64_t cache_hit_count = 0;
+	uint64_t cache_miss_count = 0;
+
+	std::mutex stats_mutex;
+};
+} // namespace duckdb

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -1,0 +1,58 @@
+#include "temp_profile_collector.hpp"
+#include "utils/include/time_utils.hpp"
+
+namespace duckdb {
+
+void TempProfileCollector::RecordOperationStart(const std::string &oper) {
+	std::lock_guard<std::mutex> lck(stats_mutex);
+	const bool is_new = operation_events
+	                        .emplace(oper,
+	                                 OperationStats {
+	                                     .start_timestamp = GetSteadyNowMilliSecSinceEpoch(),
+	                                 })
+	                        .second;
+	D_ASSERT(is_new);
+}
+
+void TempProfileCollector::RecordOperationEnd(const std::string &oper) {
+	std::lock_guard<std::mutex> lck(stats_mutex);
+	auto iter = operation_events.find(oper);
+	D_ASSERT(iter != operation_events.end());
+	iter->second.end_timestamp = GetSteadyNowMilliSecSinceEpoch();
+}
+
+void TempProfileCollector::RecordCacheAccess(CacheAccess cache_access) {
+	std::lock_guard<std::mutex> lck(stats_mutex);
+	cache_hit_count += cache_access == CacheAccess::kCacheHit;
+	cache_miss_count += cache_access == CacheAccess::kCacheMiss;
+}
+
+void TempProfileCollector::Reset() {
+	std::lock_guard<std::mutex> lck(stats_mutex);
+	operation_events.clear();
+	cache_hit_count = 0;
+	cache_miss_count = 0;
+}
+
+std::pair<std::string, uint64_t> TempProfileCollector::GetHumanReadableStats() {
+	std::lock_guard<std::mutex> lck(stats_mutex);
+	uint64_t total_time_milli = 0;
+	uint64_t total_io_count = 0;
+	uint64_t latest_timestamp = 0;
+	for (const auto &[_, cur_stat] : operation_events) {
+		// Check operation has finished.
+		D_ASSERT(cur_stat.end_timestamp != 0);
+		total_time_milli += cur_stat.end_timestamp - cur_stat.start_timestamp;
+		++total_io_count;
+		latest_timestamp = MaxValue<uint64_t>(latest_timestamp, cur_stat.end_timestamp);
+	}
+	double avg = static_cast<double>(total_time_milli) / total_io_count;
+	auto stats = StringUtil::Format("for temp profile collector, stats for %s\n"
+	                                "cache hit count = %d\n"
+	                                "cache miss count = %d\n"
+	                                "remote access takes %lf milliseconds in average",
+	                                cache_reader_type, cache_hit_count, cache_miss_count, avg);
+	return std::make_pair(std::move(stats), latest_timestamp);
+}
+
+} // namespace duckdb

--- a/src/utils/include/time_utils.hpp
+++ b/src/utils/include/time_utils.hpp
@@ -1,0 +1,37 @@
+// Time related utils.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace duckdb {
+
+inline constexpr uint64_t kMicrosToNanos = 1000ULL;
+inline constexpr uint64_t kSecondsToMicros = 1000ULL * 1000ULL;
+inline constexpr uint64_t kSecondsToNanos = 1000ULL * 1000ULL * 1000ULL;
+inline constexpr uint64_t kMilliToNanos = 1000ULL * 1000ULL;
+
+// Get current timestamp in steady clock since epoch in nanoseconds.
+inline int64_t GetSteadyNowNanoSecSinceEpoch() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+	    .count();
+}
+
+// Get current timestamp in steady clock since epoch in milliseconds.
+inline int64_t GetSteadyNowMilliSecSinceEpoch() {
+	return GetSteadyNowNanoSecSinceEpoch() / kMilliToNanos;
+}
+
+// Get current timestamp in steady clock since epoch in nanoseconds.
+inline int64_t GetSystemNowNanoSecSinceEpoch() {
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
+	    .count();
+}
+
+// Get current timestamp in steady clock since epoch in milliseconds.
+inline int64_t GetSystemNowMilliSecSinceEpoch() {
+	return GetSystemNowNanoSecSinceEpoch() / kMilliToNanos;
+}
+
+} // namespace duckdb

--- a/unit/test_in_memory_cache_filesystem.cpp
+++ b/unit/test_in_memory_cache_filesystem.cpp
@@ -6,6 +6,7 @@
 #include "cache_filesystem_config.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "in_memory_cache_filesystem.hpp"
 #include "scope_guard.hpp"
@@ -52,6 +53,37 @@ TEST_CASE("Test on in-memory cache filesystem", "[in-memory cache filesystem tes
 		in_mem_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
 		                      start_offset);
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+}
+
+TEST_CASE("Test on concurrent access", "[in-memory cache filesystem test]") {
+	g_cache_block_size = 5;
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+
+	auto in_mem_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	auto handle = in_mem_cache_fs->OpenFile(TEST_FILENAME,
+	                                        FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	const uint64_t start_offset = 0;
+	const uint64_t bytes_to_read = TEST_FILE_SIZE;
+
+	// Spawn multiple threads to read through in-memory cache filesystem.
+	constexpr idx_t THREAD_NUM = 200;
+	vector<thread> reader_threads;
+	reader_threads.reserve(THREAD_NUM);
+	for (idx_t idx = 0; idx < THREAD_NUM; ++idx) {
+		reader_threads.emplace_back([&]() {
+			string content(bytes_to_read, '\0');
+			in_mem_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+			                      start_offset);
+			REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+		});
+	}
+	for (auto &cur_thd : reader_threads) {
+		D_ASSERT(cur_thd.joinable());
+		cur_thd.join();
 	}
 }
 


### PR DESCRIPTION
Example usage:
```
D LOAD read_cache_fs;
D SELECT cache_httpfs_get_latest_profile();
┌─────────────────────────────────────┐
│  cache_httpfs_get_latest_profile()  │
│               varchar               │
├─────────────────────────────────────┤
│ No valid access to cache filesystem │
└─────────────────────────────────────┘
D SET cached_http_profile_type='temp';
D select * from read_csv_auto('https://csvbase.com/meripaterson/stock-exchanges');
<content>
D SELECT cache_httpfs_get_latest_profile();
┌───────────────────────────────────┐
│ cache_httpfs_get_latest_profile() │
│              varchar              │
├───────────────────────────────────┤
│ (noop profile collector)          │
└───────────────────────────────────┘
D COPY (SELECT cache_httpfs_get_profile()) TO '/tmp/output.txt';
-- content in redirected file
cache_httpfs_get_profile()
"for temp profile collector, stats for on_disk_cache_reader
cache hit count = 1
cache miss count = 1
remote access takes 224.000000 milliseconds in average"
```