### PR TITLE
Integrate histogram into profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
-include_directories(src/include)
 include_directories(src/utils/include)
+include_directories(src/include)
 include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 
@@ -19,11 +19,11 @@ set(EXTENSION_SOURCES
     src/cache_filesystem_config.cpp
     src/disk_cache_reader.cpp
     src/in_memory_cache_reader.cpp
+    src/histogram.cpp
     src/noop_cache_reader.cpp
     src/read_cache_fs_extension.cpp
     src/temp_profile_collector.cpp
     src/utils/filesystem_utils.cpp
-    src/utils/histogram.cpp
     src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp
     duckdb-httpfs/extension/httpfs/crypto.cpp

--- a/src/histogram.cpp
+++ b/src/histogram.cpp
@@ -8,13 +8,20 @@
 
 namespace duckdb {
 
-Histogram::Histogram(double min_val, double max_val, int num_bkt) : min_val_(min_val), max_val_(max_val) {
+Histogram::Histogram(double min_val, double max_val, int num_bkt)
+    : min_val_(min_val), max_val_(max_val), num_bkt_(num_bkt) {
 	D_ASSERT(min_val_ < max_val_);
 	D_ASSERT(num_bkt > 0);
-	hist_.resize(num_bkt);
+	Reset();
+}
 
+void Histogram::Reset() {
 	min_encountered_ = max_val_;
 	max_encountered_ = min_val_;
+	total_counts_ = 0;
+	sum_ = 0;
+	hist_ = std::vector<size_t>(num_bkt_, 0);
+	outliers_.clear();
 }
 
 size_t Histogram::Bucket(double val) const {

--- a/src/include/histogram.hpp
+++ b/src/include/histogram.hpp
@@ -46,9 +46,13 @@ public:
 	// Display histogram into string format.
 	std::string FormatString() const;
 
+	// Reset histogram.
+	void Reset();
+
 private:
 	const double min_val_;
 	const double max_val_;
+	const int num_bkt_;
 	// Max and min value encountered.
 	double min_encountered_;
 	double max_encountered_;

--- a/src/include/temp_profile_collector.hpp
+++ b/src/include/temp_profile_collector.hpp
@@ -4,6 +4,7 @@
 
 #include "base_profile_collector.hpp"
 #include "duckdb/common/profiler.hpp"
+#include "histogram.hpp"
 
 #include <mutex>
 
@@ -11,7 +12,7 @@ namespace duckdb {
 
 class TempProfileCollector final : public BaseProfileCollector {
 public:
-	TempProfileCollector() = default;
+	TempProfileCollector();
 	~TempProfileCollector() override = default;
 
 	void RecordOperationStart(const std::string &oper) override;
@@ -27,14 +28,17 @@ private:
 	struct OperationStats {
 		// Accounted as time elapsed since unix epoch in milliseconds.
 		int64_t start_timestamp = 0;
-		int64_t end_timestamp = 0;
 	};
 
-	// Maps from operation name to its stats.
+	// Maps from operation name to its stats, only records ongoing operations.
 	unordered_map<string, OperationStats> operation_events;
+	// Only records finished operations.
+	Histogram histogram;
 	// Aggregated cache access condition.
 	uint64_t cache_hit_count = 0;
 	uint64_t cache_miss_count = 0;
+	// Latest access timestamp in milliseconds since unix epoch.
+	uint64_t latest_timestamp = 0;
 
 	std::mutex stats_mutex;
 };

--- a/unit/test_histogram.cpp
+++ b/unit/test_histogram.cpp
@@ -15,6 +15,15 @@ TEST_CASE("Histogram test", "[histogram test]") {
 	REQUIRE(hist.max() == 3);
 	REQUIRE(hist.counts() == 2);
 	REQUIRE(hist.mean() == 2);
+
+	// Reset and check again.
+	hist.Reset();
+	hist.Add(1);
+	REQUIRE(hist.outliers().empty());
+	REQUIRE(hist.min() == 1);
+	REQUIRE(hist.max() == 1);
+	REQUIRE(hist.counts() == 1);
+	REQUIRE(hist.mean() == 1);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Example SQL:
```
COPY (SELECT cache_httpfs_get_profile()) TO '/tmp/output.txt';
```

Example result:
```
For temp profile collector and stats for on_disk_cache_reader (unit in milliseconds)
cache hit count = 2
cache miss count = 1
IO latency is Max = 88.000000
Min = 88.000000
Mean = 88.000000
```