### PR TITLE
Mention ccache on contribution doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@
 
 ## Building
 
+* Install `ccache` to improve compilation speed.
 * To pull latest dependencies, run `git submodule update --init --recursive`.
 * To build the project, run `CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make <debug>`.
 


### PR DESCRIPTION
Did some experiment on how `ccache` helps improve compilation speed.

Commands to rebuild:
- delete all already built targets: `make clean`
- clean up page cache: `sudo sync; sudo sh -c "echo 3 > /proc/sys/vm/drop_caches"`
- rebuild from scratch: `time CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) make`

Without `ccache`
```sh
real    3m25.561s
user    64m55.043s
sys     2m51.529s
```
With `ccache` and cache hit:
```sh
real    0m56.167s
user    2m41.581s
sys     0m30.165s
```