### PR TITLE
Make lru cache entries eventual consistency

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -23,7 +23,7 @@ void CacheFileSystem::SetMetadataCache() {
 		return;
 	}
 	if (metadata_cache == nullptr) {
-		metadata_cache = make_uniq<MetadataCache>(MAX_METADATA_ENTRY);
+		metadata_cache = make_uniq<MetadataCache>(g_max_metadata_entry, g_metadata_cache_entry_size);
 	}
 }
 

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -42,7 +42,9 @@ struct CacheReadChunk {
 
 void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
                                        idx_t requested_bytes_to_read, idx_t file_size) {
-	std::call_once(cache_init_flag, [this]() { cache = make_uniq<InMemCache>(g_max_in_mem_cache_block_count); });
+	std::call_once(cache_init_flag, [this]() {
+		cache = make_uniq<InMemCache>(g_max_in_mem_cache_block_count, g_in_mem_cache_block_timeout_millisec);
+	});
 
 	const idx_t block_size = g_cache_block_size;
 	const idx_t aligned_start_offset = requested_start_offset / block_size * block_size;

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -186,8 +186,6 @@ private:
 	CacheReaderManager &cache_reader_manager;
 	// Used to profile operations.
 	unique_ptr<BaseProfileCollector> profile_collector;
-	// Max number of cache entries for file metadata cache.
-	inline static constexpr size_t MAX_METADATA_ENTRY = 125;
 	using MetadataCache = ThreadSafeSharedLruConstCache<string, FileMetadata>;
 	// Metadata cache, which maps from file name to metadata.
 	unique_ptr<MetadataCache> metadata_cache;

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -39,10 +39,20 @@ inline std::string DEFAULT_CACHE_TYPE = ON_DISK_CACHE_TYPE;
 
 // To prevent go out of disk space, we set a threshold to disallow local caching if insufficient. It applies to all
 // filesystems. The value here is the decimal representation for percentage value; for example, 0.05 means 5%.
-inline const double MIN_DISK_SPACE_PERCENTAGE_FOR_CACHE = 0.05;
+inline constexpr double MIN_DISK_SPACE_PERCENTAGE_FOR_CACHE = 0.05;
 
 // Maximum in-memory cache block number, which caps the overall memory consumption as (block size * max block count).
-inline const idx_t DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
+inline constexpr idx_t DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
+
+// Default timeout in seconds for in-memory block cache entries (which meand no timeout).
+// TODO(hjiang): Use a better default timeout value after we make it configurable, say, 1 hour.
+inline constexpr idx_t DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC = 0;
+
+// Max number of cache entries for file metadata cache.
+inline static constexpr size_t DEFAULT_MAX_METADATA_ENTRY = 125;
+
+// Timeout in milliseconds of cache entries for file metadata cache.
+inline static constexpr uint64_t DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC = 0;
 
 // Number of seconds which we define as the threshold of staleness.
 inline constexpr idx_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
@@ -69,6 +79,9 @@ inline idx_t DEFAULT_MIN_DISK_BYTES_FOR_CACHE = 0;
 inline idx_t g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
 inline std::string g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
 inline idx_t g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
+inline idx_t g_in_mem_cache_block_timeout_millisec = DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC;
+inline idx_t g_max_metadata_entry = DEFAULT_MAX_METADATA_ENTRY;
+inline idx_t g_metadata_cache_entry_size = DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC;
 inline std::string g_cache_type = DEFAULT_CACHE_TYPE;
 inline std::string g_profile_type = DEFAULT_PROFILE_TYPE;
 inline uint64_t g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;

--- a/src/utils/include/lru_cache.hpp
+++ b/src/utils/include/lru_cache.hpp
@@ -20,6 +20,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/vector.hpp"
 #include "map_utils.hpp"
+#include "time_utils.hpp"
 
 namespace duckdb {
 
@@ -31,8 +32,11 @@ public:
 	using hasher = KeyHash;
 	using key_equal = KeyEqual;
 
-	// A `max_entries` of 0 means that there is no limit on the number of entries in the cache.
-	explicit SharedLruCache(size_t max_entries_p) : max_entries(max_entries_p) {
+	// @param max_entries_p: A `max_entries` of 0 means that there is no limit on the number of entries in the cache.
+	// @param timeout_millisec_p: Timeout in milliseconds for entries, exceeding which invalidates the cache entries; 0
+	// means no timeout.
+	SharedLruCache(size_t max_entries_p, uint64_t timeout_millisec_p)
+	    : max_entries(max_entries_p), timeout_millisec(timeout_millisec_p) {
 	}
 
 	// Disable copy and move.
@@ -44,7 +48,11 @@ public:
 	// Insert `value` with key `key`. This will replace any previous entry with the same key.
 	void Put(Key key, shared_ptr<Val> value) {
 		lru_list.emplace_front(key);
-		Entry new_entry {std::move(value), lru_list.begin()};
+		Entry new_entry {
+		    .value = std::move(value),
+		    .timestamp = static_cast<uint64_t>(GetSteadyNowMilliSecSinceEpoch()),
+		    .lru_iterator = lru_list.begin(),
+		};
 		auto key_cref = std::cref(lru_list.front());
 		entry_map[key_cref] = std::move(new_entry);
 
@@ -62,8 +70,7 @@ public:
 		if (it == entry_map.end()) {
 			return false;
 		}
-		lru_list.erase(it->second.lru_iterator);
-		entry_map.erase(it);
+		DeleteImpl(it);
 		return true;
 	}
 
@@ -74,6 +81,16 @@ public:
 		if (entry_map_iter == entry_map.end()) {
 			return nullptr;
 		}
+
+		// Check whether found cache entry is expired or not.
+		if (timeout_millisec > 0) {
+			const auto now = GetSteadyNowMilliSecSinceEpoch();
+			if (now - entry_map_iter->second.timestamp > timeout_millisec) {
+				DeleteImpl(entry_map_iter);
+				return nullptr;
+			}
+		}
+
 		lru_list.splice(lru_list.begin(), lru_list, entry_map_iter->second.lru_iterator);
 		return entry_map_iter->second.value;
 	}
@@ -108,6 +125,11 @@ private:
 		// The entry's value.
 		shared_ptr<Val> value;
 
+		// Steady clock timestamp when current entry was inserted into cache.
+		// 1. It's not updated at later accesses.
+		// 2. It's updated at replace update operations.
+		uint64_t timestamp;
+
 		// A list iterator pointing to the entry's position in the LRU list.
 		typename std::list<Key>::iterator lru_iterator;
 	};
@@ -115,8 +137,17 @@ private:
 	using KeyConstRef = std::reference_wrapper<const Key>;
 	using EntryMap = std::unordered_map<KeyConstRef, Entry, RefHash<KeyHash>, RefEq<KeyEqual>>;
 
+	// Delete key-value pairs indicated by the given entry map iterator [iter] from cache.
+	void DeleteImpl(typename EntryMap::iterator iter) {
+		lru_list.erase(iter->second.lru_iterator);
+		entry_map.erase(iter);
+	}
+
 	// The maximum number of entries in the cache. A value of 0 means there is no limit on entry count.
 	const size_t max_entries;
+
+	// The timeout in seconds for cache entries; entries with exceeding timeout would be invalidated.
+	const uint64_t timeout_millisec;
 
 	// All keys are stored as refernce (`std::reference_wrapper`), and the ownership lies in `lru_list`.
 	EntryMap entry_map;
@@ -138,8 +169,11 @@ public:
 	using hasher = KeyHash;
 	using key_equal = KeyEqual;
 
-	// A `max_entries` of 0 means that there is no limit on the number of entries in the cache.
-	explicit ThreadSafeSharedLruCache(size_t max_entries) : internal_cache(max_entries) {
+	// @param max_entries_p: A `max_entries` of 0 means that there is no limit on the number of entries in the cache.
+	// @param timeout_millisec_p: Timeout in milliseconds for entries, exceeding which invalidates the cache entries; 0
+	// means no timeout.
+	ThreadSafeSharedLruCache(size_t max_entries, uint64_t timeout_millisec)
+	    : internal_cache(max_entries, timeout_millisec) {
 	}
 
 	// Disable copy and move.

--- a/unit/test_copiable_value_lru_cache.cpp
+++ b/unit/test_copiable_value_lru_cache.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <future>
 #include <string>
 #include <thread>
@@ -29,7 +30,7 @@ struct MapKeyHash {
 } // namespace
 
 TEST_CASE("PutAndGetSameKey", "[shared lru test]") {
-	ThreadSafeCopiableValLruCache<std::string, std::string> cache {1};
+	ThreadSafeCopiableValLruCache<std::string, std::string> cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/0};
 
 	// No value initially.
 	auto val = cache.Get("1");
@@ -57,7 +58,8 @@ TEST_CASE("PutAndGetSameKey", "[shared lru test]") {
 }
 
 TEST_CASE("CustomizedStruct", "[shared lru test]") {
-	ThreadSafeCopiableValLruCache<MapKey, std::string, MapKeyHash, MapKeyEqual> cache {1};
+	ThreadSafeCopiableValLruCache<MapKey, std::string, MapKeyHash, MapKeyEqual> cache {/*max_entries_p=*/1,
+	                                                                                   /*timeout_millisec_p=*/0};
 	MapKey key;
 	key.fname = "hello";
 	key.off = 10;
@@ -72,7 +74,7 @@ TEST_CASE("CustomizedStruct", "[shared lru test]") {
 }
 
 TEST_CASE("Clear with filter test", "[shared lru test]") {
-	ThreadSafeCopiableValLruCache<std::string, std::string> cache {3};
+	ThreadSafeCopiableValLruCache<std::string, std::string> cache {/*max_entries_p=*/3, /*timeout_millisec_p=*/0};
 	cache.Put("key1", std::string("val1"));
 	cache.Put("key2", std::string("val2"));
 	cache.Put("key3", std::string("val3"));
@@ -101,7 +103,7 @@ TEST_CASE("GetOrCreate test", "[shared lru test]") {
 		return key;
 	};
 
-	CacheType cache {1};
+	CacheType cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/0};
 
 	constexpr size_t kFutureNum = 100;
 	std::vector<std::future<std::string>> futures;
@@ -120,6 +122,23 @@ TEST_CASE("GetOrCreate test", "[shared lru test]") {
 	// After we're sure key-value pair exists in cache, make one more call.
 	auto cached_val = cache.GetOrCreate(key, factory);
 	REQUIRE(cached_val == key);
+}
+
+TEST_CASE("Put and get with timeout test", "[shared lru test]") {
+	using CacheType = ThreadSafeCopiableValLruCache<std::string, std::string>;
+
+	CacheType cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/500};
+	cache.Put("key", "val");
+
+	// Getting key-value pair right afterwards is able to get the value.
+	auto val = cache.Get("key");
+	REQUIRE(!val.empty());
+	REQUIRE(val == "val");
+
+	// Sleep for a while which exceeds timeout, re-fetch key-value pair fails to get value.
+	std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+	val = cache.Get("key");
+	REQUIRE(val.empty());
 }
 
 int main(int argc, char **argv) {

--- a/unit/test_set_extension_config.cpp
+++ b/unit/test_set_extension_config.cpp
@@ -65,7 +65,7 @@ TEST_CASE("Test on correct config", "[extension config test]") {
 	REQUIRE(!result->HasError());
 }
 
-TEST_CASE("Test on changing extension config change defaul cache dir path setting", "[extension config test]") {
+TEST_CASE("Test on changing extension config change default cache dir path setting", "[extension config test]") {
 	DuckDB db(nullptr);
 	auto &instance = db.instance;
 	auto &fs = instance->GetFileSystem();


### PR DESCRIPTION
Addresses https://github.com/dentiny/duck-read-cache-fs/issues/120, which makes preparation for metadata cache on file handle and glob results.

A small followup TODO for this PR is to make these parameters configurable.