### PR TITLE
Provide an options to disable metadata cache

### DIFF
--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -63,6 +63,10 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		FileOpener::TryGetCurrentSetting(opener, "cached_http_max_in_mem_cache_block_count", val);
 		g_max_in_mem_cache_block_count = val.GetValue<uint64_t>();
 	}
+
+	// Check and update configurations for metadata cache enablement.
+	FileOpener::TryGetCurrentSetting(opener, "cached_http_enable_metadata_cache", val);
+	g_enable_metadata_cache = val.GetValue<bool>();
 }
 
 void ResetGlobalConfig() {
@@ -73,6 +77,7 @@ void ResetGlobalConfig() {
 	g_cache_type = DEFAULT_CACHE_TYPE;
 	g_profile_type = DEFAULT_PROFILE_TYPE;
 	g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
+	g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
 }
 
 uint64_t GetThreadCountForSubrequests(uint64_t io_request_count) {

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -27,7 +27,7 @@ public:
 class CacheFileSystem : public FileSystem {
 public:
 	explicit CacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
-	    : internal_filesystem(std::move(internal_filesystem_p)), metadata_cache(kMaxMetadataEntry) {
+	    : internal_filesystem(std::move(internal_filesystem_p)) {
 	}
 	~CacheFileSystem() override = default;
 
@@ -171,6 +171,9 @@ protected:
 	// Initialize profile collector data member.
 	void SetProfileCollector();
 
+	// Initialize metadata cache.
+	void SetMetadataCache();
+
 	// Used to access remote files.
 	unique_ptr<FileSystem> internal_filesystem;
 	// Noop, in-memory and on-disk cache reader.
@@ -184,8 +187,9 @@ protected:
 	unique_ptr<BaseProfileCollector> profile_collector;
 	// Max number of cache entries for file metadata cache.
 	static constexpr size_t kMaxMetadataEntry = 125;
+	using MetadataCache = ThreadSafeSharedLruConstCache<string, FileMetadata>;
 	// Metadata cache, which maps from file name to metadata.
-	ThreadSafeSharedLruConstCache<string, FileMetadata> metadata_cache;
+	unique_ptr<MetadataCache> metadata_cache;
 };
 
 } // namespace duckdb

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -52,6 +52,9 @@ inline std::string DEFAULT_PROFILE_TYPE = NOOP_PROFILE_TYPE;
 // Default max number of parallel subrequest for a single filesystem read request. 0 means no limit.
 inline uint64_t DEFAULT_MAX_SUBREQUEST_COUNT = 0;
 
+// Default enable metadata cache.
+inline bool DEFAULT_ENABLE_METADATA_CACHE = true;
+
 //===--------------------------------------------------------------------===//
 // Global configuration
 //===--------------------------------------------------------------------===//
@@ -61,6 +64,7 @@ inline idx_t g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COU
 inline std::string g_cache_type = DEFAULT_CACHE_TYPE;
 inline std::string g_profile_type = DEFAULT_PROFILE_TYPE;
 inline uint64_t g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
+inline bool g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
 
 // Used for testing purpose, which has a higher priority over [g_cache_type], and won't be reset.
 // TODO(hjiang): A better is bake configuration into `FileOpener`.

--- a/src/read_cache_fs_extension.cpp
+++ b/src/read_cache_fs_extension.cpp
@@ -156,6 +156,9 @@ static void LoadInternal(DatabaseInstance &instance) {
 	    "config [cached_http_cache_block_size]. The setting limits the maximum request to issue for a single "
 	    "filesystem read request. 0 means no limit, by default we set no limit.",
 	    LogicalType::BIGINT, 0);
+	config.AddExtensionOption("cached_http_enable_metadata_cache",
+	                          "Whether metadata cache is enable for cache filesystem. By default enabled.",
+	                          LogicalTypeId::BOOLEAN, DEFAULT_ENABLE_METADATA_CACHE);
 
 	// Register cache cleanup function for both in-memory and on-disk cache.
 	ScalarFunction clear_cache_function("cache_httpfs_clear_cache", /*arguments=*/ {},


### PR DESCRIPTION
Metadata could be already cached in the underlying filesystem, depending on the implementation; this PR provides an option to disable on cache fs level.