### PR TITLE
Fix left bytes configuration for disk cache

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -23,7 +23,7 @@ void CacheFileSystem::SetMetadataCache() {
 		return;
 	}
 	if (metadata_cache == nullptr) {
-		metadata_cache = make_uniq<MetadataCache>(g_max_metadata_entry, g_metadata_cache_entry_size);
+		metadata_cache = make_uniq<MetadataCache>(g_max_metadata_entry, g_in_mem_cache_block_timeout_millisec);
 	}
 }
 

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -20,12 +20,9 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 
 	Value val;
 
-	// Check and update cache block size if necessary.
-	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_block_size", val);
-	const auto cache_block_size = val.GetValue<uint64_t>();
-	if (cache_block_size > 0) {
-		g_cache_block_size = cache_block_size;
-	}
+	//===--------------------------------------------------------------------===//
+	// Global cache configuration
+	//===--------------------------------------------------------------------===//
 
 	// Check and update cache type if necessary, only assign if setting valid.
 	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_type", val);
@@ -34,13 +31,16 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		g_cache_type = std::move(cache_type_string);
 	}
 
-	// Check and update configuration for max subrequest count.
-	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_max_fanout_subrequest", val);
-	g_max_subrequest_count = val.GetValue<uint64_t>();
-
 	// Testing cache type has higher priority than [g_cache_type].
 	if (!g_test_cache_type.empty()) {
 		g_cache_type = g_test_cache_type;
+	}
+
+	// Check and update cache block size if necessary.
+	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_block_size", val);
+	const auto cache_block_size = val.GetValue<uint64_t>();
+	if (cache_block_size > 0) {
+		g_cache_block_size = cache_block_size;
 	}
 
 	// Check and update profile collector type if necessary, only assign if valid.
@@ -50,30 +50,9 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		g_profile_type = std::move(profile_type_string);
 	}
 
-	// Check and update configurations for on-disk cache type.
-	if (g_cache_type == ON_DISK_CACHE_TYPE) {
-		// Check and update cache directory if necessary.
-		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_directory", val);
-		auto new_on_disk_cache_directory = val.ToString();
-		if (new_on_disk_cache_directory != g_on_disk_cache_directory) {
-			g_on_disk_cache_directory = std::move(new_on_disk_cache_directory);
-			LocalFileSystem::CreateLocal()->CreateDirectory(g_on_disk_cache_directory);
-		}
-	}
-
-	// Check and update configurations for in-memory cache type.
-	if (g_cache_type == IN_MEM_CACHE_TYPE) {
-		// Check and update max cache block count.
-		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_max_in_mem_cache_block_count", val);
-		const auto in_mem_block_count = val.GetValue<uint64_t>();
-		if (in_mem_block_count > 0) {
-			g_max_in_mem_cache_block_count = in_mem_block_count;
-		}
-	}
-
-	// Check and update configurations for metadata cache enablement.
-	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_enable_metadata_cache", val);
-	g_enable_metadata_cache = val.GetValue<bool>();
+	// Check and update configuration for max subrequest count.
+	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_max_fanout_subrequest", val);
+	g_max_subrequest_count = val.GetValue<uint64_t>();
 
 	// Check and update configurations to ignore SIGPIPE if necessary.
 	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_ignore_sigpipe", val);
@@ -84,21 +63,87 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		std::signal(SIGPIPE, SIG_IGN);
 	}
 
-	// Check and update configurations for min disk bytes reserved to enable on-disk cache.
+	//===--------------------------------------------------------------------===//
+	// On-disk cache configuration
+	//===--------------------------------------------------------------------===//
+
+	// Check and update configurations for on-disk cache type.
+	if (g_cache_type == ON_DISK_CACHE_TYPE) {
+		// Check and update cache directory if necessary.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_directory", val);
+		auto new_on_disk_cache_directory = val.ToString();
+		if (new_on_disk_cache_directory != g_on_disk_cache_directory) {
+			g_on_disk_cache_directory = std::move(new_on_disk_cache_directory);
+			LocalFileSystem::CreateLocal()->CreateDirectory(g_on_disk_cache_directory);
+		}
+
+		// Check and update min bytes for disk cache.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_min_disk_bytes_for_cache", val);
+		const auto disk_cache_min_bytes = val.GetValue<uint64_t>();
+		if (disk_cache_min_bytes > 0) {
+			g_min_disk_bytes_for_cache = disk_cache_min_bytes;
+		}
+	}
+
+	//===--------------------------------------------------------------------===//
+	// In-mem cache configuration
+	//===--------------------------------------------------------------------===//
+
+	// Check and update configurations for in-memory cache type.
+	if (g_cache_type == IN_MEM_CACHE_TYPE) {
+		// Check and update max cache block count.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_max_in_mem_cache_block_count", val);
+		const auto in_mem_block_count = val.GetValue<uint64_t>();
+		if (in_mem_block_count > 0) {
+			g_max_in_mem_cache_block_count = in_mem_block_count;
+		}
+
+		// Check and update in-memory data block caxche timeout.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_in_mem_cache_block_timeout_millisec", val);
+		g_in_mem_cache_block_timeout_millisec = val.GetValue<uint64_t>();
+	}
+
+	//===--------------------------------------------------------------------===//
+	// Metadata cache configuration
+	//===--------------------------------------------------------------------===//
+
+	// Check and update configurations for metadata cache enablement.
 	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_enable_metadata_cache", val);
-	g_min_disk_bytes_for_cache = val.GetValue<uint64_t>();
+	g_enable_metadata_cache = val.GetValue<bool>();
+
+	// Check and update metadata cache config if enabled.
+	if (g_enable_metadata_cache) {
+		// Check and update cache entry size.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_metadata_cache_entry_size", val);
+		g_max_metadata_entry = val.GetValue<uint64_t>();
+
+		// Check and update cache entry timeout.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_metadata_cache_entry_timeout_millisec", val);
+		g_metadata_cache_entry_timeout_millisec = val.GetValue<uint64_t>();
+	}
 }
 
 void ResetGlobalConfig() {
 	// Intentionally not set [g_test_cache_type] and [g_ignore_sigpipe].
+
+	// Global configuration.
 	g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
-	g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
-	g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
 	g_cache_type = DEFAULT_CACHE_TYPE;
 	g_profile_type = DEFAULT_PROFILE_TYPE;
 	g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
-	g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
+
+	// On-disk cache configuration.
+	g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
 	g_min_disk_bytes_for_cache = DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
+
+	// In-memory cache configuration.
+	g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
+	g_in_mem_cache_block_timeout_millisec = DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC;
+
+	// Metadata cache configuration.
+	g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
+	g_max_metadata_entry = DEFAULT_MAX_METADATA_ENTRY;
+	g_metadata_cache_entry_timeout_millisec = DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC;
 
 	// Reset testing options.
 	g_test_insufficient_disk_space = false;

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -172,23 +172,18 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Register extension configuration.
 	auto &config = DBConfig::GetConfig(instance);
-	config.AddExtensionOption("cache_httpfs_cache_directory", "The disk cache directory that stores cached data",
-	                          LogicalType::VARCHAR, DEFAULT_ON_DISK_CACHE_DIRECTORY);
-	config.AddExtensionOption(
-	    "cache_httpfs_cache_block_size",
-	    "Block size for cache, applies to both in-memory cache filesystem and on-disk cache filesystem. It's worth "
-	    "noting for on-disk filesystem, all existing cache files are invalidated after config update.",
-	    LogicalType::UBIGINT, Value::UBIGINT(DEFAULT_CACHE_BLOCK_SIZE));
-	config.AddExtensionOption("cache_httpfs_max_in_mem_cache_block_count",
-	                          "Max in-memory cache block count for in-memory caches for all cache filesystems, so "
-	                          "users are able to configure the maximum memory consumption. It's worth noting it "
-	                          "should be set only once before all filesystem access, otherwise there's no affect.",
-	                          LogicalType::UBIGINT, Value::UBIGINT(DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT));
+
+	// Global configurations.
 	config.AddExtensionOption("cache_httpfs_type",
 	                          "Type for cached filesystem. Currently there're two types available, one is `in_mem`, "
 	                          "another is `on_disk`. By default we use on-disk cache. Set to `noop` to disable, which "
 	                          "behaves exactly same as httpfs extension.",
 	                          LogicalType::VARCHAR, ON_DISK_CACHE_TYPE);
+	config.AddExtensionOption(
+	    "cache_httpfs_cache_block_size",
+	    "Block size for cache, applies to both in-memory cache filesystem and on-disk cache filesystem. It's worth "
+	    "noting for on-disk filesystem, all existing cache files are invalidated after config update.",
+	    LogicalType::UBIGINT, Value::UBIGINT(DEFAULT_CACHE_BLOCK_SIZE));
 	config.AddExtensionOption(
 	    "cache_httpfs_profile_type",
 	    "Profiling type for cached filesystem. There're three options available: `noop`, `temp`, and `duckdb`. `temp` "
@@ -201,19 +196,40 @@ static void LoadInternal(DatabaseInstance &instance) {
 	    "config [cache_httpfs_cache_block_size]. The setting limits the maximum request to issue for a single "
 	    "filesystem read request. 0 means no limit, by default we set no limit.",
 	    LogicalType::BIGINT, 0);
+	config.AddExtensionOption(
+	    "cache_httpfs_ignore_sigpipe",
+	    "Whether to ignore SIGPIPE for the extension. By default not ignored. Once ignored, it cannot be reverted.",
+	    LogicalTypeId::BOOLEAN, DEFAULT_IGNORE_SIGPIPE);
+
+	// On disk cache config.
+	config.AddExtensionOption("cache_httpfs_cache_directory", "The disk cache directory that stores cached data",
+	                          LogicalType::VARCHAR, DEFAULT_ON_DISK_CACHE_DIRECTORY);
 	config.AddExtensionOption("cache_httpfs_min_disk_bytes_for_cache",
 	                          "Min number of bytes on disk for the cache filesystem to enable on-disk cache; if left "
 	                          "bytes is less than the threshold, LRU based cache file eviction will be performed."
 	                          "By default, 5% disk space will be reserved for other usage. When min disk bytes "
 	                          "specified with a positive value, the default value will be overriden.",
 	                          LogicalType::UBIGINT, 0);
+
+	// In-memory cache config.
+	config.AddExtensionOption("cache_httpfs_max_in_mem_cache_block_count",
+	                          "Max in-memory cache block count for in-memory caches for all cache filesystems, so "
+	                          "users are able to configure the maximum memory consumption. It's worth noting it "
+	                          "should be set only once before all filesystem access, otherwise there's no affect.",
+	                          LogicalType::UBIGINT, Value::UBIGINT(DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT));
+	config.AddExtensionOption("cache_httpfs_in_mem_cache_block_timeout_millisec",
+	                          "Data block cache entry timeout in milliseconds.", LogicalTypeId::UBIGINT,
+	                          Value::UBIGINT(DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC));
+
+	// Metadata cache config.
 	config.AddExtensionOption("cache_httpfs_enable_metadata_cache",
 	                          "Whether metadata cache is enable for cache filesystem. By default enabled.",
 	                          LogicalTypeId::BOOLEAN, DEFAULT_ENABLE_METADATA_CACHE);
-	config.AddExtensionOption(
-	    "cache_httpfs_ignore_sigpipe",
-	    "Whether to ignore SIGPIPE for the extension. By default not ignored. Once ignored, it cannot be reverted.",
-	    LogicalTypeId::BOOLEAN, DEFAULT_IGNORE_SIGPIPE);
+	config.AddExtensionOption("cache_httpfs_metadata_cache_entry_size", "Max cache size for metadata LRU cache.",
+	                          LogicalTypeId::UBIGINT, Value::UBIGINT(DEFAULT_MAX_METADATA_ENTRY));
+	config.AddExtensionOption("cache_httpfs_metadata_cache_entry_timeout_millisec",
+	                          "Cache entry timeout in milliseconds for metadata LRU cache.", LogicalTypeId::UBIGINT,
+	                          Value::UBIGINT(DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC));
 
 	// Register cache cleanup function for both in-memory and on-disk cache.
 	ScalarFunction clear_cache_function("cache_httpfs_clear_cache", /*arguments=*/ {},

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -44,15 +44,14 @@ inline constexpr double MIN_DISK_SPACE_PERCENTAGE_FOR_CACHE = 0.05;
 // Maximum in-memory cache block number, which caps the overall memory consumption as (block size * max block count).
 inline constexpr idx_t DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
 
-// Default timeout in seconds for in-memory block cache entries (which meand no timeout).
-// TODO(hjiang): Use a better default timeout value after we make it configurable, say, 1 hour.
-inline constexpr idx_t DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC = 0;
+// Default timeout in seconds for in-memory block cache entries.
+inline constexpr idx_t DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC = 3600ULL * 1000 /*1hour*/;
 
 // Max number of cache entries for file metadata cache.
 inline static constexpr size_t DEFAULT_MAX_METADATA_ENTRY = 125;
 
 // Timeout in milliseconds of cache entries for file metadata cache.
-inline static constexpr uint64_t DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC = 0;
+inline static constexpr uint64_t DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC = 3600ULL * 1000 /*1hour*/;
 
 // Number of seconds which we define as the threshold of staleness.
 inline constexpr idx_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
@@ -76,18 +75,26 @@ inline idx_t DEFAULT_MIN_DISK_BYTES_FOR_CACHE = 0;
 //===--------------------------------------------------------------------===//
 // Global configuration
 //===--------------------------------------------------------------------===//
+
+// Global configuration.
 inline idx_t g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
-inline std::string g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
-inline idx_t g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
-inline idx_t g_in_mem_cache_block_timeout_millisec = DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC;
-inline idx_t g_max_metadata_entry = DEFAULT_MAX_METADATA_ENTRY;
-inline idx_t g_metadata_cache_entry_size = DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC;
+inline bool g_ignore_sigpipe = DEFAULT_IGNORE_SIGPIPE;
 inline std::string g_cache_type = DEFAULT_CACHE_TYPE;
 inline std::string g_profile_type = DEFAULT_PROFILE_TYPE;
 inline uint64_t g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
-inline bool g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
-inline bool g_ignore_sigpipe = DEFAULT_IGNORE_SIGPIPE;
+
+// On-disk cache configuration.
+inline std::string g_on_disk_cache_directory = DEFAULT_ON_DISK_CACHE_DIRECTORY;
 inline idx_t g_min_disk_bytes_for_cache = DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
+
+// In-memory cache configuration.
+inline idx_t g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;
+inline idx_t g_in_mem_cache_block_timeout_millisec = DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC;
+
+// Metadata cache configuration.
+inline bool g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
+inline idx_t g_max_metadata_entry = DEFAULT_MAX_METADATA_ENTRY;
+inline idx_t g_metadata_cache_entry_timeout_millisec = DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC;
 
 // Used for testing purpose, which has a higher priority over [g_cache_type], and won't be reset.
 // TODO(hjiang): A better is bake configuration into `FileOpener`.


### PR DESCRIPTION
This PR does two things:
- Add config setting for metadata cache, to make preparations for file handle cache and glob cache;
- Fix config setting for left bytes for on-disk cache.