### PR TITLE
Ability to wrap and cache all registered filesystems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(EXTENSION_SOURCES
     src/noop_cache_reader.cpp
     src/cache_httpfs_extension.cpp
     src/temp_profile_collector.cpp
+    src/utils/fake_filesystem.cpp
     src/utils/filesystem_utils.cpp
     src/utils/immutable_buffer.cpp
     src/utils/thread_pool.cpp

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -14,8 +14,6 @@
 #include <utility>
 #include <utime.h>
 
-#include <fstream>
-
 namespace duckdb {
 
 namespace {
@@ -142,13 +140,6 @@ void CacheLocal(const CacheReadChunk &chunk, FileSystem &local_filesystem, const
 		                       /*nr_bytes=*/chunk.content.length(),
 		                       /*location=*/0);
 		file_handle->Sync();
-	}
-
-	{
-		std::fstream f {"/tmp/debug-dup-file.log", std::ios::out | std::ios::app};
-		f << "move " << local_temp_file << " to " << local_cache_file << std::endl;
-		f.flush();
-		f.close();
 	}
 
 	// Then atomically move to the target postion to prevent data corruption due to concurrent write.

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <utime.h>
 
-#include <iostream>
+#include <fstream>
 
 namespace duckdb {
 
@@ -142,6 +142,13 @@ void CacheLocal(const CacheReadChunk &chunk, FileSystem &local_filesystem, const
 		                       /*nr_bytes=*/chunk.content.length(),
 		                       /*location=*/0);
 		file_handle->Sync();
+	}
+
+	{
+		std::fstream f {"/tmp/debug-dup-file.log", std::ios::out | std::ios::app};
+		f << "move " << local_temp_file << " to " << local_cache_file << std::endl;
+		f.flush();
+		f.close();
 	}
 
 	// Then atomically move to the target postion to prevent data corruption due to concurrent write.

--- a/src/utils/fake_filesystem.cpp
+++ b/src/utils/fake_filesystem.cpp
@@ -1,0 +1,62 @@
+#include "duckdb/common/string_util.hpp"
+#include "fake_filesystem.hpp"
+
+namespace duckdb {
+
+namespace {
+const std::string FAKE_FILESYSTEM_PREFIX = "/tmp/cache_httpfs_fake_filesystem";
+} // namespace
+
+CacheHttpfsFakeFsHandle::CacheHttpfsFakeFsHandle(string path, unique_ptr<FileHandle> internal_file_handle_p,
+                                                 CacheHttpfsFakeFileSystem &fs)
+    : FileHandle(fs, std::move(path), internal_file_handle_p->GetFlags()),
+      internal_file_handle(std::move(internal_file_handle_p)) {
+}
+CacheHttpfsFakeFileSystem::CacheHttpfsFakeFileSystem() : local_filesystem(LocalFileSystem::CreateLocal()) {
+	local_filesystem->CreateDirectory(FAKE_FILESYSTEM_PREFIX);
+}
+bool CacheHttpfsFakeFileSystem::CanHandleFile(const string &path) {
+	return StringUtil::StartsWith(path, FAKE_FILESYSTEM_PREFIX);
+}
+
+unique_ptr<FileHandle> CacheHttpfsFakeFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+                                                           optional_ptr<FileOpener> opener) {
+	auto file_handle = local_filesystem->OpenFile(path, flags, opener);
+	return make_uniq<CacheHttpfsFakeFsHandle>(path, std::move(file_handle), *this);
+}
+void CacheHttpfsFakeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	local_filesystem->Read(*local_filesystem_handle, buffer, nr_bytes, location);
+}
+int64_t CacheHttpfsFakeFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	return local_filesystem->Read(*local_filesystem_handle, buffer, nr_bytes);
+}
+
+void CacheHttpfsFakeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	local_filesystem->Write(*local_filesystem_handle, buffer, nr_bytes, location);
+}
+int64_t CacheHttpfsFakeFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	return local_filesystem->Write(*local_filesystem_handle, buffer, nr_bytes);
+}
+int64_t CacheHttpfsFakeFileSystem::GetFileSize(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	return local_filesystem->GetFileSize(*local_filesystem_handle);
+}
+void CacheHttpfsFakeFileSystem::FileSync(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	local_filesystem->FileSync(*local_filesystem_handle);
+}
+
+void CacheHttpfsFakeFileSystem::Seek(FileHandle &handle, idx_t location) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	local_filesystem->Seek(*local_filesystem_handle, location);
+}
+idx_t CacheHttpfsFakeFileSystem::SeekPosition(FileHandle &handle) {
+	auto &local_filesystem_handle = handle.Cast<CacheHttpfsFakeFsHandle>().internal_file_handle;
+	return local_filesystem->SeekPosition(*local_filesystem_handle);
+}
+
+} // namespace duckdb

--- a/src/utils/include/fake_filesystem.hpp
+++ b/src/utils/include/fake_filesystem.hpp
@@ -1,0 +1,18 @@
+// A fake filesystem for cache httpfs extension testing purpose.
+
+#pragma once
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/local_file_system.hpp"
+
+namespace duckdb {
+
+// WARNING: fake filesystem is used for testing purpose and shouldn't be used in production.
+class CacheHttpfsFakeFileSystem : public LocalFileSystem {
+public:
+	std::string GetName() const override {
+		return "cache_httpfs_fake_filesystem";
+	}
+};
+
+} // namespace duckdb

--- a/src/utils/include/fake_filesystem.hpp
+++ b/src/utils/include/fake_filesystem.hpp
@@ -7,12 +7,42 @@
 
 namespace duckdb {
 
+// Forward declaration.
+class CacheHttpfsFakeFileSystem;
+
+class CacheHttpfsFakeFsHandle : public FileHandle {
+public:
+	CacheHttpfsFakeFsHandle(string path, unique_ptr<FileHandle> internal_file_handle_p, CacheHttpfsFakeFileSystem &fs);
+	~CacheHttpfsFakeFsHandle() override = default;
+	void Close() override {
+		internal_file_handle->Close();
+	}
+
+	unique_ptr<FileHandle> internal_file_handle;
+};
+
 // WARNING: fake filesystem is used for testing purpose and shouldn't be used in production.
 class CacheHttpfsFakeFileSystem : public LocalFileSystem {
 public:
+	CacheHttpfsFakeFileSystem();
+	bool CanHandleFile(const string &path) override;
 	std::string GetName() const override {
 		return "cache_httpfs_fake_filesystem";
 	}
+
+	// Delegate to local filesystem.
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) override;
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	int64_t GetFileSize(FileHandle &handle) override;
+	void FileSync(FileHandle &handle) override;
+	void Seek(FileHandle &handle, idx_t location) override;
+	idx_t SeekPosition(FileHandle &handle) override;
+
+private:
+	unique_ptr<FileSystem> local_filesystem;
 };
 
 } // namespace duckdb

--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -1,6 +1,6 @@
 # name: test/sql/inmem_cache_filesystem.test
 # description: test cached_fs in-memory read and cache
-# group: [cached_fs]
+# group: [cache_httpfs]
 
 require cache_httpfs
 
@@ -552,18 +552,16 @@ SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
 ----
 1
 
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
+----
+/tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	stock/exchanges.csv	0	16222	on-disk
+
 # Query parquet file.
 query I
 SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.parquet');
 ----
 7433139
-
-query IIIII
-SELECT * FROM cache_httpfs_cache_status_query();
-----
-/tmp/duckdb_cache_httpfs_cache/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-126000000-1000000	taxi_2019_04.parquet	126000000	127000000	on-disk
-/tmp/duckdb_cache_httpfs_cache/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-127000000-56503	taxi_2019_04.parquet	127000000	127056503	on-disk
-/tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	stock/exchanges.csv	0	16222	on-disk
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok

--- a/test/sql/extension.test
+++ b/test/sql/extension.test
@@ -1,6 +1,6 @@
 # name: test/sql/extension.test
 # description: test cached_fs extension loading
-# group: [cached_fs]
+# group: [cache_httpfs]
 
 statement error
 SELECT cache_httpfs_get_cache_size();

--- a/test/sql/inmem_cache_filesystem.test
+++ b/test/sql/inmem_cache_filesystem.test
@@ -1,6 +1,6 @@
 # name: test/sql/inmem_cache_filesystem.test
 # description: test cached_fs in-memory read and cache
-# group: [cached_fs]
+# group: [cache_httpfs]
 
 require cache_httpfs
 
@@ -548,11 +548,14 @@ SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.pa
 ----
 7433139
 
-query IIIII
-SELECT * FROM cache_httpfs_cache_status_query();
+query I
+SELECT COUNT(*) FROM cache_httpfs_cache_status_query() WHERE remote_filename = 'https://blobs.duckdb.org/data/taxi_2019_04.parquet';
 ----
-(no disk cache)	https://blobs.duckdb.org/data/taxi_2019_04.parquet	126000000	127000000	in-mem
-(no disk cache)	https://blobs.duckdb.org/data/taxi_2019_04.parquet	127000000	127056503	in-mem
+117
+
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query() WHERE remote_filename = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv';
+----
 (no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem
 
 # Test cases when cache block size and IO request size is smaller than file size.

--- a/test/sql/noop_cache_filesystem.test
+++ b/test/sql/noop_cache_filesystem.test
@@ -1,6 +1,6 @@
 # name: test/sql/noop_cache_filesystem.test
 # description: test cached_fs noop read, which is exactly the same as native duckdb httpfs
-# group: [cached_fs]
+# group: [cache_httpfs]
 
 require cache_httpfs
 

--- a/test/sql/wrap_cache_filesystem.test
+++ b/test/sql/wrap_cache_filesystem.test
@@ -11,3 +11,29 @@ Invalid Input Error: Filesystem unregistered_filesystem hasn't been registered y
 
 statement ok
 SELECT cache_httpfs_wrap_cache_filesystem('cache_httpfs_fake_filesystem');
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+# Check read through fake filesystem works fine.
+statement ok
+COPY (SELECT * FROM read_csv('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv')) TO '/tmp/cache_httpfs_fake_filesystem/stock-exchanges.csv';
+
+# Clear cache after COPY, because reading from httfs already leads to local cache files.
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+query I
+SELECT COUNT(*) FROM read_csv('/tmp/cache_httpfs_fake_filesystem/stock-exchanges.csv');
+----
+251
+
+# Check local cache files.
+# File count = 16KiB / 64KiB = 1
+query I
+SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
+----
+1
+
+statement ok
+SELECT cache_httpfs_clear_cache();

--- a/test/sql/wrap_cache_filesystem.test
+++ b/test/sql/wrap_cache_filesystem.test
@@ -1,0 +1,13 @@
+# name: test/sql/wrap_cache_filesystem.test
+# description: test cache httpfs extension wrap feature for filesystem instances other than those in httpfs.
+# group: [cache_httpfs]
+
+require cache_httpfs
+
+statement error
+SELECT cache_httpfs_wrap_cache_filesystem('unregistered_filesystem');
+----
+Invalid Input Error: Filesystem unregistered_filesystem hasn't been registered yet!
+
+statement ok
+SELECT cache_httpfs_wrap_cache_filesystem('cache_httpfs_fake_filesystem');

--- a/unit/test_filesystem_utils.cpp
+++ b/unit/test_filesystem_utils.cpp
@@ -10,8 +10,6 @@
 
 #include <utime.h>
 
-#include <iostream>
-
 using namespace duckdb; // NOLINT
 
 namespace {


### PR DESCRIPTION
This PR registers an extension function, which allows users to wrap all possible filesystem with cache httpfs filesystem.

Also update duckdb to commit `981c7a8573b254f8efd6b71f764c5c3bd924a53d`.