### PR TITLE
Query cache status for disk cache

### DIFF
--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -1,6 +1,3 @@
-// TODO(hjiang): Disk cache reader should be initialized at the extension load, otherwise a lot of util functions
-// doesn't know what's inside of the cache.
-
 #define DUCKDB_EXTENSION_MAIN
 
 #include "cache_filesystem.hpp"

--- a/src/cache_reader_manager.cpp
+++ b/src/cache_reader_manager.cpp
@@ -11,6 +11,12 @@ namespace duckdb {
 	return cache_reader_manager;
 }
 
+void CacheReaderManager::InitializeDiskCacheReader() {
+	if (on_disk_cache_reader == nullptr) {
+		on_disk_cache_reader = make_uniq<DiskCacheReader>();
+	}
+}
+
 void CacheReaderManager::SetCacheReader() {
 	if (g_cache_type == NOOP_CACHE_TYPE) {
 		if (noop_cache_reader == nullptr) {

--- a/src/include/cache_reader_manager.hpp
+++ b/src/include/cache_reader_manager.hpp
@@ -23,6 +23,9 @@ public:
 	// Get all cache readers if they're initialized.
 	vector<BaseCacheReader *> GetCacheReaders() const;
 
+	// Initialize disk cache reader if uninitialized.
+	void InitializeDiskCacheReader();
+
 	// Clear cache for all cache readers.
 	void ClearCache();
 

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -27,11 +27,7 @@ public:
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 
-	// TODO(hjiang): Implement getting cache entries for disk cache reader, which should've been initialized at
-	// extension load.
-	vector<CacheEntryInfo> GetCacheEntriesInfo() const override {
-		return {};
-	}
+	vector<CacheEntryInfo> GetCacheEntriesInfo() const override;
 
 private:
 	// Used to access local cache files.

--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -20,6 +20,11 @@ SET cache_httpfs_cache_directory='/tmp/duckdb_cache_httpfs_cache';
 statement ok
 SELECT cache_httpfs_clear_cache();
 
+#query I
+#SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+#----
+#0
+
 # Test uncached query.
 query IIIIII
 SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
@@ -552,6 +557,13 @@ query I
 SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.parquet');
 ----
 7433139
+
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
+----
+/tmp/duckdb_cache_httpfs_cache/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-126000000-1000000	taxi_2019_04.parquet	126000000	127000000	on-disk
+/tmp/duckdb_cache_httpfs_cache/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-127000000-56503	taxi_2019_04.parquet	127000000	127056503	on-disk
+/tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	stock/exchanges.csv	0	16222	on-disk
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok


### PR DESCRIPTION
Followup PR for https://github.com/dentiny/duck-read-cache-fs/pull/107

Example query:
```sql
SELECT * FROM cache_httpfs_cache_status_query();
----
/tmp/duckdb_cache_httpfs_cache/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-126000000-1000000	taxi_2019_04.parquet	126000000	127000000	on-disk
/tmp/duckdb_cache_httpfs_cache/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-127000000-56503	taxi_2019_04.parquet	127000000	127056503	on-disk
/tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	stock/exchanges.csv	0	16222	on-disk
```