### PR TITLE
Clear cache entries for the single file

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -37,6 +37,18 @@ void CacheFileSystem::SetAndGetCacheReader() {
 	}
 }
 
+void CacheFileSystem::ClearCache(const string &fname) {
+	if (noop_cache_reader != nullptr) {
+		noop_cache_reader->ClearCache(fname);
+	}
+	if (in_mem_cache_reader != nullptr) {
+		in_mem_cache_reader->ClearCache(fname);
+	}
+	if (on_disk_cache_reader != nullptr) {
+		on_disk_cache_reader->ClearCache(fname);
+	}
+}
+
 void CacheFileSystem::ClearCache() {
 	if (noop_cache_reader != nullptr) {
 		noop_cache_reader->ClearCache();

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -151,4 +151,10 @@ void InMemoryCacheReader::ClearCache() {
 	}
 }
 
+void InMemoryCacheReader::ClearCache(const string &fname) {
+	if (cache != nullptr) {
+		cache->Clear([&fname](const InMemCacheBlock &block) { return block.fname == fname; });
+	}
+}
+
 } // namespace duckdb

--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -20,8 +20,11 @@ public:
 	virtual void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
 	                          idx_t requested_bytes_to_read, idx_t file_size) = 0;
 
-	// Clear all cache (in-memory or on-disk).
+	// Clear all cache.
 	virtual void ClearCache() = 0;
+
+	// Clear cache for the given [fname].
+	virtual void ClearCache(const string &fname) = 0;
 
 	// Get name for cache reader.
 	virtual std::string GetName() const {

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -38,6 +38,8 @@ public:
 	BaseProfileCollector *GetProfileCollector() const {
 		return profile_collector.get();
 	}
+	// Clear cached content for the given filename (whether it's in-memory or on-disk).
+	void ClearCache(const string &fname);
 	// Clear all cached content (whether it's in-memory or on-disk).
 	void ClearCache();
 	// Get file size, which gets cached in-memory.

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -21,6 +21,7 @@ public:
 	}
 
 	void ClearCache() override;
+	void ClearCache(const string &fname) override;
 
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -25,6 +25,7 @@ public:
 	}
 
 	void ClearCache() override;
+	void ClearCache(const string &fname) override;
 	void ReadAndCache(FileHandle &handle, char *buffer, uint64_t requested_start_offset,
 	                  uint64_t requested_bytes_to_read, uint64_t file_size) override;
 

--- a/src/include/noop_cache_reader.hpp
+++ b/src/include/noop_cache_reader.hpp
@@ -18,6 +18,8 @@ public:
 
 	void ClearCache() override {
 	}
+	void ClearCache(const string &fname) override {
+	}
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 

--- a/unit/test_shared_lru_cache.cpp
+++ b/unit/test_shared_lru_cache.cpp
@@ -71,6 +71,25 @@ TEST_CASE("CustomizedStruct", "[shared lru test]") {
 	REQUIRE(*val == "world");
 }
 
+TEST_CASE("Clear with filter test", "[shared lru test]") {
+	ThreadSafeSharedLruCache<std::string, std::string> cache {3};
+	cache.Put("key1", make_shared_ptr<std::string>("val1"));
+	cache.Put("key2", make_shared_ptr<std::string>("val2"));
+	cache.Put("key3", make_shared_ptr<std::string>("val3"));
+	cache.Clear([](const std::string &key) { return key >= "key2"; });
+
+	// Still valid keys.
+	auto val = cache.Get("key1");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "val1");
+
+	// Non-existent keys.
+	val = cache.Get("key2");
+	REQUIRE(val == nullptr);
+	val = cache.Get("key3");
+	REQUIRE(val == nullptr);
+}
+
 TEST_CASE("GetOrCreate test", "[shared lru test]") {
 	using CacheType = ThreadSafeSharedLruCache<std::string, std::string>;
 


### PR DESCRIPTION
As titled, we're now able to clear in-memory cache entry and on-disk files for the given filename.