### PR TITLE
Load httpfs extension inside of cache extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,3 @@ SELECT cache_httpfs_get_cache_size();
 -- Clear all local cache files.
 SELECT cache_httpfs_clear_cache();
 ```
-
-## TODO items
-- [ ] Clear specification on compilation/link options, for example, C++ version, warning and error options.
-- [ ] Provide options to configure parameters, for example, block size, total memory consumption for in-memory cache, etc.
-- [ ] Provide an option to profile read cache filesystem and store them in an in-memory duckdb table for later diagnose; key metrics include single IO request latency, request latency distribution, etc.

--- a/src/include/read_cache_fs_extension.hpp
+++ b/src/include/read_cache_fs_extension.hpp
@@ -11,6 +11,9 @@ public:
 	void Load(DuckDB &db) override;
 	std::string Name() override;
 	std::string Version() const override;
+
+private:
+	unique_ptr<Extension> httpfs_extension;
 };
 
 } // namespace duckdb


### PR DESCRIPTION
As titled, this PR loads httpfs internally before we load cached version, which include all necessary type/function/... to access remote resource, so users only need to load one single extension.
