### PR TITLE
Provide SQL function to query in-memory cache status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,11 @@ include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 
 set(EXTENSION_SOURCES
+    src/cache_entry_info.cpp
     src/cache_filesystem.cpp
     src/cache_filesystem_config.cpp
+    src/cache_filesystem_ref_registry.cpp
+    src/cache_status_query_function.cpp
     src/disk_cache_reader.cpp
     src/in_memory_cache_reader.cpp
     src/histogram.cpp

--- a/src/cache_entry_info.cpp
+++ b/src/cache_entry_info.cpp
@@ -1,0 +1,12 @@
+#include "cache_entry_info.hpp"
+
+#include <tuple>
+
+namespace duckdb {
+
+bool operator<(const CacheEntryInfo &lhs, const CacheEntryInfo &rhs) {
+	return std::tie(lhs.cache_filepath, lhs.remote_filename, lhs.start_offset, lhs.end_offset, lhs.cache_type) <
+	       std::tie(rhs.cache_filepath, rhs.remote_filename, rhs.start_offset, rhs.end_offset, rhs.cache_type);
+}
+
+} // namespace duckdb

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -12,6 +12,17 @@ CacheFileSystemHandle::CacheFileSystemHandle(unique_ptr<FileHandle> internal_fil
       internal_file_handle(std::move(internal_file_handle_p)) {
 }
 
+vector<BaseCacheReader *> CacheFileSystem::GetCacheReaders() const {
+	vector<BaseCacheReader *> cache_readers;
+	if (in_mem_cache_reader != nullptr) {
+		cache_readers.emplace_back(in_mem_cache_reader.get());
+	}
+	if (on_disk_cache_reader != nullptr) {
+		cache_readers.emplace_back(on_disk_cache_reader.get());
+	}
+	return cache_readers;
+}
+
 void CacheFileSystem::SetMetadataCache() {
 	if (!g_enable_metadata_cache) {
 		metadata_cache = nullptr;

--- a/src/cache_filesystem_ref_registry.cpp
+++ b/src/cache_filesystem_ref_registry.cpp
@@ -1,0 +1,24 @@
+#include "cache_filesystem_ref_registry.hpp"
+
+#include "cache_filesystem.hpp"
+
+namespace duckdb {
+
+/*static*/ CacheFsRefRegistry &CacheFsRefRegistry::Get() {
+	static CacheFsRefRegistry registry;
+	return registry;
+}
+
+void CacheFsRefRegistry::Register(CacheFileSystem *fs) {
+	cache_filesystems.emplace_back(fs);
+}
+
+void CacheFsRefRegistry::Reset() {
+	cache_filesystems.clear();
+}
+
+const vector<CacheFileSystem *> &CacheFsRefRegistry::GetAllCacheFs() const {
+	return cache_filesystems;
+}
+
+} // namespace duckdb

--- a/src/cache_status_query_function.cpp
+++ b/src/cache_status_query_function.cpp
@@ -1,0 +1,127 @@
+#include "cache_status_query_function.hpp"
+
+#include <algorithm>
+
+#include "cache_entry_info.hpp"
+#include "cache_filesystem.hpp"
+#include "cache_filesystem_ref_registry.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension_util.hpp"
+
+namespace duckdb {
+
+namespace {
+
+struct CacheStatusData : public GlobalTableFunctionState {
+	vector<CacheEntryInfo> cache_entries_info;
+
+	// Used to record the progress of emission.
+	uint64_t offset = 0;
+};
+
+unique_ptr<FunctionData> CacheStatusQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+
+	return_types.reserve(5);
+	names.reserve(5);
+
+	// Cache filepath.
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("cache_filepath");
+
+	// Remote object name.
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("remote_filename");
+
+	// Start offset for cache file.
+	return_types.emplace_back(LogicalType::UBIGINT);
+	names.emplace_back("start_offset");
+
+	// End offset for cache file.
+	return_types.emplace_back(LogicalType::UBIGINT);
+	names.emplace_back("end_offset");
+
+	// Cache type.
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("cache_type");
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> CacheStatusQueryFuncInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheStatusData>();
+	auto &entries_info = result->cache_entries_info;
+
+	// Get cache entries information from all cache filesystems and all initialized cache readers.
+	const auto &all_file_systems = CacheFsRefRegistry::Get().GetAllCacheFs();
+	for (const auto *cur_fs : all_file_systems) {
+		auto cache_readers = cur_fs->GetCacheReaders();
+		for (auto *cur_cache_reader : cache_readers) {
+			auto cache_entries_info = cur_cache_reader->GetCacheEntriesInfo();
+			entries_info.reserve(entries_info.size() + cache_entries_info.size());
+
+			for (auto &cur_cache_info : cache_entries_info) {
+				entries_info.emplace_back(cur_cache_info);
+			}
+		}
+	}
+
+	// Sort the cache entries info for better visibility.
+	std::sort(entries_info.begin(), entries_info.end());
+
+	return std::move(result);
+}
+
+void CacheStatusQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheStatusData>();
+
+	// All entries have been emitted.
+	if (data.offset >= data.cache_entries_info.size()) {
+		return;
+	}
+
+	// Start filling in the result buffer.
+	idx_t count = 0;
+	while (data.offset < data.cache_entries_info.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.cache_entries_info[data.offset++];
+		idx_t col = 0;
+
+		// Cache filepath.
+		output.SetValue(col++, count, entry.cache_filepath);
+
+		// Remote filename.
+		output.SetValue(col++, count, entry.remote_filename);
+
+		// Start offset.
+		output.SetValue(col++, count, Value::BIGINT(NumericCast<uint64_t>(entry.start_offset)));
+
+		// End offset.
+		output.SetValue(col++, count, Value::BIGINT(NumericCast<uint64_t>(entry.end_offset)));
+
+		// Cache type.
+		output.SetValue(col++, count, entry.cache_type);
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
+} // namespace
+
+TableFunction GetCacheStatusQueryFunc() {
+	TableFunction cache_status_query_func {/*name=*/"cache_httpfs_cache_status_query",
+	                                       /*arguments=*/ {},
+	                                       /*function=*/CacheStatusQueryTableFunc,
+	                                       /*bind=*/CacheStatusQueryFuncBind,
+	                                       /*init_global=*/CacheStatusQueryFuncInit};
+	return cache_status_query_func;
+}
+
+} // namespace duckdb

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -142,6 +142,26 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 	io_threads.Wait();
 }
 
+vector<CacheEntryInfo> InMemoryCacheReader::GetCacheEntriesInfo() const {
+	if (cache == nullptr) {
+		return {};
+	}
+
+	auto keys = cache->Keys();
+	vector<CacheEntryInfo> cache_entries_info;
+	cache_entries_info.reserve(keys.size());
+	for (auto &cur_key : keys) {
+		cache_entries_info.emplace_back(CacheEntryInfo {
+		    .cache_filepath = "(no disk cache)",
+		    .remote_filename = std::move(cur_key.fname),
+		    .start_offset = cur_key.start_off,
+		    .end_offset = cur_key.start_off + cur_key.blk_size,
+		    .cache_type = "in-mem",
+		});
+	}
+	return cache_entries_info;
+}
+
 void InMemoryCacheReader::ClearCache() {
 	if (cache != nullptr) {
 		cache->Clear();

--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -4,8 +4,10 @@
 
 #include "base_cache_reader.hpp"
 #include "base_profile_collector.hpp"
+#include "cache_entry_info.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 
@@ -17,10 +19,14 @@ public:
 	BaseCacheReader(const BaseCacheReader &) = delete;
 	BaseCacheReader &operator=(const BaseCacheReader &) = delete;
 
-	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache
-	// to local filesystem and return to user.
+	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache to local filesystem and return to
+	// user.
 	virtual void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
 	                          idx_t requested_bytes_to_read, idx_t file_size) = 0;
+
+	// Get status information for all cache entries for the current cache reader. Entries are returned in a random
+	// order.
+	virtual vector<CacheEntryInfo> GetCacheEntriesInfo() const = 0;
 
 	// Clear all cache.
 	virtual void ClearCache() = 0;

--- a/src/include/cache_entry_info.hpp
+++ b/src/include/cache_entry_info.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace duckdb {
+
+struct CacheEntryInfo {
+	std::string cache_filepath;
+	std::string remote_filename;
+	uint64_t start_offset = 0; // Inclusive.
+	uint64_t end_offset = 0;   // Exclusive.
+	std::string cache_type;    // Either in-memory or on-disk.
+};
+
+bool operator<(const CacheEntryInfo &lhs, const CacheEntryInfo &rhs);
+
+} // namespace duckdb

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -40,10 +40,11 @@ public:
 	BaseProfileCollector *GetProfileCollector() const {
 		return profile_collector.get();
 	}
-	// Expose for testing purpose.
 	BaseCacheReader *GetCacheReader() const {
 		return internal_cache_reader;
 	}
+	// Get all cache readers which have been initialized.
+	vector<BaseCacheReader *> GetCacheReaders() const;
 	// Clear cached content for the given filename (whether it's in-memory or on-disk).
 	void ClearCache(const string &fname);
 	// Clear all cached content (whether it's in-memory or on-disk).

--- a/src/include/cache_filesystem_ref_registry.hpp
+++ b/src/include/cache_filesystem_ref_registry.hpp
@@ -1,0 +1,34 @@
+// CacheFsRefRegistry is a singleton registry which stores references for all cache filesystems.
+// The class is not thread-safe.
+
+#pragma once
+
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+// Forward declaration.
+class CacheFileSystem;
+
+class CacheFsRefRegistry {
+public:
+	// Get the singleton instance for the registry.
+	static CacheFsRefRegistry &Get();
+
+	// Register the cache filesystem to the registry.
+	void Register(CacheFileSystem *fs);
+
+	// Reset the registry.
+	void Reset();
+
+	// Get all cache filesystems.
+	const vector<CacheFileSystem *> &GetAllCacheFs() const;
+
+private:
+	CacheFsRefRegistry() = default;
+
+	// The ownership lies in db instance.
+	vector<CacheFileSystem *> cache_filesystems;
+};
+
+} // namespace duckdb

--- a/src/include/cache_status_query_function.hpp
+++ b/src/include/cache_status_query_function.hpp
@@ -1,0 +1,12 @@
+// Function which queries cache status.
+
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+// Get the table function to query cache status.
+TableFunction GetCacheStatusQueryFunc();
+
+} // namespace duckdb

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -26,6 +26,12 @@ public:
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 
+	// TODO(hjiang): Implement getting cache entries for disk cache reader, which should've been initialized at
+	// extension load.
+	vector<CacheEntryInfo> GetCacheEntriesInfo() const override {
+		return {};
+	}
+
 private:
 	// Used to access local cache files.
 	unique_ptr<FileSystem> local_filesystem;

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -29,6 +29,7 @@ public:
 	void ClearCache(const string &fname) override;
 	void ReadAndCache(FileHandle &handle, char *buffer, uint64_t requested_start_offset,
 	                  uint64_t requested_bytes_to_read, uint64_t file_size) override;
+	vector<CacheEntryInfo> GetCacheEntriesInfo() const override;
 
 private:
 	using InMemCache =

--- a/src/include/noop_cache_reader.hpp
+++ b/src/include/noop_cache_reader.hpp
@@ -23,6 +23,10 @@ public:
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 
+	vector<CacheEntryInfo> GetCacheEntriesInfo() const override {
+		return {};
+	}
+
 	virtual std::string GetName() const {
 		return "noop_cache_reader";
 	}

--- a/test/sql/inmem_cache_filesystem.test
+++ b/test/sql/inmem_cache_filesystem.test
@@ -529,6 +529,11 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 250	Africa	Zimbabwe	Victoria Falls Stock Exchange	NULL	2020-11-01
 251	Asia	China	Beijing Stock Exchange	NULL	2021-12-27
 
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
+----
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem
+
 statement ok
 SELECT cache_httpfs_clear_cache();
 
@@ -542,6 +547,13 @@ query I
 SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.parquet');
 ----
 7433139
+
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
+----
+(no disk cache)	https://blobs.duckdb.org/data/taxi_2019_04.parquet	126000000	127000000	in-mem
+(no disk cache)	https://blobs.duckdb.org/data/taxi_2019_04.parquet	127000000	127056503	in-mem
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok


### PR DESCRIPTION
This function provides an insight on in-memory cache status. Example see below:
```
D SELECT * FROM cache_httpfs_cache_status_query();
┌─────────────────┬───────────────────────────────────┬──────────────┬────────────┬────────────┐
│ cache_filepath  │          remote_filename          │ start_offset │ end_offset │ cache_type │
│     varchar     │              varchar              │    uint64    │   uint64   │  varchar   │
├─────────────────┼───────────────────────────────────┼──────────────┼────────────┼────────────┤
│ (no disk cache) │ https://blobs.duckdb.org/data/t…  │    126877696 │  126943232 │ in-mem     │
│ (no disk cache) │ https://blobs.duckdb.org/data/t…  │    126943232 │  127008768 │ in-mem     │
│ (no disk cache) │ https://blobs.duckdb.org/data/t…  │    127008768 │  127056503 │ in-mem     │
└─────────────────┴───────────────────────────────────┴──────────────┴────────────┴────────────┘
```

In the next PR, I will implement the cache status fetching for on-disk cache reader.