### PR TITLE
Add random access benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,43 +50,46 @@ install(
 # Test cases.
 include_directories(duckdb/third_party/catch)
 
-add_executable(test_noop_cache_reader unit/test_noop_cache_reader.cpp)
-target_link_libraries(test_noop_cache_reader ${EXTENSION_NAME})
+# add_executable(test_noop_cache_reader unit/test_noop_cache_reader.cpp)
+# target_link_libraries(test_noop_cache_reader ${EXTENSION_NAME})
 
-add_executable(test_disk_cache_filesystem unit/test_disk_cache_filesystem.cpp)
-target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})
+# add_executable(test_disk_cache_filesystem unit/test_disk_cache_filesystem.cpp)
+# target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})
 
-add_executable(test_in_memory_cache_filesystem
-               unit/test_in_memory_cache_filesystem.cpp)
-target_link_libraries(test_in_memory_cache_filesystem ${EXTENSION_NAME})
+# add_executable(test_in_memory_cache_filesystem
+# unit/test_in_memory_cache_filesystem.cpp)
+# target_link_libraries(test_in_memory_cache_filesystem ${EXTENSION_NAME})
 
-add_executable(test_stale_deletion unit/test_stale_deletion.cpp)
-target_link_libraries(test_stale_deletion ${EXTENSION_NAME})
+# add_executable(test_stale_deletion unit/test_stale_deletion.cpp)
+# target_link_libraries(test_stale_deletion ${EXTENSION_NAME})
 
-add_executable(test_histogram unit/test_histogram.cpp)
-target_link_libraries(test_histogram ${EXTENSION_NAME})
+# add_executable(test_histogram unit/test_histogram.cpp)
+# target_link_libraries(test_histogram ${EXTENSION_NAME})
 
-add_executable(test_thread_pool unit/test_thread_pool.cpp)
-target_link_libraries(test_thread_pool ${EXTENSION_NAME})
+# add_executable(test_thread_pool unit/test_thread_pool.cpp)
+# target_link_libraries(test_thread_pool ${EXTENSION_NAME})
 
-add_executable(test_shared_lru_cache unit/test_shared_lru_cache.cpp)
-target_link_libraries(test_shared_lru_cache ${EXTENSION_NAME})
+# add_executable(test_shared_lru_cache unit/test_shared_lru_cache.cpp)
+# target_link_libraries(test_shared_lru_cache ${EXTENSION_NAME})
 
-add_executable(test_size_literals unit/test_size_literals.cpp)
-target_link_libraries(test_size_literals ${EXTENSION_NAME})
+# add_executable(test_size_literals unit/test_size_literals.cpp)
+# target_link_libraries(test_size_literals ${EXTENSION_NAME})
 
-add_executable(test_filesystem_config unit/test_filesystem_config.cpp)
-target_link_libraries(test_filesystem_config ${EXTENSION_NAME})
+# add_executable(test_filesystem_config unit/test_filesystem_config.cpp)
+# target_link_libraries(test_filesystem_config ${EXTENSION_NAME})
 
-add_executable(test_set_extension_config unit/test_set_extension_config.cpp)
-target_link_libraries(test_set_extension_config ${EXTENSION_NAME})
+# add_executable(test_set_extension_config unit/test_set_extension_config.cpp)
+# target_link_libraries(test_set_extension_config ${EXTENSION_NAME})
 
-add_executable(test_base_cache_filesystem unit/test_base_cache_filesystem)
-target_link_libraries(test_base_cache_filesystem ${EXTENSION_NAME})
+# add_executable(test_base_cache_filesystem unit/test_base_cache_filesystem)
+# target_link_libraries(test_base_cache_filesystem ${EXTENSION_NAME})
 
-# Benchmark
-add_executable(read_s3_object benchmark/read_s3_object.cpp)
-target_link_libraries(read_s3_object ${EXTENSION_NAME})
+# # Benchmark add_executable(read_s3_object benchmark/read_s3_object.cpp)
+# target_link_libraries(read_s3_object ${EXTENSION_NAME})
 
-add_executable(sequential_read_benchmark benchmark/sequential_read_benchmark.cpp)
-target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
+# add_executable(sequential_read_benchmark
+# benchmark/sequential_read_benchmark.cpp)
+# target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
+
+add_executable(random_read_benchmark benchmark/random_read_benchmark.cpp)
+target_link_libraries(random_read_benchmark ${EXTENSION_NAME})

--- a/benchmark/rand_utils.hpp
+++ b/benchmark/rand_utils.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <random>
+
+namespace duckdb {
+
+// Generate a random value base on [min, max) range using in uniform distribution feature.
+template <typename T>
+T GetRandomValueInRange(T min, T max) {
+	thread_local std::random_device rand_dev;
+	std::mt19937 rand_engine(rand_dev());
+	std::uniform_real_distribution<double> unif(min, max);
+	return unif(rand_engine);
+}
+
+} // namespace duckdb

--- a/benchmark/random_read_benchmark.cpp
+++ b/benchmark/random_read_benchmark.cpp
@@ -1,0 +1,116 @@
+#include "disk_cache_reader.hpp"
+#include "duckdb/storage/standard_buffer_manager.hpp"
+#include "duckdb/main/client_context_file_opener.hpp"
+#include "rand_utils.hpp"
+#include "s3fs.hpp"
+#include "scope_guard.hpp"
+#include "time_utils.hpp"
+
+#include <csignal>
+#include <array>
+#include <iostream>
+
+namespace {
+const std::string BENCHMARK_DISK_CACHE_DIRECTORY = "/tmp/benchmark_cache";
+constexpr uint64_t BYTES_TO_READ = 10;
+constexpr uint64_t BENCHMARK_RUNS = 25;
+} // namespace
+
+namespace duckdb {
+
+namespace {
+
+struct BenchmarkSetup {
+	std::string cache_type;
+	std::string profile_type;
+	std::string disk_cache_directory;
+	uint64_t block_size = DEFAULT_CACHE_BLOCK_SIZE;
+};
+
+void SetConfig(case_insensitive_map_t<Value> &setting, char *env_key, char *secret_key) {
+	const char *env_val = getenv(env_key);
+	if (env_val == nullptr) {
+		return;
+	}
+	setting[secret_key] = Value(env_val);
+}
+
+void SetOpenerConfig(shared_ptr<ClientContext> ctx, const BenchmarkSetup &benchmark_setup) {
+	auto &set_vars = ctx->config.set_variables;
+	SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
+	SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
+	SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
+	set_vars["cached_http_profile_type"] = Value(benchmark_setup.profile_type);
+	set_vars["cached_http_type"] = Value(benchmark_setup.cache_type);
+	set_vars["cached_http_cache_directory"] = Value(benchmark_setup.disk_cache_directory);
+	set_vars["cached_http_cache_block_size"] = Value::UBIGINT(benchmark_setup.block_size);
+}
+
+void TestSequentialRead(const BenchmarkSetup &benchmark_setup) {
+	DuckDB db {};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
+	auto cache_fs = make_uniq<CacheFileSystem>(std::move(s3fs));
+	auto client_context = make_shared_ptr<ClientContext>(db.instance);
+
+	SetOpenerConfig(client_context, benchmark_setup);
+	ClientContextFileOpener file_opener {*client_context};
+	client_context->transaction.BeginTransaction();
+
+	auto file_handle =
+	    cache_fs->OpenFile("s3://duckdb-cache-fs/lineitem.parquet", FileOpenFlags::FILE_FLAGS_READ, &file_opener);
+	const uint64_t file_size = cache_fs->GetFileSize(*file_handle);
+	std::string buffer(BYTES_TO_READ, '\0');
+
+	const auto start = GetSteadyNowMilliSecSinceEpoch();
+
+	for (uint16_t ii = 0; ii < BENCHMARK_RUNS; ++ii) {
+		const uint64_t start_offset = GetRandomValueInRange<uint64_t>(0, file_size);
+		const uint64_t cur_bytes_to_read = MinValue<uint64_t>(BYTES_TO_READ, file_size - start_offset);
+		cache_fs->Read(*file_handle, const_cast<char *>(buffer.data()), /*nr_bytes=*/cur_bytes_to_read,
+		               /*location=*/start_offset);
+	}
+
+	const auto end = GetSteadyNowMilliSecSinceEpoch();
+	const auto duration_millisec = end - start;
+	std::cout << BENCHMARK_RUNS << " runs of random read of " << BYTES_TO_READ << " bytes takes " << duration_millisec
+	          << " milliseconds" << std::endl;
+}
+
+} // namespace
+
+} // namespace duckdb
+
+int main(int argc, char **argv) {
+	// Ignore SIGPIPE, reference: https://blog.erratasec.com/2018/10/tcpip-sockets-and-sigpipe.html
+	std::signal(SIGPIPE, SIG_IGN);
+
+	// Warm up system resource (i.e. httpfs metadata cache, TCP congestion window, etc).
+	std::cout << "Starts to warmup read" << std::endl;
+	duckdb::FileSystem::CreateLocal()->RemoveDirectory(BENCHMARK_DISK_CACHE_DIRECTORY);
+	duckdb::BenchmarkSetup benchmark_setup;
+	benchmark_setup.cache_type = duckdb::NOOP_CACHE_TYPE;
+	benchmark_setup.profile_type = duckdb::NOOP_PROFILE_TYPE;
+	duckdb::TestSequentialRead(benchmark_setup);
+
+	// Benchmark httpfs (with no cache reader).
+	std::cout << "Starts with httpfs read with no cache" << std::endl;
+	duckdb::FileSystem::CreateLocal()->RemoveDirectory(BENCHMARK_DISK_CACHE_DIRECTORY);
+	benchmark_setup.cache_type = duckdb::NOOP_CACHE_TYPE;
+	benchmark_setup.profile_type = duckdb::TEMP_PROFILE_TYPE;
+	benchmark_setup.disk_cache_directory = BENCHMARK_DISK_CACHE_DIRECTORY;
+	duckdb::TestSequentialRead(benchmark_setup);
+
+	// Benchmark on-disk cache reader.
+	std::cout << "Starts on-disk cache read with no existing cache" << std::endl;
+	duckdb::FileSystem::CreateLocal()->RemoveDirectory(BENCHMARK_DISK_CACHE_DIRECTORY);
+	benchmark_setup.cache_type = duckdb::ON_DISK_CACHE_TYPE;
+	benchmark_setup.profile_type = duckdb::TEMP_PROFILE_TYPE;
+	benchmark_setup.disk_cache_directory = BENCHMARK_DISK_CACHE_DIRECTORY;
+	duckdb::TestSequentialRead(benchmark_setup);
+
+	// Cleanup on-disk cache after benchmark.
+	duckdb::FileSystem::CreateLocal()->RemoveDirectory(BENCHMARK_DISK_CACHE_DIRECTORY);
+
+	return 0;
+}


### PR DESCRIPTION
Hardward config:
```
ubuntu@hjiang-devbox-pg$ lscpu
Architecture:            x86_64
  CPU op-mode(s):        32-bit, 64-bit
  Address sizes:         46 bits physical, 48 bits virtual
  Byte Order:            Little Endian
CPU(s):                  32
  On-line CPU(s) list:   0-31
Caches (sum of all):     
  L1d:                   512 KiB (16 instances)
  L1i:                   512 KiB (16 instances)
  L2:                    16 MiB (16 instances)
  L3:                    35.8 MiB (1 instance)

ubuntu@hjiang-devbox-pg$ lsmem 
RANGE                                   SIZE  STATE REMOVABLE   BLOCK
0x0000000000000000-0x00000000bfffffff     3G online       yes    0-23
0x0000000100000000-0x0000001fe7ffffff 123.6G online       yes 32-1020

Memory block size:       128M
Total online memory:    126.6G
Total offline memory:      0B
```

Benchmark and bucket region:
- Benchmark is performed at us-west1 region
- Bucket is at Tokyo

Benchmark results:
```
Starts to warmup read
Starts to warmup read
25 runs of random read of 10 bytes takes 3573 milliseconds
Starts with httpfs read with no cache
25 runs of random read of 10 bytes takes 3263 milliseconds
Starts on-disk cache read with no existing cache
25 runs of random read of 10 bytes takes 3602 milliseconds
```