### PR TITLE
Add test for `read_parquet`

### DIFF
--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -4,6 +4,8 @@
 
 require cache_httpfs
 
+require parquet
+
 statement ok
 SET cache_httpfs_type='on_disk';
 
@@ -544,6 +546,12 @@ query I
 SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
 ----
 1
+
+# Query parquet file.
+query I
+SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.parquet');
+----
+7433139
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok

--- a/test/sql/inmem_cache_filesystem.test
+++ b/test/sql/inmem_cache_filesystem.test
@@ -4,6 +4,8 @@
 
 require cache_httpfs
 
+require parquet
+
 statement ok
 SET cache_httpfs_type='in_mem';
 
@@ -534,6 +536,12 @@ query I
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
+
+# Query parquet file.
+query I
+SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.parquet');
+----
+7433139
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok

--- a/test/sql/noop_cache_filesystem.test
+++ b/test/sql/noop_cache_filesystem.test
@@ -4,6 +4,8 @@
 
 require cache_httpfs
 
+require parquet
+
 statement ok
 SET cache_httpfs_type='noop';
 
@@ -537,6 +539,12 @@ query I
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
+
+# Query parquet file.
+query I
+SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.parquet');
+----
+7433139
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok


### PR DESCRIPTION
Add more test on `read_parquet` function; I use weblink instead of pulling the data into repository (as we did for csv test data) due to its size.