### PR TITLE
Register customized filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Key features:
   + profiling is by default disabled
 - 100% Compatibility with duckdb `httpfs`
   + Extension is built upon `httpfs` extension and automatically load it beforehand, so it's fully compatible with it; we provide option `SET cache_httpfs_type='noop';` to fallback to and behave exactly as httpfs.
-- Able to wrap **ALL** duckdb-compatible with one simple SQL `SELECT cache_httpfs_wrap_cache_filesystem(<your-fs>)`, and get all the benefit of caching, parallel read, IO performance stats, you name it.
+- Able to wrap **ALL** duckdb-compatible filesystem with one simple SQL `SELECT cache_httpfs_wrap_cache_filesystem(<your-fs>)`, and get all the benefit of caching, parallel read, IO performance stats, you name it.
 
 Caveat:
 - The extension is implemented for object storage, which is expected to be read-heavy workload and (mostly) immutable, so it only supports read cache (at the moment), cache won't be cleared on write operation for the same object.

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -117,7 +117,10 @@ static void WrapCacheFileSystem(const DataChunk &args, ExpressionState &state, V
 	if (internal_filesystem == nullptr) {
 		throw InvalidInputException("Filesystem %s hasn't been registered yet!", filesystem_name);
 	}
-	vfs.RegisterSubSystem(make_uniq<CacheFileSystem>(std::move(internal_filesystem)));
+
+	auto cache_filesystem = make_uniq<CacheFileSystem>(std::move(internal_filesystem));
+	CacheFsRefRegistry::Get().Register(cache_filesystem.get());
+	vfs.RegisterSubSystem(std::move(cache_filesystem));
 
 	constexpr bool SUCCESS = true;
 	result.Reference(Value(SUCCESS));

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -240,16 +240,13 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 			    GetLocalCacheFile(g_on_disk_cache_directory, handle.GetPath(), cache_read_chunk.aligned_start_offset,
 			                      cache_read_chunk.chunk_size);
 
-			// TODO(hjiang): Add documentation and implementation for stale cache eviction policy, before that it's safe
-			// to access cache file directly.
 			if (local_filesystem->FileExists(local_cache_file)) {
 				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
 				                                     BaseProfileCollector::CacheAccess::kCacheHit);
 				auto file_handle = local_filesystem->OpenFile(local_cache_file, FileOpenFlags::FILE_FLAGS_READ);
 				void *addr = !cache_read_chunk.content.empty() ? const_cast<char *>(cache_read_chunk.content.data())
 				                                               : cache_read_chunk.requested_start_addr;
-				local_filesystem->Read(*file_handle, addr, cache_read_chunk.chunk_size,
-				                       /*location=*/0);
+				local_filesystem->Read(*file_handle, addr, cache_read_chunk.chunk_size, /*location=*/0);
 				cache_read_chunk.CopyBufferToRequestedMemory();
 
 				// Update access and modification timestamp for the cache file, so it


### PR DESCRIPTION
Certain functions (i.e. getting filesystem profiles) relies on registered filesystem instances, and we should register customized filesystems also.