### PR TITLE
Record file metadata cache access

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -191,7 +191,8 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 			// TODO(hjiang): Add documentation and implementation for stale cache eviction policy, before that it's safe
 			// to access cache file directly.
 			if (local_filesystem->FileExists(local_cache_file)) {
-				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheAccess::kCacheHit);
+				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
+				                                     BaseProfileCollector::CacheAccess::kCacheHit);
 				auto file_handle = local_filesystem->OpenFile(local_cache_file, FileOpenFlags::FILE_FLAGS_READ);
 				void *addr = !cache_read_chunk.content.empty() ? const_cast<char *>(cache_read_chunk.content.data())
 				                                               : cache_read_chunk.requested_start_addr;
@@ -211,7 +212,8 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 			}
 
 			// We suffer a cache loss, fallback to remote access then local filesystem write.
-			profile_collector->RecordCacheAccess(BaseProfileCollector::CacheAccess::kCacheMiss);
+			profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
+			                                     BaseProfileCollector::CacheAccess::kCacheMiss);
 			if (cache_read_chunk.content.empty()) {
 				cache_read_chunk.content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
 			}

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -114,13 +114,15 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 			auto cache_block = cache->Get(block_key);
 
 			if (cache_block != nullptr) {
-				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheAccess::kCacheHit);
+				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
+				                                     BaseProfileCollector::CacheAccess::kCacheHit);
 				cache_read_chunk.CopyBufferToRequestedMemory(*cache_block);
 				return;
 			}
 
 			// We suffer a cache loss, fallback to remote access then local filesystem write.
-			profile_collector->RecordCacheAccess(BaseProfileCollector::CacheAccess::kCacheMiss);
+			profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
+			                                     BaseProfileCollector::CacheAccess::kCacheMiss);
 			auto content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
 			auto &in_mem_cache_handle = handle.Cast<CacheFileSystemHandle>();
 

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -13,6 +13,10 @@ namespace duckdb {
 // filesystem in the extension), profiler collector is used as a data member for cache filesystem.
 class BaseProfileCollector {
 public:
+	enum class CacheEntity {
+		kMetadata, // File metadata.
+		kData,     // File data block.
+	};
 	enum class CacheAccess {
 		kCacheHit,
 		kCacheMiss,
@@ -26,7 +30,7 @@ public:
 	// Record the finish of operation [oper].
 	virtual void RecordOperationEnd(const std::string &oper) = 0;
 	// Record cache access condition.
-	virtual void RecordCacheAccess(CacheAccess cache_access) = 0;
+	virtual void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) = 0;
 	// Get profiler type.
 	virtual std::string GetProfilerType() = 0;
 	// Set cache reader type.
@@ -51,7 +55,7 @@ public:
 	}
 	void RecordOperationEnd(const std::string &oper) override {
 	}
-	void RecordCacheAccess(CacheAccess cache_access) override {
+	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) override {
 	}
 	std::string GetProfilerType() override {
 		return NOOP_PROFILE_TYPE;

--- a/src/include/temp_profile_collector.hpp
+++ b/src/include/temp_profile_collector.hpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/profiler.hpp"
 #include "histogram.hpp"
 
+#include <array>
 #include <mutex>
 
 namespace duckdb {
@@ -17,7 +18,7 @@ public:
 
 	void RecordOperationStart(const std::string &oper) override;
 	void RecordOperationEnd(const std::string &oper) override;
-	void RecordCacheAccess(CacheAccess cache_access) override;
+	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) override;
 	std::string GetProfilerType() override {
 		return TEMP_PROFILE_TYPE;
 	}
@@ -35,8 +36,7 @@ private:
 	// Only records finished operations.
 	Histogram histogram;
 	// Aggregated cache access condition.
-	uint64_t cache_hit_count = 0;
-	uint64_t cache_miss_count = 0;
+	std::array<uint64_t, 4> cache_access_count {};
 	// Latest access timestamp in milliseconds since unix epoch.
 	uint64_t latest_timestamp = 0;
 


### PR DESCRIPTION
This PR adds a new cache access category for metadata access.

Example output:
```
For temp profile collector and stats for in_mem_cache_reader (unit in milliseconds)
metadata cache hit count = 15
metadata cache miss count = 1
data block cache hit count = 5
data block cache miss count = 1
IO latency is Max = 89.000000
Min = 89.000000
Mean = 89.000000
```