### PR TITLE
Introduce immutable buffer for in-memory cache and corresponding LRU cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ target_link_libraries(test_thread_pool ${EXTENSION_NAME})
 add_executable(test_shared_lru_cache unit/test_shared_lru_cache.cpp)
 target_link_libraries(test_shared_lru_cache ${EXTENSION_NAME})
 
+add_executable(test_copiable_value_lru_cache
+               unit/test_copiable_value_lru_cache.cpp)
+target_link_libraries(test_copiable_value_lru_cache ${EXTENSION_NAME})
+
 add_executable(test_size_literals unit/test_size_literals.cpp)
 target_link_libraries(test_size_literals ${EXTENSION_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(EXTENSION_SOURCES
     src/cache_httpfs_extension.cpp
     src/temp_profile_collector.cpp
     src/utils/filesystem_utils.cpp
+    src/utils/string_utils.cpp
     src/utils/thread_pool.cpp
     src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp
@@ -118,6 +119,9 @@ target_link_libraries(test_set_extension_config ${EXTENSION_NAME})
 
 add_executable(test_base_cache_filesystem unit/test_base_cache_filesystem)
 target_link_libraries(test_base_cache_filesystem ${EXTENSION_NAME})
+
+add_executable(test_string_utils unit/test_string_utils)
+target_link_libraries(test_string_utils ${EXTENSION_NAME})
 
 # Benchmark
 add_executable(read_s3_object benchmark/read_s3_object.cpp)

--- a/src/utils/include/string_utils.hpp
+++ b/src/utils/include/string_utils.hpp
@@ -1,0 +1,44 @@
+// Data structure used for immutable buffer.
+// Compared with other buffer representations like `std::vector<char>` and `std::string` it has a few advantages:
+// - It supports creation with no initialization (aka, no `memset`).
+// - It's cheap to copy and move.
+// - One pointer indirection to actual content.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <memory>
+
+namespace duckdb {
+
+struct ImmutableBuffer {
+	std::shared_ptr<char[]> buffer;
+	std::size_t buf_size;
+
+	ImmutableBuffer(std::size_t size) : buffer(new char[size]), buf_size(size) {
+	}
+
+	// Get pointer to content.
+	const char *Data() const {
+		return buffer.get();
+	}
+	// Get size of the buffer.
+	std::size_t Size() const {
+		return buf_size;
+	}
+};
+
+// Compare with std::string.
+bool operator==(const ImmutableBuffer &buffer1, const std::string &buffer2);
+inline bool operator==(const std::string &buffer1, const ImmutableBuffer &buffer2) {
+	return buffer2 == buffer1;
+}
+inline bool operator!=(const ImmutableBuffer &buffer1, const std::string &buffer2) {
+	return !(buffer1 == buffer2);
+}
+inline bool operator!=(const std::string &buffer1, const ImmutableBuffer &buffer2) {
+	return !(buffer1 == buffer2);
+}
+
+} // namespace duckdb

--- a/src/utils/include/string_utils.hpp
+++ b/src/utils/include/string_utils.hpp
@@ -20,12 +20,16 @@ struct ImmutableBuffer {
 	}
 
 	// Get pointer to content.
-	const char *Data() const {
+	const char *data() const {
 		return buffer.get();
 	}
 	// Get size of the buffer.
-	std::size_t Size() const {
+	std::size_t size() const {
 		return buf_size;
+	}
+	// Whether the buffer is empty.
+	bool empty() const {
+		return buf_size == 0;
 	}
 };
 

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -1,0 +1,19 @@
+#include "string_utils.hpp"
+
+#include "duckdb/common/helper.hpp"
+
+namespace duckdb {
+
+bool operator==(const ImmutableBuffer &buffer1, const std::string &buffer2) {
+	if (buffer1.Size() != buffer2.length()) {
+		return false;
+	}
+	for (size_t idx = 0; idx < buffer1.Size(); ++idx) {
+		if (buffer1.Data()[idx] != buffer2[idx]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+} // namespace duckdb

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -5,11 +5,11 @@
 namespace duckdb {
 
 bool operator==(const ImmutableBuffer &buffer1, const std::string &buffer2) {
-	if (buffer1.Size() != buffer2.length()) {
+	if (buffer1.size() != buffer2.length()) {
 		return false;
 	}
-	for (size_t idx = 0; idx < buffer1.Size(); ++idx) {
-		if (buffer1.Data()[idx] != buffer2[idx]) {
+	for (size_t idx = 0; idx < buffer1.size(); ++idx) {
+		if (buffer1.data()[idx] != buffer2[idx]) {
 			return false;
 		}
 	}

--- a/unit/test_copiable_value_lru_cache.cpp
+++ b/unit/test_copiable_value_lru_cache.cpp
@@ -1,0 +1,128 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include <atomic>
+#include <future>
+#include <string>
+#include <thread>
+#include <tuple>
+
+#include "copiable_value_lru_cache.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+struct MapKey {
+	std::string fname;
+	uint64_t off;
+};
+struct MapKeyEqual {
+	bool operator()(const MapKey &lhs, const MapKey &rhs) const {
+		return std::tie(lhs.fname, lhs.off) == std::tie(rhs.fname, rhs.off);
+	}
+};
+struct MapKeyHash {
+	std::size_t operator()(const MapKey &key) const {
+		return std::hash<std::string> {}(key.fname) ^ std::hash<uint64_t> {}(key.off);
+	}
+};
+} // namespace
+
+TEST_CASE("PutAndGetSameKey", "[shared lru test]") {
+	ThreadSafeCopiableValLruCache<std::string, std::string> cache {1};
+
+	// No value initially.
+	auto val = cache.Get("1");
+	REQUIRE(val.empty());
+
+	// Check put and get.
+	cache.Put("1", std::string("1"));
+	val = cache.Get("1");
+	REQUIRE(!val.empty());
+	REQUIRE(val == "1");
+
+	// Check key eviction.
+	cache.Put("2", std::string("2"));
+	val = cache.Get("1");
+	REQUIRE(val.empty());
+	val = cache.Get("2");
+	REQUIRE(!val.empty());
+	REQUIRE(val == "2");
+
+	// Check deletion.
+	REQUIRE(!cache.Delete("1"));
+	REQUIRE(cache.Delete("2"));
+	val = cache.Get("2");
+	REQUIRE(val.empty());
+}
+
+TEST_CASE("CustomizedStruct", "[shared lru test]") {
+	ThreadSafeCopiableValLruCache<MapKey, std::string, MapKeyHash, MapKeyEqual> cache {1};
+	MapKey key;
+	key.fname = "hello";
+	key.off = 10;
+	cache.Put(key, std::string("world"));
+
+	MapKey lookup_key;
+	lookup_key.fname = key.fname;
+	lookup_key.off = key.off;
+	auto val = cache.Get(lookup_key);
+	REQUIRE(!val.empty());
+	REQUIRE(val == "world");
+}
+
+TEST_CASE("Clear with filter test", "[shared lru test]") {
+	ThreadSafeCopiableValLruCache<std::string, std::string> cache {3};
+	cache.Put("key1", std::string("val1"));
+	cache.Put("key2", std::string("val2"));
+	cache.Put("key3", std::string("val3"));
+	cache.Clear([](const std::string &key) { return key >= "key2"; });
+
+	// Still valid keys.
+	auto val = cache.Get("key1");
+	REQUIRE(!val.empty());
+	REQUIRE(val == "val1");
+
+	// Non-existent keys.
+	val = cache.Get("key2");
+	REQUIRE(val.empty());
+	val = cache.Get("key3");
+	REQUIRE(val.empty());
+}
+
+TEST_CASE("GetOrCreate test", "[shared lru test]") {
+	using CacheType = ThreadSafeCopiableValLruCache<std::string, std::string>;
+
+	std::atomic<bool> invoked = {false}; // Used to check only invoke once.
+	auto factory = [&invoked](const std::string &key) -> std::string {
+		REQUIRE(!invoked.exchange(true));
+		// Sleep for a while so multiple threads could kick in and get blocked.
+		std::this_thread::sleep_for(std::chrono::seconds(3));
+		return key;
+	};
+
+	CacheType cache {1};
+
+	constexpr size_t kFutureNum = 100;
+	std::vector<std::future<std::string>> futures;
+	futures.reserve(kFutureNum);
+
+	const std::string key = "key";
+	for (size_t idx = 0; idx < kFutureNum; ++idx) {
+		futures.emplace_back(
+		    std::async(std::launch::async, [&cache, &key, &factory]() { return cache.GetOrCreate(key, factory); }));
+	}
+	for (auto &fut : futures) {
+		auto val = fut.get();
+		REQUIRE(val == key);
+	}
+
+	// After we're sure key-value pair exists in cache, make one more call.
+	auto cached_val = cache.GetOrCreate(key, factory);
+	REQUIRE(cached_val == key);
+}
+
+int main(int argc, char **argv) {
+	int result = Catch::Session().run(argc, argv);
+	return result;
+}

--- a/unit/test_string_utils.cpp
+++ b/unit/test_string_utils.cpp
@@ -1,0 +1,30 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "string_utils.hpp"
+
+using namespace duckdb;  // NOLINT
+
+namespace {
+constexpr std::size_t kBufSize = 10;
+}  // namespace
+
+TEST_CASE("StringUtilsTest", "ImmutableBuffer") {
+    ImmutableBuffer buffer(kBufSize);
+    std::memmove(/*dst=*/const_cast<char*>(buffer.Data()), /*src=*/"helloworld", kBufSize);
+
+    // Inequal case.
+    const std::string content1 = "hello world";
+    REQUIRE(buffer != content1);
+    REQUIRE(content1 != buffer);
+
+    // Equal case.
+    const std::string content2 = "helloworld";
+    REQUIRE(buffer == content2);
+    REQUIRE(content2 == buffer);
+}
+
+int main(int argc, char **argv) {
+	int result = Catch::Session().run(argc, argv);
+	return result;
+}

--- a/unit/test_string_utils.cpp
+++ b/unit/test_string_utils.cpp
@@ -11,7 +11,7 @@ constexpr std::size_t kBufSize = 10;
 
 TEST_CASE("StringUtilsTest", "ImmutableBuffer") {
     ImmutableBuffer buffer(kBufSize);
-    std::memmove(/*dst=*/const_cast<char*>(buffer.Data()), /*src=*/"helloworld", kBufSize);
+    std::memmove(/*dst=*/const_cast<char*>(buffer.data()), /*src=*/"helloworld", kBufSize);
 
     // Inequal case.
     const std::string content1 = "hello world";


### PR DESCRIPTION
```
struct ImmutableBuffer {
	std::shared_ptr<char[]> buffer;
	std::size_t buf_size;
}
```
is so far the best data structure I could ever think of to represent an immutable buffer.

But unfortunately duckdb extension is only C++14, so we lack two important piece:
- `make_shard_for_overwrite`
- `std::optional`

In the next PR, I will integrate it with in-memory cache reader.