### PR TITLE
Add distributuion format string for histogram

### DIFF
--- a/src/include/histogram.hpp
+++ b/src/include/histogram.hpp
@@ -13,7 +13,11 @@ namespace duckdb {
 // The reason why outliers are not considered as statistic is they disturb statistical value a lot.
 class Histogram {
 public:
+	// [min_val] is inclusive, and [max_val] is exclusive.
 	Histogram(double min_val, double max_val, int num_bkt);
+
+	// Set the distribution stats name and unit, used for formatting purpose.
+	void SetStatsDistribution(std::string name, std::string unit);
 
 	// Add [val] into the histogram.
 	// Return whether [val] is valid.
@@ -64,6 +68,9 @@ private:
 	std::vector<size_t> hist_;
 	// List of outliers.
 	std::vector<double> outliers_;
+	// Item name and unit for stats distribution.
+	std::string distribution_name_;
+	std::string distribution_unit_;
 };
 
 } // namespace duckdb

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -5,12 +5,16 @@ namespace duckdb {
 
 namespace {
 // Heuristic estimation of single IO request latency, out of which range are classified as outliers.
-constexpr double kMinLatencyMillisec = 0;
-constexpr double kMaxLatencyMillisec = 1000;
-constexpr int kLatencyNumBkt = 200;
+constexpr double MIN_LATENCY_MILLISEC = 0;
+constexpr double MAX_LATENCY_MILLISEC = 1000;
+constexpr int LATENCY_NUM_BKT = 200;
+
+const string LATENCY_HISTOGRAM_ITEM = "latency";
+const string LATENCY_HISTOGRAM_UNIT = "millisec";
 } // namespace
 
-TempProfileCollector::TempProfileCollector() : histogram(kMinLatencyMillisec, kMaxLatencyMillisec, kLatencyNumBkt) {
+TempProfileCollector::TempProfileCollector() : histogram(MIN_LATENCY_MILLISEC, MAX_LATENCY_MILLISEC, LATENCY_NUM_BKT) {
+	histogram.SetStatsDistribution(LATENCY_HISTOGRAM_ITEM, LATENCY_HISTOGRAM_UNIT);
 }
 
 void TempProfileCollector::RecordOperationStart(const std::string &oper) {


### PR DESCRIPTION
Example output:
```
For temp profile collector and stats for in_mem_cache_reader (unit in milliseconds)
metadata cache hit count = 15
metadata cache miss count = 1
data block cache hit count = 5
data block cache miss count = 1
IO latency is Max = 92.000000
Min = 92.000000
Mean = 92.000000
Distribution latency [90.000000, 95.000000) millisec: 100.000000 %
```