### PR TITLE
Add benchmark README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,7 @@ SELECT * FROM duckdb_settings() WHERE name LIKE 'cached_http%';
 SELECT * FROM duckdb_functions() WHERE function_name LIKE 'cache_httpfs%';
 ```
 
-## Design doc
-[doc](https://docs.google.com/document/d/1IU8NQ_1_u6g178DReO0LCKYdlAHfa1QRU25eRXhf4jI/edit?usp=sharing)
-
-## Benchmark 
-### [More About Benchmark](/benchmark/README.md)
+## [More About Benchmark](/benchmark/README.md)
 
 ![sequential-read.cpp](benchmark-graph/seq-performance-barchart.svg)
 

--- a/README.md
+++ b/README.md
@@ -67,3 +67,8 @@ SELECT * FROM duckdb_functions() WHERE function_name LIKE 'cache_httpfs%';
 
 ## Design doc
 [doc](https://docs.google.com/document/d/1IU8NQ_1_u6g178DReO0LCKYdlAHfa1QRU25eRXhf4jI/edit?usp=sharing)
+
+## Benchmark 
+### [More About Benchmark](/benchmark/README.md)
+
+![sequential-read.cpp](benchmark-graph/seq-performance-barchart.svg)

--- a/README.md
+++ b/README.md
@@ -72,3 +72,5 @@ SELECT * FROM duckdb_functions() WHERE function_name LIKE 'cache_httpfs%';
 ### [More About Benchmark](/benchmark/README.md)
 
 ![sequential-read.cpp](benchmark-graph/seq-performance-barchart.svg)
+
+![random-read.cpp](benchmark-graph/random-performance-barchart.svg)

--- a/benchmark-graph/random-performance-barchart.svg
+++ b/benchmark-graph/random-performance-barchart.svg
@@ -21,7 +21,7 @@
     <!-- Native httpfs -->
     <rect x="200" y="100" width="150" height="200" fill="#1f77b4" opacity="0.8"/>
     <text x="275" y="320" text-anchor="middle" font-family="Arial" font-size="12">
-        DuckDB native
+        DuckDB Native
     </text>
     <text x="275" y="335" text-anchor="middle" font-family="Arial" font-size="12">
         httpfs

--- a/benchmark-graph/random-performance-barchart.svg
+++ b/benchmark-graph/random-performance-barchart.svg
@@ -36,7 +36,7 @@
         Cache FS Extension
     </text>
     <text x="525" y="335" text-anchor="middle" font-family="Arial" font-size="12">
-        (Disk Cache)
+        (uncached read)
     </text>
     <text x="525" y="355" text-anchor="middle" font-family="Arial" font-size="12">
         3,602 ms

--- a/benchmark-graph/random-performance-barchart.svg
+++ b/benchmark-graph/random-performance-barchart.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400">
+    <!-- Background -->
+    <rect width="800" height="400" fill="#ffffff"/>
+    
+    <!-- Title -->
+    <text x="400" y="40" text-anchor="middle" font-family="Arial" font-size="20" font-weight="bold">
+        Random Read Performance: S3 lineitem.parquet (25 runs × 10 bytes)
+    </text>
+    
+    <!-- Y-axis -->
+    <line x1="100" y1="300" x2="100" y2="50" stroke="black" stroke-width="1"/>
+    <!-- Y-axis label -->
+    <text x="30" y="175" text-anchor="middle" font-family="Arial" font-size="14" transform="rotate(-90, 30, 175)">
+        Time (milliseconds)
+    </text>
+    
+    <!-- X-axis -->
+    <line x1="100" y1="300" x2="700" y2="300" stroke="black" stroke-width="1"/>
+    
+    <!-- Bars -->
+    <!-- Native httpfs -->
+    <rect x="200" y="100" width="150" height="200" fill="#1f77b4" opacity="0.8"/>
+    <text x="275" y="320" text-anchor="middle" font-family="Arial" font-size="12">
+        DuckDB native
+    </text>
+    <text x="275" y="335" text-anchor="middle" font-family="Arial" font-size="12">
+        httpfs
+    </text>
+    <text x="275" y="355" text-anchor="middle" font-family="Arial" font-size="12">
+        3,263 ms
+    </text>
+    
+    <!-- Cache hit -->
+    <rect x="450" y="90" width="150" height="210" fill="#2ca02c" opacity="0.8"/>
+    <text x="525" y="320" text-anchor="middle" font-family="Arial" font-size="12">
+        Cache FS Extension
+    </text>
+    <text x="525" y="335" text-anchor="middle" font-family="Arial" font-size="12">
+        (Disk Cache)
+    </text>
+    <text x="525" y="355" text-anchor="middle" font-family="Arial" font-size="12">
+        3,602 ms
+    </text>
+    
+    <!-- Y-axis values -->
+    <text x="90" y="300" text-anchor="end" font-family="Arial" font-size="12">0</text>
+    <text x="90" y="240" text-anchor="end" font-family="Arial" font-size="12">1,000</text>
+    <text x="90" y="180" text-anchor="end" font-family="Arial" font-size="12">2,000</text>
+    <text x="90" y="120" text-anchor="end" font-family="Arial" font-size="12">3,000</text>
+    <text x="90" y="60" text-anchor="end" font-family="Arial" font-size="12">4,000</text>
+    
+    <!-- Grid lines -->
+    <line x1="100" y1="240" x2="700" y2="240" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+    <line x1="100" y1="180" x2="700" y2="180" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+    <line x1="100" y1="120" x2="700" y2="120" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+    <line x1="100" y1="60" x2="700" y2="60" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+</svg>

--- a/benchmark-graph/seq-performance-barchart.svg
+++ b/benchmark-graph/seq-performance-barchart.svg
@@ -3,8 +3,8 @@
     <rect width="800" height="400" fill="#ffffff"/>
     
     <!-- Title -->
-    <text x="400" y="30" text-anchor="middle" font-family="Arial" font-size="20" font-weight="bold">
-        Sequential Read Performance: S3 lineitem.parquet (SF=1)
+    <text x="400" y="40" text-anchor="middle" font-family="Arial" font-size="20" font-weight="bold">
+        Sequential Read Performance: S3 lineitem.parquet (256 MB)
     </text>
     
     <!-- Y-axis -->
@@ -27,11 +27,11 @@
         httpfs
     </text>
     <text x="200" y="355" text-anchor="middle" font-family="Arial" font-size="12">
-        47,323 ms
+        10,681 ms
     </text>
     
     <!-- First read -->
-    <rect x="350" y="85" width="100" height="215" fill="#ff7f0e" opacity="0.8"/>
+    <rect x="350" y="180" width="100" height="120" fill="#ff7f0e" opacity="0.8"/>
     <text x="400" y="320" text-anchor="middle" font-family="Arial" font-size="12">
         Cache FS Extension
     </text>
@@ -39,7 +39,7 @@
         (First Read)
     </text>
     <text x="400" y="355" text-anchor="middle" font-family="Arial" font-size="12">
-        43,170 ms
+        3,934 ms
     </text>
     
     <!-- Cache hit -->
@@ -51,15 +51,15 @@
         (Cache Hit)
     </text>
     <text x="600" y="355" text-anchor="middle" font-family="Arial" font-size="12">
-        20 ms
+        31 ms
     </text>
     
     <!-- Y-axis values -->
     <text x="90" y="300" text-anchor="end" font-family="Arial" font-size="12">0</text>
-    <text x="90" y="240" text-anchor="end" font-family="Arial" font-size="12">10,000</text>
-    <text x="90" y="180" text-anchor="end" font-family="Arial" font-size="12">20,000</text>
-    <text x="90" y="120" text-anchor="end" font-family="Arial" font-size="12">30,000</text>
-    <text x="90" y="60" text-anchor="end" font-family="Arial" font-size="12">50,000</text>
+    <text x="90" y="240" text-anchor="end" font-family="Arial" font-size="12">2,500</text>
+    <text x="90" y="180" text-anchor="end" font-family="Arial" font-size="12">5,000</text>
+    <text x="90" y="120" text-anchor="end" font-family="Arial" font-size="12">7,500</text>
+    <text x="90" y="60" text-anchor="end" font-family="Arial" font-size="12">10,000</text>
     
     <!-- Grid lines -->
     <line x1="100" y1="240" x2="700" y2="240" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>

--- a/benchmark-graph/seq-performance-barchart.svg
+++ b/benchmark-graph/seq-performance-barchart.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400">
+    <!-- Background -->
+    <rect width="800" height="400" fill="#ffffff"/>
+    
+    <!-- Title -->
+    <text x="400" y="30" text-anchor="middle" font-family="Arial" font-size="20" font-weight="bold">
+        Sequential Read Performance: S3 lineitem.parquet (SF=1)
+    </text>
+    
+    <!-- Y-axis -->
+    <line x1="100" y1="300" x2="100" y2="50" stroke="black" stroke-width="1"/>
+    <!-- Y-axis label -->
+    <text x="30" y="175" text-anchor="middle" font-family="Arial" font-size="14" transform="rotate(-90, 30, 175)">
+        Time (milliseconds)
+    </text>
+    
+    <!-- X-axis -->
+    <line x1="100" y1="300" x2="700" y2="300" stroke="black" stroke-width="1"/>
+    
+    <!-- Bars -->
+    <!-- Native httpfs -->
+    <rect x="150" y="80" width="100" height="220" fill="#1f77b4" opacity="0.8"/>
+    <text x="200" y="320" text-anchor="middle" font-family="Arial" font-size="12">
+        DuckDB native
+    </text>
+    <text x="200" y="335" text-anchor="middle" font-family="Arial" font-size="12">
+        httpfs
+    </text>
+    <text x="200" y="355" text-anchor="middle" font-family="Arial" font-size="12">
+        47,323 ms
+    </text>
+    
+    <!-- First read -->
+    <rect x="350" y="85" width="100" height="215" fill="#ff7f0e" opacity="0.8"/>
+    <text x="400" y="320" text-anchor="middle" font-family="Arial" font-size="12">
+        Cache FS Extension
+    </text>
+    <text x="400" y="335" text-anchor="middle" font-family="Arial" font-size="12">
+        (First Read)
+    </text>
+    <text x="400" y="355" text-anchor="middle" font-family="Arial" font-size="12">
+        43,170 ms
+    </text>
+    
+    <!-- Cache hit -->
+    <rect x="550" y="280" width="100" height="20" fill="#2ca02c" opacity="0.8"/>
+    <text x="600" y="320" text-anchor="middle" font-family="Arial" font-size="12">
+        Cache FS Extension
+    </text>
+    <text x="600" y="335" text-anchor="middle" font-family="Arial" font-size="12">
+        (Cache Hit)
+    </text>
+    <text x="600" y="355" text-anchor="middle" font-family="Arial" font-size="12">
+        20 ms
+    </text>
+    
+    <!-- Y-axis values -->
+    <text x="90" y="300" text-anchor="end" font-family="Arial" font-size="12">0</text>
+    <text x="90" y="240" text-anchor="end" font-family="Arial" font-size="12">10,000</text>
+    <text x="90" y="180" text-anchor="end" font-family="Arial" font-size="12">20,000</text>
+    <text x="90" y="120" text-anchor="end" font-family="Arial" font-size="12">30,000</text>
+    <text x="90" y="60" text-anchor="end" font-family="Arial" font-size="12">50,000</text>
+    
+    <!-- Grid lines -->
+    <line x1="100" y1="240" x2="700" y2="240" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+    <line x1="100" y1="180" x2="700" y2="180" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+    <line x1="100" y1="120" x2="700" y2="120" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+    <line x1="100" y1="60" x2="700" y2="60" stroke="gray" stroke-width="0.5" stroke-dasharray="5,5"/>
+</svg>

--- a/benchmark-graph/seq-performance-barchart.svg
+++ b/benchmark-graph/seq-performance-barchart.svg
@@ -36,7 +36,7 @@
         Cache FS Extension
     </text>
     <text x="400" y="335" text-anchor="middle" font-family="Arial" font-size="12">
-        (uncache read)
+        (uncached read)
     </text>
     <text x="400" y="355" text-anchor="middle" font-family="Arial" font-size="12">
         3,934 ms
@@ -48,7 +48,7 @@
         Cache FS Extension
     </text>
     <text x="600" y="335" text-anchor="middle" font-family="Arial" font-size="12">
-        (cache read)
+        (cached read)
     </text>
     <text x="600" y="355" text-anchor="middle" font-family="Arial" font-size="12">
         31 ms

--- a/benchmark-graph/seq-performance-barchart.svg
+++ b/benchmark-graph/seq-performance-barchart.svg
@@ -21,7 +21,7 @@
     <!-- Native httpfs -->
     <rect x="150" y="80" width="100" height="220" fill="#1f77b4" opacity="0.8"/>
     <text x="200" y="320" text-anchor="middle" font-family="Arial" font-size="12">
-        DuckDB native
+        DuckDB Native
     </text>
     <text x="200" y="335" text-anchor="middle" font-family="Arial" font-size="12">
         httpfs
@@ -36,7 +36,7 @@
         Cache FS Extension
     </text>
     <text x="400" y="335" text-anchor="middle" font-family="Arial" font-size="12">
-        (First Read)
+        (uncache read)
     </text>
     <text x="400" y="355" text-anchor="middle" font-family="Arial" font-size="12">
         3,934 ms
@@ -48,7 +48,7 @@
         Cache FS Extension
     </text>
     <text x="600" y="335" text-anchor="middle" font-family="Arial" font-size="12">
-        (Cache Hit)
+        (cache read)
     </text>
     <text x="600" y="355" text-anchor="middle" font-family="Arial" font-size="12">
         31 ms

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,8 +4,8 @@
 This benchmark suite evaluates the performance of our DuckDB fs extension compared to the standard DuckDB httpfs. 
 
 The TLDR here is:
-- For request size larger than block size, our extension's performance is much better than httpfs due to parallelism and cache hit
-- For request size smaller than block size, its performance is similar to httpfs but slightly worse, because extension read more bytes due to alignment
+- If request size larger than request block size, our extension's performance is much better than httpfs due to parallelism and cache hit
+- If request size smaller than request block size, its performance is similar to httpfs but slightly worse, because extension read more bytes due to alignment
 - Overall, the extension provides no worse performance, meanwhile providing a few extra features
 
 ## Configuration

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,60 @@
+# Duck-Read-Cache-FS Performance Benchmark Suite
+
+## Overview
+This benchmark suite evaluates the performance of our DuckDB fs extension compared to the standard DuckDB httpfs. 
+Key aspects measured include:
+
+* Read performance from cloud storage (S3)
+* Caching efficiency for frequently accessed data (working)
+* Query execution time with cached vs non-cached data (working)
+* Memory usage and disk utilization (working)
+* Compatibility with existing DuckDB httpfs workflows 
+
+> **Note**
+> Our goal is to provide a more efficient, caching-aware alternative to DuckDB's httpfs while maintaining full compatibility.
+
+
+## Installation
+1. Build all release binaries:
+```bash
+make
+```
+## Configuration
+
+### AWS Credentials
+
+Set up your AWS credentials in your environment:
+```bash
+export AWS_ACCESS_KEY_ID='your-key-id'
+export AWS_SECRET_ACCESS_KEY='your-secret-key'
+export AWS_DEFAULT_REGION='your-region'
+```
+
+### Available Benchmark Suites
+
+The compiled benchmarks are located in:
+```bash
+build/release/extension/read_cache_fs/
+```
+
+To list available benchmark suites:
+```bash
+ls build/release/extension/read_cache_fs/
+```
+
+### Executing a Benchmark
+
+Run any benchmark binary from the suite:
+```bash
+./build/release/extension/read_cache_fs/<benchmark-name>
+```
+
+## Benchmark Methodology
+
+### Test Categories
+
+- Read Performance
+  - Sequential read operations
+  - Random read operations
+  - Cache hit ratio analysis
+

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@
 This benchmark suite evaluates the performance of our DuckDB fs extension compared to the standard DuckDB httpfs. 
 Key aspects measured include:
 
-* Out of box parallel read support ✅
+* Out-of-the-box parallel read support ✅
 * Read performance from cloud storage ✅
 * Compatibility with existing DuckDB httpfs workflows ✅
 * Memory usage and disk utilization ✅
@@ -55,7 +55,7 @@ Run any benchmark binary from the suite:
 ### Environment Setup
 
 #### Location Details
-- **Benchmark Region**: us-west1
+- **Benchmark Machine Region**: us-west1
 - **S3 Storage Bucket Location**: ap-northeast-1
 
 #### Hardware Specifications

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,18 +2,10 @@
 
 ## Overview
 This benchmark suite evaluates the performance of our DuckDB fs extension compared to the standard DuckDB httpfs. 
-Key aspects measured include:
 
-
-## Installation
-1. Build all release binaries:
-```bash
-CMAKE_BUILD_PARALLEL_LEVE=<how-many-thread-you-have>  make 
-```
 ## Configuration
 
 ### AWS Credentials
-
 Set up your AWS credentials in your environment:
 ```bash
 export AWS_ACCESS_KEY_ID='your-key-id'
@@ -22,24 +14,11 @@ export AWS_DEFAULT_REGION='your-region'
 ```
 
 ### Available Benchmark Suites
-
-The compiled benchmarks are located in:
-```bash
-build/release/extension/read_cache_fs/
-```
-
 Available benchmark suites:
 ```bash
 build/release/extension/read_cache_fs/read_s3_object
 build/release/extension/read_cache_fs/sequential_read_benchmark
 build/release/extension/read_cache_fs/random_read_benchmark
-```
-
-### Executing a Benchmark
-
-Run any benchmark binary from the suite:
-```bash
-./build/release/extension/read_cache_fs/<benchmark-name>
 ```
 
 ## Benchmark Methodology
@@ -80,6 +59,6 @@ Run any benchmark binary from the suite:
 ### Test Categories
 
 - Read Performance
-  - Sequential read operations
-  - Random read operations
+  - [Sequential read operations](benchmark/sequential_read_benchmark.cpp)
+  - [Random read operations](benchmark/random_read_benchmark.cpp)
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,15 +4,6 @@
 This benchmark suite evaluates the performance of our DuckDB fs extension compared to the standard DuckDB httpfs. 
 Key aspects measured include:
 
-* Out-of-the-box parallel read support ✅
-* Read performance from cloud storage ✅
-* Compatibility with existing DuckDB httpfs workflows ✅
-* Memory usage and disk utilization ✅
-* End-to-end query execution time with cached vs. non-cached data (work in progress) 
-
-> **Note**
-> Our goal is to provide a more efficient alternative to DuckDB's httpfs extension while maintaining full compatibility. By caching the data locally, you not only get a performance boost but also save network costs from object storage.
-
 
 ## Installation
 1. Build all release binaries:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,20 +4,20 @@
 This benchmark suite evaluates the performance of our DuckDB fs extension compared to the standard DuckDB httpfs. 
 Key aspects measured include:
 
-* Read performance from cloud storage (S3)
-* Caching efficiency for frequently accessed data (working)
-* Query execution time with cached vs non-cached data (working)
-* Memory usage and disk utilization (working)
-* Compatibility with existing DuckDB httpfs workflows 
+* Out of box parallel read support ✅
+* Read performance from cloud storage ✅
+* Compatibility with existing DuckDB httpfs workflows ✅
+* Memory usage and disk utilization ✅
+* End-to-end query execution time with cached vs. non-cached data (work in progress) 
 
 > **Note**
-> Our goal is to provide a more efficient, caching-aware alternative to DuckDB's httpfs while maintaining full compatibility.
+> Our goal is to provide a more efficient alternative to DuckDB's httpfs extension while maintaining full compatibility. By caching the data locally, you not only get a performance boost but also save network costs from object storage.
 
 
 ## Installation
 1. Build all release binaries:
 ```bash
-make
+CMAKE_BUILD_PARALLEL_LEVE=<how-many-thread-you-have>  make 
 ```
 ## Configuration
 
@@ -37,9 +37,11 @@ The compiled benchmarks are located in:
 build/release/extension/read_cache_fs/
 ```
 
-To list available benchmark suites:
+Available benchmark suites:
 ```bash
-ls build/release/extension/read_cache_fs/
+build/release/extension/read_cache_fs/read_s3_object
+build/release/extension/read_cache_fs/sequential_read_benchmark
+build/release/extension/read_cache_fs/random_read_benchmark
 ```
 
 ### Executing a Benchmark
@@ -50,11 +52,43 @@ Run any benchmark binary from the suite:
 ```
 
 ## Benchmark Methodology
+### Environment Setup
+
+#### Location Details
+- **Benchmark Region**: us-west1
+- **S3 Storage Bucket Location**: ap-northeast-1
+
+#### Hardware Specifications
+
+**CPU Architecture**
+- Architecture: x86_64
+- Operation Modes: 32-bit, 64-bit
+- Physical/Virtual Address: 46 bits physical, 48 bits virtual
+- Byte Order: Little Endian
+- Total CPUs: 32 (all online, cores 0-31)
+
+**Cache Information**
+- L1 Data Cache: 512 KiB (16 instances)
+- L1 Instruction Cache: 512 KiB (16 instances)
+- L2 Cache: 16 MiB (16 instances)
+- L3 Cache: 35.8 MiB (1 instance)
+
+**Memory Configuration**
+- Range 1: 0x0000000000000000-0x00000000bfffffff
+  - Size: 3G
+  - State: Online
+  - Removable: Yes
+  - Blocks: 0-23
+
+- Range 2: 0x0000000100000000-0x0000001fe7ffffff
+  - Size: 123.6G
+  - State: Online
+  - Removable: Yes
+  - Blocks: 32-1020
 
 ### Test Categories
 
 - Read Performance
   - Sequential read operations
   - Random read operations
-  - Cache hit ratio analysis
 

--- a/benchmark/random_read_benchmark.cpp
+++ b/benchmark/random_read_benchmark.cpp
@@ -1,3 +1,5 @@
+// Benchmark setup: start from a random offset, and read 10 bytes every time (which is much less than block size).
+
 #include "disk_cache_reader.hpp"
 #include "duckdb/storage/standard_buffer_manager.hpp"
 #include "duckdb/main/client_context_file_opener.hpp"

--- a/benchmark/sequential_read_benchmark.cpp
+++ b/benchmark/sequential_read_benchmark.cpp
@@ -1,3 +1,7 @@
+// Benchmark setup:
+// - Request number of bytes larger than cache block size;
+// - Sequentially read forward until the end of remote file.
+
 #include "disk_cache_reader.hpp"
 #include "duckdb/storage/standard_buffer_manager.hpp"
 #include "duckdb/main/client_context_file_opener.hpp"

--- a/src/utils/thread_utils.cpp
+++ b/src/utils/thread_utils.cpp
@@ -1,6 +1,7 @@
 #include "thread_utils.hpp"
 
 #include <pthread.h>
+#include <thread>
 
 #if defined(__linux__)
 #include <sched.h>


### PR DESCRIPTION
Add performance benchmark documentation comparing DuckDB native httpfs vs Cache FS Extension for sequential S3 reads.