### PR TITLE
Disable copy and move semantics for a few classes

### DIFF
--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -14,6 +14,8 @@ public:
 	BaseCacheReader(FileSystem *internal_filesystem_p) : internal_filesystem(internal_filesystem_p) {
 	}
 	virtual ~BaseCacheReader() = default;
+	BaseCacheReader(const BaseCacheReader &) = delete;
+	BaseCacheReader &operator=(const BaseCacheReader &) = delete;
 
 	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache
 	// to local filesystem and return to user.

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -24,6 +24,8 @@ public:
 
 	BaseProfileCollector() = default;
 	virtual ~BaseProfileCollector() = default;
+	BaseProfileCollector(const BaseProfileCollector &) = delete;
+	BaseProfileCollector &operator=(const BaseProfileCollector &) = delete;
 
 	// Get an ID which uniquely identifies current operation.
 	virtual std::string GetOperId() const = 0;


### PR DESCRIPTION
Follows the C++ best practice.