### PR TITLE
Provide option to ignore SIGPIPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Key features:
   + duckdb (under work), stats are stored in duckdb so we could leverage its rich feature for analysis purpose (i.e. use histogram to understant latency distribution)
   + profiling is by default disabled
 - Compatibility with duckdb `httpfs`
-  + Extension is built upon `httpfs` extension and load it beforehand, so it's fully compatible with it; we provide option `SET cached_http_type='noop';` to fallback to no cache and parallel IO version, which fallbacks to and behaves exactly as httpfs.
+  + Extension is built upon `httpfs` extension and load it beforehand, so it's fully compatible with it; we provide option `SET cache_httpfs_type='noop';` to fallback to no cache and parallel IO version, which fallbacks to and behaves exactly as httpfs.
 
 ## Example usage
 ```sql
@@ -30,7 +30,7 @@ D CREATE SECRET my_secret (      TYPE S3,      KEY_ID '<key>',      SECRET '<sec
 │ true    │
 └─────────┘
 -- Set cache type to in-memory.
-D SET cached_http_type='in_mem';
+D SET cache_httpfs_type='in_mem';
 D SELECT * FROM 's3://s3-bucket-user-2skzy8zuigonczyfiofztl0zbug--use1-az6--x-s3/t.parquet';
 ┌───────┬───────┐
 │   i   │   j   │

--- a/benchmark/random_read_benchmark.cpp
+++ b/benchmark/random_read_benchmark.cpp
@@ -42,15 +42,15 @@ void SetOpenerConfig(shared_ptr<ClientContext> ctx, const BenchmarkSetup &benchm
 	SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
 	SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
 	SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
-	set_vars["cached_http_profile_type"] = Value(benchmark_setup.profile_type);
-	set_vars["cached_http_type"] = Value(benchmark_setup.cache_type);
-	set_vars["cached_http_cache_directory"] = Value(benchmark_setup.disk_cache_directory);
-	set_vars["cached_http_cache_block_size"] = Value::UBIGINT(benchmark_setup.block_size);
+	set_vars["cache_httpfs_profile_type"] = Value(benchmark_setup.profile_type);
+	set_vars["cache_httpfs_type"] = Value(benchmark_setup.cache_type);
+	set_vars["cache_httpfs_cache_directory"] = Value(benchmark_setup.disk_cache_directory);
+	set_vars["cache_httpfs_cache_block_size"] = Value::UBIGINT(benchmark_setup.block_size);
 }
 
 void TestSequentialRead(const BenchmarkSetup &benchmark_setup) {
 	DuckDB db {};
-	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cache_httpfs_fs_benchmark"};
 	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
 	auto cache_fs = make_uniq<CacheFileSystem>(std::move(s3fs));
 	auto client_context = make_shared_ptr<ClientContext>(db.instance);

--- a/benchmark/read_s3_object.cpp
+++ b/benchmark/read_s3_object.cpp
@@ -28,7 +28,7 @@ void SetConfig(case_insensitive_map_t<Value> &setting, char *env_key, char *secr
 // caching.
 void BaseLineRead() {
 	DuckDB db {};
-	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cache_httpfs_fs_benchmark"};
 	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
 
 	auto client_context = make_shared_ptr<ClientContext>(db.instance);
@@ -63,7 +63,7 @@ void ReadUncachedWholeFile(uint64_t block_size) {
 	};
 
 	DuckDB db {};
-	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cache_httpfs_fs_benchmark"};
 	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
 
 	FileSystem::CreateLocal()->RemoveDirectory(g_on_disk_cache_directory);

--- a/benchmark/sequential_read_benchmark.cpp
+++ b/benchmark/sequential_read_benchmark.cpp
@@ -37,15 +37,15 @@ void SetOpenerConfig(shared_ptr<ClientContext> ctx, const BenchmarkSetup &benchm
 	SetConfig(set_vars, "AWS_DEFAULT_REGION", "s3_region");
 	SetConfig(set_vars, "AWS_ACCESS_KEY_ID", "s3_access_key_id");
 	SetConfig(set_vars, "AWS_SECRET_ACCESS_KEY", "s3_secret_access_key");
-	set_vars["cached_http_profile_type"] = Value(benchmark_setup.profile_type);
-	set_vars["cached_http_type"] = Value(benchmark_setup.cache_type);
-	set_vars["cached_http_cache_directory"] = Value(benchmark_setup.disk_cache_directory);
-	set_vars["cached_http_cache_block_size"] = Value::UBIGINT(benchmark_setup.block_size);
+	set_vars["cache_httpfs_profile_type"] = Value(benchmark_setup.profile_type);
+	set_vars["cache_httpfs_type"] = Value(benchmark_setup.cache_type);
+	set_vars["cache_httpfs_cache_directory"] = Value(benchmark_setup.disk_cache_directory);
+	set_vars["cache_httpfs_cache_block_size"] = Value::UBIGINT(benchmark_setup.block_size);
 }
 
 void TestSequentialRead(const BenchmarkSetup &benchmark_setup) {
 	DuckDB db {};
-	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cache_httpfs_fs_benchmark"};
 	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
 	auto cache_fs = make_uniq<CacheFileSystem>(std::move(s3fs));
 	auto client_context = make_shared_ptr<ClientContext>(db.instance);

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -32,7 +32,7 @@ inline const std::unordered_set<std::string> ALL_PROFILE_TYPES = {NOOP_PROFILE_T
 // Default configuration
 //===--------------------------------------------------------------------===//
 inline const idx_t DEFAULT_CACHE_BLOCK_SIZE = 64_KiB;
-inline const std::string DEFAULT_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_cached_http_cache";
+inline const std::string DEFAULT_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_cache_httpfs_cache";
 
 // Default to use on-disk cache filesystem.
 inline std::string DEFAULT_CACHE_TYPE = ON_DISK_CACHE_TYPE;
@@ -55,6 +55,9 @@ inline uint64_t DEFAULT_MAX_SUBREQUEST_COUNT = 0;
 // Default enable metadata cache.
 inline bool DEFAULT_ENABLE_METADATA_CACHE = true;
 
+// Default not ignore SIGPIPE in the extension.
+inline bool DEFAULT_IGNORE_SIGPIPE = false;
+
 //===--------------------------------------------------------------------===//
 // Global configuration
 //===--------------------------------------------------------------------===//
@@ -65,6 +68,7 @@ inline std::string g_cache_type = DEFAULT_CACHE_TYPE;
 inline std::string g_profile_type = DEFAULT_PROFILE_TYPE;
 inline uint64_t g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
 inline bool g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
+inline bool g_ignore_sigpipe = DEFAULT_IGNORE_SIGPIPE;
 
 // Used for testing purpose, which has a higher priority over [g_cache_type], and won't be reset.
 // TODO(hjiang): A better is bake configuration into `FileOpener`.

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -33,7 +33,7 @@ const auto TEST_FILE_CONTENT = []() {
 	return content;
 }();
 const auto TEST_FILENAME = StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
-const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
+const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache";
 } // namespace
 
 // Test default directory works for cached read.

--- a/unit/test_filesystem_config.cpp
+++ b/unit/test_filesystem_config.cpp
@@ -30,13 +30,13 @@ TEST_CASE("Filesystem config test", "[filesystem config]") {
 
 TEST_CASE("Filesystem cache config test", "[filesystem config]") {
 	DuckDB db {};
-	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cache_httpfs_fs_benchmark"};
 	auto cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
 	auto client_context = make_shared_ptr<ClientContext>(db.instance);
 
 	// Check noop cache reader.
 	{
-		client_context->config.set_variables["cached_http_type"] = Value(NOOP_CACHE_TYPE);
+		client_context->config.set_variables["cache_httpfs_type"] = Value(NOOP_CACHE_TYPE);
 		ClientContextFileOpener file_opener {*client_context};
 		cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ, &file_opener);
 		auto *cache_reader = cache_fs->GetCacheReader();
@@ -45,7 +45,7 @@ TEST_CASE("Filesystem cache config test", "[filesystem config]") {
 
 	// Check in-memory cache reader.
 	{
-		client_context->config.set_variables["cached_http_type"] = Value(IN_MEM_CACHE_TYPE);
+		client_context->config.set_variables["cache_httpfs_type"] = Value(IN_MEM_CACHE_TYPE);
 		ClientContextFileOpener file_opener {*client_context};
 		cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ, &file_opener);
 		auto *cache_reader = cache_fs->GetCacheReader();
@@ -54,7 +54,7 @@ TEST_CASE("Filesystem cache config test", "[filesystem config]") {
 
 	// Check on-disk cache reader.
 	{
-		client_context->config.set_variables["cached_http_type"] = Value(ON_DISK_CACHE_TYPE);
+		client_context->config.set_variables["cache_httpfs_type"] = Value(ON_DISK_CACHE_TYPE);
 		ClientContextFileOpener file_opener {*client_context};
 		cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ, &file_opener);
 		auto *cache_reader = cache_fs->GetCacheReader();
@@ -64,13 +64,13 @@ TEST_CASE("Filesystem cache config test", "[filesystem config]") {
 
 TEST_CASE("Filesystem profile config test", "[filesystem config]") {
 	DuckDB db {};
-	StandardBufferManager buffer_manager {*db.instance, "/tmp/cached_http_fs_benchmark"};
+	StandardBufferManager buffer_manager {*db.instance, "/tmp/cache_httpfs_fs_benchmark"};
 	auto cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
 	auto client_context = make_shared_ptr<ClientContext>(db.instance);
 
 	// Check noop profiler.
 	{
-		client_context->config.set_variables["cached_http_profile_type"] = Value(NOOP_PROFILE_TYPE);
+		client_context->config.set_variables["cache_httpfs_profile_type"] = Value(NOOP_PROFILE_TYPE);
 		ClientContextFileOpener file_opener {*client_context};
 		cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ, &file_opener);
 		auto *profiler = cache_fs->GetProfileCollector();
@@ -79,7 +79,7 @@ TEST_CASE("Filesystem profile config test", "[filesystem config]") {
 
 	// Check temp cache reader.
 	{
-		client_context->config.set_variables["cached_http_profile_type"] = Value(TEMP_PROFILE_TYPE);
+		client_context->config.set_variables["cache_httpfs_profile_type"] = Value(TEMP_PROFILE_TYPE);
 		ClientContextFileOpener file_opener {*client_context};
 		cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ, &file_opener);
 		auto *profiler = cache_fs->GetProfileCollector();

--- a/unit/test_set_extension_config.cpp
+++ b/unit/test_set_extension_config.cpp
@@ -16,8 +16,8 @@
 using namespace duckdb; // NOLINT
 
 namespace {
-const std::string TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
-const std::string TEST_SECOND_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache_second";
+const std::string TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache";
+const std::string TEST_SECOND_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache_second";
 const std::string TEST_ON_DISK_CACHE_FILE = "/tmp/test-config.parquet";
 
 void CleanupTestDirectory() {
@@ -40,11 +40,11 @@ TEST_CASE("Test on incorrect config", "[extension config test]") {
 
 	// Set non-existent config parameter.
 	auto result =
-	    con.Query(StringUtil::Format("SET wrong_cached_http_cache_directory ='%s'", TEST_ON_DISK_CACHE_DIRECTORY));
+	    con.Query(StringUtil::Format("SET wrong_cache_httpfs_cache_directory ='%s'", TEST_ON_DISK_CACHE_DIRECTORY));
 	REQUIRE(result->HasError());
 
 	// Set existent config parameter to incorrect type.
-	result = con.Query(StringUtil::Format("SET cached_http_cache_block_size='hello'"));
+	result = con.Query(StringUtil::Format("SET cache_httpfs_cache_block_size='hello'"));
 	REQUIRE(result->HasError());
 }
 
@@ -53,15 +53,15 @@ TEST_CASE("Test on correct config", "[extension config test]") {
 	Connection con(db);
 
 	// On-disk cache directory.
-	auto result = con.Query(StringUtil::Format("SET cached_http_cache_directory='helloworld'"));
+	auto result = con.Query(StringUtil::Format("SET cache_httpfs_cache_directory='helloworld'"));
 	REQUIRE(!result->HasError());
 
 	// Cache block size.
-	result = con.Query(StringUtil::Format("SET cached_http_cache_block_size=10"));
+	result = con.Query(StringUtil::Format("SET cache_httpfs_cache_block_size=10"));
 	REQUIRE(!result->HasError());
 
 	// In-memory cache block count.
-	result = con.Query(StringUtil::Format("SET cached_http_max_in_mem_cache_block_count=10"));
+	result = con.Query(StringUtil::Format("SET cache_httpfs_max_in_mem_cache_block_count=10"));
 	REQUIRE(!result->HasError());
 }
 
@@ -72,7 +72,7 @@ TEST_CASE("Test on changing extension config change defaul cache dir path settin
 	fs.RegisterSubSystem(make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal()));
 
 	Connection con(db);
-	con.Query(StringUtil::Format("SET cached_http_cache_directory ='%s'", TEST_ON_DISK_CACHE_DIRECTORY));
+	con.Query(StringUtil::Format("SET cache_httpfs_cache_directory ='%s'", TEST_ON_DISK_CACHE_DIRECTORY));
 	con.Query("CREATE TABLE integers AS SELECT i, i+1 as j FROM range(10) r(i)");
 	con.Query(StringUtil::Format("COPY integers TO '%s'", TEST_ON_DISK_CACHE_FILE));
 
@@ -89,7 +89,7 @@ TEST_CASE("Test on changing extension config change defaul cache dir path settin
 	REQUIRE(files_after_query == 1);
 
 	// Change the cache directory path and execute the query again.
-	con.Query(StringUtil::Format("SET cached_http_cache_directory ='%s'", TEST_SECOND_ON_DISK_CACHE_DIRECTORY));
+	con.Query(StringUtil::Format("SET cache_httpfs_cache_directory ='%s'", TEST_SECOND_ON_DISK_CACHE_DIRECTORY));
 	result = con.Query(StringUtil::Format("SELECT * FROM '%s'", TEST_ON_DISK_CACHE_FILE));
 	REQUIRE(!result->HasError());
 
@@ -103,8 +103,8 @@ TEST_CASE("Test on changing extension config change defaul cache dir path settin
 	// Update cache type to in-memory cache type and on-disk cache directory, and check no new cache files created.
 	//
 	// Set cache directory to the root directory, which test program doesn't have the permission to write to.
-	con.Query(StringUtil::Format("SET cached_http_cache_directory ='%s'", "/non_existent_directory"));
-	con.Query("SET cached_http_type='in_mem'");
+	con.Query(StringUtil::Format("SET cache_httpfs_cache_directory ='%s'", "/non_existent_directory"));
+	con.Query("SET cache_httpfs_type='in_mem'");
 	result = con.Query(StringUtil::Format("SELECT * FROM '%s'", TEST_ON_DISK_CACHE_FILE));
 	REQUIRE(!result->HasError());
 };

--- a/unit/test_stale_deletion.cpp
+++ b/unit/test_stale_deletion.cpp
@@ -12,7 +12,7 @@
 using namespace duckdb; // NOLINT
 
 namespace {
-const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cached_http_cache";
+const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache";
 } // namespace
 
 TEST_CASE("Stale file deletion", "[utils test]") {


### PR DESCRIPTION
This PR does two things:
- Rename extension config settings and functions to uniformly prefixed with `cache_httpfs_`
- Add a new option to ignore SIGPIPE, see inline comments for reference