### PR TITLE
Fix on noop reader profile

### DIFF
--- a/src/noop_cache_reader.cpp
+++ b/src/noop_cache_reader.cpp
@@ -6,11 +6,11 @@ namespace duckdb {
 void NoopCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
                                    idx_t requested_bytes_to_read, idx_t file_size) {
 	auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-	const string cur_oper = StringUtil::Format("%d", requested_start_offset);
-	profile_collector->RecordOperationStart(cur_oper);
+	const string oper_id = profile_collector->GetOperId();
+	profile_collector->RecordOperationStart(oper_id);
 	internal_filesystem->Read(*disk_cache_handle.internal_file_handle, buffer, requested_bytes_to_read,
 	                          requested_start_offset);
-	profile_collector->RecordOperationEnd(cur_oper);
+	profile_collector->RecordOperationEnd(oper_id);
 }
 
 } // namespace duckdb

--- a/src/read_cache_fs_extension.cpp
+++ b/src/read_cache_fs_extension.cpp
@@ -21,7 +21,9 @@ static vector<CacheFileSystem *> cache_file_systems;
 // Clear both in-memory and on-disk data block cache.
 static void ClearAllCache(const DataChunk &args, ExpressionState &state, Vector &result) {
 	// Clear local disk cache.
-	LocalFileSystem::CreateLocal()->RemoveDirectory(g_on_disk_cache_directory);
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	local_filesystem->RemoveDirectory(g_on_disk_cache_directory);
+	local_filesystem->CreateDirectory(g_on_disk_cache_directory);
 
 	for (auto *cur_filesystem : cache_file_systems) {
 		cur_filesystem->ClearCache();

--- a/unit/test_noop_cache_reader.cpp
+++ b/unit/test_noop_cache_reader.cpp
@@ -57,6 +57,22 @@ TEST_CASE("Test on noop cache filesystem", "[noop cache filesystem test]") {
 	}
 }
 
+TEST_CASE("Test noop read whole file", "[noop cache filesystem test]") {
+	g_cache_block_size = TEST_FILE_SIZE;
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+
+	auto noop_filesystem = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+	auto handle = noop_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+	const uint64_t start_offset = 0;
+	const uint64_t bytes_to_read = TEST_FILE_SIZE;
+	string content(bytes_to_read, '\0');
+	noop_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+	                      start_offset);
+	REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+}
+
 int main(int argc, char **argv) {
 	// Set global cache type for testing.
 	g_test_cache_type = NOOP_CACHE_TYPE;


### PR DESCRIPTION
This PR does three things:
- When we delete all cache files under on-disk cache directory, we should recreate after deletion;
- Use UUID for operation id from profiler, otherwise we could suffer profiling key collision;
- Add a unit test for noop cache reader.