### PR TITLE
Ignore SIGPIPE in benchmark

### DIFF
--- a/benchmark/read_s3_object.cpp
+++ b/benchmark/read_s3_object.cpp
@@ -8,6 +8,7 @@
 #include "scope_guard.hpp"
 
 #include <array>
+#include <csignal>
 #include <iostream>
 
 namespace duckdb {
@@ -103,6 +104,9 @@ void ReadUncachedWholeFile(uint64_t block_size) {
 } // namespace duckdb
 
 int main(int argc, char **argv) {
+	// Ignore SIGPIPE, reference: https://blog.erratasec.com/2018/10/tcpip-sockets-and-sigpipe.html
+	std::signal(SIGPIPE, SIG_IGN);
+
 	constexpr std::array<uint64_t, 10> BLOCK_SIZE_ARR {
 	    64ULL * 1024,        // 64KiB
 	    256ULL * 1024,       // 256KiB


### PR DESCRIPTION
See inline reference for details. In addition, signals should be handled in main program rather than library.