### PR TITLE
[2/N] Integrate immutable buffer with in-memory cache reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(EXTENSION_SOURCES
     src/cache_httpfs_extension.cpp
     src/temp_profile_collector.cpp
     src/utils/filesystem_utils.cpp
-    src/utils/string_utils.cpp
+    src/utils/immutable_buffer.cpp
     src/utils/thread_pool.cpp
     src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -32,9 +32,9 @@ struct CacheReadChunk {
 	idx_t bytes_to_copy = 0;
 
 	// Copy from [content] to application-provided buffer.
-	void CopyBufferToRequestedMemory(const std::string &content) {
+	void CopyBufferToRequestedMemory(const ImmutableBuffer &buffer) {
 		const idx_t delta_offset = requested_start_offset - aligned_start_offset;
-		std::memmove(requested_start_addr, const_cast<char *>(content.data()) + delta_offset, bytes_to_copy);
+		std::memmove(requested_start_addr, const_cast<char *>(buffer.data()) + delta_offset, bytes_to_copy);
 	}
 };
 
@@ -113,30 +113,30 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 			block_key.blk_size = cache_read_chunk.chunk_size;
 			auto cache_block = cache->Get(block_key);
 
-			if (cache_block != nullptr) {
+			if (!cache_block.empty()) {
 				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
 				                                     BaseProfileCollector::CacheAccess::kCacheHit);
-				cache_read_chunk.CopyBufferToRequestedMemory(*cache_block);
+				cache_read_chunk.CopyBufferToRequestedMemory(cache_block);
 				return;
 			}
 
 			// We suffer a cache loss, fallback to remote access then local filesystem write.
 			profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
 			                                     BaseProfileCollector::CacheAccess::kCacheMiss);
-			auto content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
+			ImmutableBuffer content {cache_read_chunk.chunk_size};
 			auto &in_mem_cache_handle = handle.Cast<CacheFileSystemHandle>();
 
 			const string oper_id = profile_collector->GetOperId();
 			profile_collector->RecordOperationStart(oper_id);
 			internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle, const_cast<char *>(content.data()),
-			                          content.length(), cache_read_chunk.aligned_start_offset);
+			                          content.size(), cache_read_chunk.aligned_start_offset);
 			profile_collector->RecordOperationEnd(oper_id);
 
 			// Copy to destination buffer.
 			cache_read_chunk.CopyBufferToRequestedMemory(content);
 
 			// Attempt to cache file locally.
-			cache->Put(std::move(block_key), make_shared_ptr<std::string>(std::move(content)));
+			cache->Put(std::move(block_key), std::move(content));
 		});
 	}
 	io_threads.Wait();

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -5,12 +5,13 @@
 #include "base_cache_reader.hpp"
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
+#include "copiable_value_lru_cache.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "immutable_buffer.hpp"
 #include "in_mem_cache_block.hpp"
-#include "lru_cache.hpp"
 
 namespace duckdb {
 
@@ -30,7 +31,8 @@ public:
 	                  uint64_t requested_bytes_to_read, uint64_t file_size) override;
 
 private:
-	using InMemCache = ThreadSafeSharedLruCache<InMemCacheBlock, string, InMemCacheBlockHash, InMemCacheBlockEqual>;
+	using InMemCache =
+	    ThreadSafeCopiableValLruCache<InMemCacheBlock, ImmutableBuffer, InMemCacheBlockHash, InMemCacheBlockEqual>;
 
 	// Once flag to guard against cache's initialization.
 	std::once_flag cache_init_flag;

--- a/src/utils/immutable_buffer.cpp
+++ b/src/utils/immutable_buffer.cpp
@@ -1,4 +1,4 @@
-#include "string_utils.hpp"
+#include "immutable_buffer.hpp"
 
 #include "duckdb/common/helper.hpp"
 

--- a/src/utils/include/immutable_buffer.hpp
+++ b/src/utils/include/immutable_buffer.hpp
@@ -1,14 +1,16 @@
 // Data structure used for immutable buffer.
-// Compared with other buffer representations like `std::vector<char>` and `std::string` it has a few advantages:
+// Compared with other buffer representations like `std::vector<char>`, `std::string` and `std::shared_ptr<std::string>`
+// it has a few advantages:
 // - It supports creation with no initialization (aka, no `memset`).
 // - It's cheap to copy and move.
 // - One pointer indirection to actual content.
+// - One heap allocation.
 
 #pragma once
 
 #include <cstddef>
-#include <string>
 #include <memory>
+#include <string>
 
 namespace duckdb {
 
@@ -16,8 +18,15 @@ struct ImmutableBuffer {
 	std::shared_ptr<char[]> buffer;
 	std::size_t buf_size;
 
+	ImmutableBuffer() : buffer(nullptr), buf_size(0) {
+	}
 	ImmutableBuffer(std::size_t size) : buffer(new char[size]), buf_size(size) {
 	}
+
+	ImmutableBuffer(const ImmutableBuffer &) = default;
+	ImmutableBuffer &operator=(const ImmutableBuffer &) = default;
+	ImmutableBuffer(ImmutableBuffer &&) = default;
+	ImmutableBuffer &operator=(ImmutableBuffer &&) = default;
 
 	// Get pointer to content.
 	const char *data() const {

--- a/unit/test_string_utils.cpp
+++ b/unit/test_string_utils.cpp
@@ -1,7 +1,7 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-#include "string_utils.hpp"
+#include "immutable_buffer.hpp"
 
 using namespace duckdb;  // NOLINT
 


### PR DESCRIPTION
This PR integrate immutable buffer into in-memory cache reader;
compared with previous `std::shared_ptr<std::string>`, we save one pointer direction and memory allocation for every access, thus better cache locality.