### PR TITLE
Fix duplicate operation id

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -230,12 +230,12 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 				cache_read_chunk.content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
 			}
 			auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-			const string cur_oper = StringUtil::Format("%d", cache_read_chunk.aligned_start_offset);
-			profile_collector->RecordOperationStart(cur_oper);
+			const string oper_id = profile_collector->GetOperId();
+			profile_collector->RecordOperationStart(oper_id);
 			internal_filesystem->Read(*disk_cache_handle.internal_file_handle,
 			                          const_cast<char *>(cache_read_chunk.content.data()),
 			                          cache_read_chunk.content.length(), cache_read_chunk.aligned_start_offset);
-			profile_collector->RecordOperationEnd(cur_oper);
+			profile_collector->RecordOperationEnd(oper_id);
 
 			// Copy to destination buffer.
 			cache_read_chunk.CopyBufferToRequestedMemory();

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -131,11 +131,11 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 			auto content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
 			auto &in_mem_cache_handle = handle.Cast<CacheFileSystemHandle>();
 
-			const string cur_oper = StringUtil::Format("%d", cache_read_chunk.aligned_start_offset);
-			profile_collector->RecordOperationStart(cur_oper);
+			const string oper_id = profile_collector->GetOperId();
+			profile_collector->RecordOperationStart(oper_id);
 			internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle, const_cast<char *>(content.data()),
 			                          content.length(), cache_read_chunk.aligned_start_offset);
-			profile_collector->RecordOperationEnd(cur_oper);
+			profile_collector->RecordOperationEnd(oper_id);
 
 			// Copy to destination buffer.
 			cache_read_chunk.CopyBufferToRequestedMemory(content);

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -25,6 +25,8 @@ public:
 	BaseProfileCollector() = default;
 	virtual ~BaseProfileCollector() = default;
 
+	// Get an ID which uniquely identifies current operation.
+	virtual std::string GetOperId() const = 0;
 	// Record the start of operation [oper].
 	virtual void RecordOperationStart(const std::string &oper) = 0;
 	// Record the finish of operation [oper].
@@ -51,6 +53,9 @@ public:
 	NoopProfileCollector() = default;
 	~NoopProfileCollector() override = default;
 
+	std::string GetOperId() const override {
+		return "";
+	}
 	void RecordOperationStart(const std::string &oper) override {
 	}
 	void RecordOperationEnd(const std::string &oper) override {

--- a/src/include/temp_profile_collector.hpp
+++ b/src/include/temp_profile_collector.hpp
@@ -16,6 +16,7 @@ public:
 	TempProfileCollector();
 	~TempProfileCollector() override = default;
 
+	std::string GetOperId() const override;
 	void RecordOperationStart(const std::string &oper) override;
 	void RecordOperationEnd(const std::string &oper) override;
 	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) override;

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/types/uuid.hpp"
 #include "temp_profile_collector.hpp"
 #include "utils/include/time_utils.hpp"
 
@@ -15,6 +16,10 @@ const string LATENCY_HISTOGRAM_UNIT = "millisec";
 
 TempProfileCollector::TempProfileCollector() : histogram(MIN_LATENCY_MILLISEC, MAX_LATENCY_MILLISEC, LATENCY_NUM_BKT) {
 	histogram.SetStatsDistribution(LATENCY_HISTOGRAM_ITEM, LATENCY_HISTOGRAM_UNIT);
+}
+
+std::string TempProfileCollector::GetOperId() const {
+	return UUID::ToString(UUID::GenerateRandomUUID());
 }
 
 void TempProfileCollector::RecordOperationStart(const std::string &oper) {


### PR DESCRIPTION
It's possible that a filesystem goes through requests with the same starting offset, so should use a unique ID to differentiate.