### PR TITLE
Clear cache for all cached reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,10 @@ include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 
 set(EXTENSION_SOURCES
-    src/base_cache_filesystem.cpp
+    src/cache_filesystem.cpp
     src/cache_filesystem_config.cpp
-    src/disk_cache_filesystem.cpp
-    src/in_memory_cache_filesystem.cpp
+    src/disk_cache_reader.cpp
+    src/in_memory_cache_reader.cpp
     src/noop_cache_reader.cpp
     src/read_cache_fs_extension.cpp
     src/temp_profile_collector.cpp

--- a/benchmark/read_s3_object.cpp
+++ b/benchmark/read_s3_object.cpp
@@ -1,7 +1,7 @@
 // This file serves as a benchmark to read a whole S3 objects; it only tests
 // uncached read.
 
-#include "disk_cache_filesystem.hpp"
+#include "disk_cache_reader.hpp"
 #include "duckdb/storage/standard_buffer_manager.hpp"
 #include "duckdb/main/client_context_file_opener.hpp"
 #include "s3fs.hpp"

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -1,7 +1,7 @@
-#include "base_cache_filesystem.hpp"
+#include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
-#include "disk_cache_filesystem.hpp"
-#include "in_memory_cache_filesystem.hpp"
+#include "disk_cache_reader.hpp"
+#include "in_memory_cache_reader.hpp"
 #include "noop_cache_reader.hpp"
 #include "temp_profile_collector.hpp"
 
@@ -34,6 +34,18 @@ void CacheFileSystem::SetAndGetCacheReader() {
 		}
 		internal_cache_reader = in_mem_cache_reader.get();
 		return;
+	}
+}
+
+void CacheFileSystem::ClearCache() {
+	if (noop_cache_reader != nullptr) {
+		noop_cache_reader->ClearCache();
+	}
+	if (in_mem_cache_reader != nullptr) {
+		in_mem_cache_reader->ClearCache();
+	}
+	if (on_disk_cache_reader != nullptr) {
+		on_disk_cache_reader->ClearCache();
 	}
 }
 

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -1,5 +1,5 @@
 #include "crypto.hpp"
-#include "disk_cache_filesystem.hpp"
+#include "disk_cache_reader.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/thread.hpp"
@@ -234,6 +234,13 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 		D_ASSERT(cur_thd.joinable());
 		cur_thd.join();
 	}
+}
+
+void DiskCacheReader::ClearCache() {
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	local_filesystem->RemoveDirectory(g_on_disk_cache_directory);
+	// Create an empty directory, otherwise later read access errors.
+	local_filesystem->CreateDirectory(g_on_disk_cache_directory);
 }
 
 } // namespace duckdb

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -1,8 +1,8 @@
-#include "in_memory_cache_filesystem.hpp"
 #include "duckdb/common/thread.hpp"
 #include "crypto.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "in_memory_cache_reader.hpp"
 #include "utils/include/resize_uninitialized.hpp"
 #include "utils/include/filesystem_utils.hpp"
 
@@ -140,6 +140,12 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 	for (auto &cur_thd : io_threads) {
 		D_ASSERT(cur_thd.joinable());
 		cur_thd.join();
+	}
+}
+
+void InMemoryCacheReader::ClearCache() {
+	if (cache != nullptr) {
+		cache->Clear();
 	}
 }
 

--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -20,6 +20,9 @@ public:
 	virtual void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
 	                          idx_t requested_bytes_to_read, idx_t file_size) = 0;
 
+	// Clear all cache (in-memory or on-disk).
+	virtual void ClearCache() = 0;
+
 	// Get name for cache reader.
 	virtual std::string GetName() const {
 		throw NotImplementedException("Base cache reader doesn't implement GetName.");

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -37,6 +37,8 @@ public:
 	BaseProfileCollector *GetProfileCollector() const {
 		return profile_collector.get();
 	}
+	// Clear all cached content (whether it's in-memory or on-disk).
+	void ClearCache();
 
 	// For other API calls, delegate to [internal_filesystem] to handle.
 	unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) override {

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -2,12 +2,12 @@
 
 #pragma once
 
+#include "base_cache_reader.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
-#include "base_cache_reader.hpp"
-#include "base_cache_filesystem.hpp"
 
 namespace duckdb {
 
@@ -20,8 +20,8 @@ public:
 		return "on_disk_cache_reader";
 	}
 
-	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache
-	// to local filesystem and return to user.
+	void ClearCache() override;
+
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "base_cache_filesystem.hpp"
 #include "base_cache_reader.hpp"
+#include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -24,8 +24,7 @@ public:
 		return "in_mem_cache_reader";
 	}
 
-	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache
-	// to local filesystem and return to user.
+	void ClearCache() override;
 	void ReadAndCache(FileHandle &handle, char *buffer, uint64_t requested_start_offset,
 	                  uint64_t requested_bytes_to_read, uint64_t file_size) override;
 

--- a/src/include/noop_cache_reader.hpp
+++ b/src/include/noop_cache_reader.hpp
@@ -16,6 +16,8 @@ public:
 	}
 	virtual ~NoopCacheReader() = default;
 
+	void ClearCache() override {
+	}
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 

--- a/src/noop_cache_reader.cpp
+++ b/src/noop_cache_reader.cpp
@@ -1,4 +1,4 @@
-#include "base_cache_filesystem.hpp"
+#include "cache_filesystem.hpp"
 #include "noop_cache_reader.hpp"
 
 namespace duckdb {

--- a/src/read_cache_fs_extension.cpp
+++ b/src/read_cache_fs_extension.cpp
@@ -5,8 +5,8 @@
 #include "hffs.hpp"
 #include "crypto.hpp"
 #include "duckdb/main/extension_util.hpp"
+#include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
-#include "base_cache_filesystem.hpp"
 #include "duckdb/common/local_file_system.hpp"
 
 #include <array>
@@ -18,11 +18,9 @@ namespace duckdb {
 static vector<CacheFileSystem *> cache_file_systems;
 
 static void ClearOnDiskCache(const DataChunk &args, ExpressionState &state, Vector &result) {
-	auto local_filesystem = LocalFileSystem::CreateLocal();
-	local_filesystem->RemoveDirectory(g_on_disk_cache_directory);
-	// Create an empty directory, otherwise later read access errors.
-	local_filesystem->CreateDirectory(g_on_disk_cache_directory);
-
+	for (auto *cur_filesystem : cache_file_systems) {
+		cur_filesystem->ClearCache();
+	}
 	constexpr int32_t SUCCESS = 1;
 	result.Reference(Value(SUCCESS));
 }

--- a/unit/test_base_cache_filesystem.cpp
+++ b/unit/test_base_cache_filesystem.cpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "disk_cache_filesystem.hpp"
+#include "disk_cache_reader.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "hffs.hpp"
 

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -12,7 +12,7 @@
 #include "catch.hpp"
 
 #include "cache_filesystem_config.hpp"
-#include "disk_cache_filesystem.hpp"
+#include "disk_cache_reader.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/thread.hpp"

--- a/unit/test_in_memory_cache_filesystem.cpp
+++ b/unit/test_in_memory_cache_filesystem.cpp
@@ -8,7 +8,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/uuid.hpp"
-#include "in_memory_cache_filesystem.hpp"
+#include "in_memory_cache_reader.hpp"
 #include "scope_guard.hpp"
 
 using namespace duckdb; // NOLINT

--- a/unit/test_noop_cache_reader.cpp
+++ b/unit/test_noop_cache_reader.cpp
@@ -3,13 +3,13 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
+#include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "noop_cache_reader.hpp"
-#include "base_cache_filesystem.hpp"
 #include "scope_guard.hpp"
 
 using namespace duckdb; // NOLINT

--- a/unit/test_set_extension_config.cpp
+++ b/unit/test_set_extension_config.cpp
@@ -4,14 +4,14 @@
 #include "catch.hpp"
 
 #include "cache_filesystem_config.hpp"
-#include "disk_cache_filesystem.hpp"
+#include "disk_cache_reader.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/connection.hpp"
 #include "filesystem_utils.hpp"
-#include "in_memory_cache_filesystem.hpp"
+#include "in_memory_cache_reader.hpp"
 
 using namespace duckdb; // NOLINT
 


### PR DESCRIPTION
This PR does two things:
- Expose duckdb functions to clear cache for all cache readers;
- Rename cache filesystem into cache readers.