### PR TITLE
Add a util of historgram to display purpose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(EXTENSION_SOURCES
     src/read_cache_fs_extension.cpp
     src/temp_profile_collector.cpp
     src/utils/filesystem_utils.cpp
+    src/utils/histogram.cpp
     src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp
     duckdb-httpfs/extension/httpfs/crypto.cpp
@@ -60,6 +61,9 @@ target_link_libraries(test_in_memory_cache_filesystem ${EXTENSION_NAME})
 
 add_executable(test_stale_deletion unit/test_stale_deletion.cpp)
 target_link_libraries(test_stale_deletion ${EXTENSION_NAME})
+
+add_executable(test_histogram unit/test_histogram.cpp)
+target_link_libraries(test_histogram ${EXTENSION_NAME})
 
 add_executable(test_shared_lru_cache unit/test_shared_lru_cache.cpp)
 target_link_libraries(test_shared_lru_cache ${EXTENSION_NAME})

--- a/src/read_cache_fs_extension.cpp
+++ b/src/read_cache_fs_extension.cpp
@@ -151,6 +151,7 @@ static void LoadInternal(DatabaseInstance &instance) {
 	ExtensionUtil::RegisterFunction(instance, get_cache_size_function);
 
 	// Register profile collector metrics.
+	// A commonly-used SQL is `COPY (SELECT cache_httpfs_get_profile()) TO '/tmp/output.txt';`.
 	ScalarFunction get_profile_stats_function("cache_httpfs_get_profile", /*arguments=*/ {},
 	                                          /*return_type=*/LogicalType::VARCHAR, GetProfileStats);
 	ExtensionUtil::RegisterFunction(instance, get_profile_stats_function);

--- a/src/utils/histogram.cpp
+++ b/src/utils/histogram.cpp
@@ -1,0 +1,71 @@
+#include "histogram.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/string_util.hpp"
+
+namespace duckdb {
+
+Histogram::Histogram(double min_val, double max_val, int num_bkt) : min_val_(min_val), max_val_(max_val) {
+	D_ASSERT(min_val_ < max_val_);
+	D_ASSERT(num_bkt > 0);
+	hist_.resize(num_bkt);
+
+	min_encountered_ = max_val_;
+	max_encountered_ = min_val_;
+}
+
+size_t Histogram::Bucket(double val) const {
+	D_ASSERT(val >= min_val_);
+	D_ASSERT(val <= max_val_);
+
+	if (val == max_val_) {
+		return hist_.size() - 1;
+	}
+	const double idx = (val - min_val_) / (max_val_ - min_val_);
+	return static_cast<size_t>(std::floor(idx * hist_.size()));
+}
+
+void Histogram::Add(double val) {
+	if (val < min_val_ || val > max_val_) {
+		outliers_.emplace_back(val);
+		return;
+	}
+	++hist_[Bucket(val)];
+	min_encountered_ = std::min(min_encountered_, val);
+	max_encountered_ = std::max(max_encountered_, val);
+	++total_counts_;
+	sum_ += val;
+}
+
+double Histogram::mean() const {
+	if (total_counts_ == 0) {
+		return 0.0;
+	}
+	return sum_ / total_counts_;
+}
+
+// TODO(hjiang): Add buckets into formatted string.
+std::string Histogram::FormatString() const {
+	std::string res;
+
+	// Format outliers.
+	if (!outliers_.empty()) {
+		auto double_to_string = [](double v) -> string {
+			return StringUtil::Format("%lf", v);
+		};
+		res =
+		    StringUtil::Format("Outliers: %s\n", StringUtil::Join(outliers_, outliers_.size(), ", ", double_to_string));
+	}
+
+	// Format aggregated stats.
+	res += StringUtil::Format("Max = %lf\n", max());
+	res += StringUtil::Format("Min = %lf\n", min());
+	res += StringUtil::Format("Mean = %lf\n", mean());
+
+	return res;
+}
+
+} // namespace duckdb

--- a/src/utils/include/histogram.hpp
+++ b/src/utils/include/histogram.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// Historgram supports two types of records
+// - For values within the given range, all the stats functions (i.e. min and max) only considers in-range values;
+// - For values out of range, we provide extra functions to retrieve.
+//
+// The reason why outliers are not considered as statistic is they disturb statistical value a lot.
+class Histogram {
+public:
+	Histogram(double min_val, double max_val, int num_bkt);
+
+	// Add [val] into the histogram.
+	// Return whether [val] is valid.
+	void Add(double val);
+
+	// Get bucket index for the given [val].
+	size_t Bucket(double val) const;
+
+	// Stats data.
+	size_t counts() const {
+		return total_counts_;
+	}
+	double sum() const {
+		return sum_;
+	}
+	double mean() const;
+	// Precondition: there's at least one value inserted.
+	double min() const {
+		return min_encountered_;
+	}
+	double max() const {
+		return max_encountered_;
+	}
+
+	// Get outliers for stat records.
+	const std::vector<double> outliers() const {
+		return outliers_;
+	}
+
+	// Display histogram into string format.
+	std::string FormatString() const;
+
+private:
+	const double min_val_;
+	const double max_val_;
+	// Max and min value encountered.
+	double min_encountered_;
+	double max_encountered_;
+	// Total number of values.
+	size_t total_counts_ = 0;
+	// Accumulated sum.
+	double sum_ = 0.0;
+	// List of bucket counts.
+	std::vector<size_t> hist_;
+	// List of outliers.
+	std::vector<double> outliers_;
+};
+
+} // namespace duckdb

--- a/unit/test_histogram.cpp
+++ b/unit/test_histogram.cpp
@@ -1,0 +1,23 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "histogram.hpp"
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("Histogram test", "[histogram test]") {
+	Histogram hist {/*min_val=*/0, /*max_val=*/10, /*num_bkt=*/10};
+	hist.Add(1);
+	hist.Add(3);
+	hist.Add(-3);
+	REQUIRE(hist.outliers() == std::vector<double> {-3});
+	REQUIRE(hist.min() == 1);
+	REQUIRE(hist.max() == 3);
+	REQUIRE(hist.counts() == 2);
+	REQUIRE(hist.mean() == 2);
+}
+
+int main(int argc, char **argv) {
+	int result = Catch::Session().run(argc, argv);
+	return result;
+}


### PR DESCRIPTION
Later on, I will integrate it with `cache_httpfs_get_profile` function to provide more cache access information.