### PR TITLE
Add profiler for open and glob

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -276,12 +276,12 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 			auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
 			auto *internal_filesystem = disk_cache_handle.GetInternalFileSystem();
 
-			const string oper_id = profile_collector->GetOperId();
-			profile_collector->RecordOperationStart(oper_id);
+			const string oper_id = profile_collector->GenerateOperId();
+			profile_collector->RecordOperationStart(BaseProfileCollector::IoOperation::kRead, oper_id);
 			internal_filesystem->Read(*disk_cache_handle.internal_file_handle,
 			                          const_cast<char *>(cache_read_chunk.content.data()),
 			                          cache_read_chunk.content.length(), cache_read_chunk.aligned_start_offset);
-			profile_collector->RecordOperationEnd(oper_id);
+			profile_collector->RecordOperationEnd(BaseProfileCollector::IoOperation::kRead, oper_id);
 
 			// Copy to destination buffer.
 			cache_read_chunk.CopyBufferToRequestedMemory();

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -129,11 +129,11 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 			auto &in_mem_cache_handle = handle.Cast<CacheFileSystemHandle>();
 			auto *internal_filesystem = in_mem_cache_handle.GetInternalFileSystem();
 
-			const string oper_id = profile_collector->GetOperId();
-			profile_collector->RecordOperationStart(oper_id);
+			const string oper_id = profile_collector->GenerateOperId();
+			profile_collector->RecordOperationStart(BaseProfileCollector::IoOperation::kRead, oper_id);
 			internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle, const_cast<char *>(content.data()),
 			                          content.size(), cache_read_chunk.aligned_start_offset);
-			profile_collector->RecordOperationEnd(oper_id);
+			profile_collector->RecordOperationEnd(BaseProfileCollector::IoOperation::kRead, oper_id);
 
 			// Copy to destination buffer.
 			cache_read_chunk.CopyBufferToRequestedMemory(content);

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -21,6 +21,13 @@ public:
 		kCacheHit,
 		kCacheMiss,
 	};
+	enum class IoOperation {
+		kOpen,
+		kRead,
+		kGlob,
+		kUnknown,
+	};
+	static constexpr auto kIoOperationCount = static_cast<idx_t>(IoOperation::kUnknown);
 
 	BaseProfileCollector() = default;
 	virtual ~BaseProfileCollector() = default;
@@ -28,11 +35,11 @@ public:
 	BaseProfileCollector &operator=(const BaseProfileCollector &) = delete;
 
 	// Get an ID which uniquely identifies current operation.
-	virtual std::string GetOperId() const = 0;
-	// Record the start of operation [oper].
-	virtual void RecordOperationStart(const std::string &oper) = 0;
-	// Record the finish of operation [oper].
-	virtual void RecordOperationEnd(const std::string &oper) = 0;
+	virtual std::string GenerateOperId() const = 0;
+	// Record the start of operation [io_oper] with operation identifier [oper_id].
+	virtual void RecordOperationStart(IoOperation io_oper, const std::string &oper_id) = 0;
+	// Record the finish of operation [io_oper] with operation identifier [oper_id].
+	virtual void RecordOperationEnd(IoOperation io_oper, const std::string &oper_id) = 0;
 	// Record cache access condition.
 	virtual void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) = 0;
 	// Get profiler type.
@@ -66,12 +73,12 @@ public:
 	NoopProfileCollector() = default;
 	~NoopProfileCollector() override = default;
 
-	std::string GetOperId() const override {
+	std::string GenerateOperId() const override {
 		return "";
 	}
-	void RecordOperationStart(const std::string &oper) override {
+	void RecordOperationStart(IoOperation io_oper, const std::string &oper_id) override {
 	}
-	void RecordOperationEnd(const std::string &oper) override {
+	void RecordOperationEnd(IoOperation io_oper, const std::string &oper_id) override {
 	}
 	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) override {
 	}

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -120,9 +120,7 @@ public:
 	string PathSeparator(const string &path) override {
 		return internal_filesystem->PathSeparator(path);
 	}
-	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
-		return internal_filesystem->Glob(path, opener);
-	}
+	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override;
 	void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
 		internal_filesystem->RegisterSubSystem(std::move(sub_fs));
 	}
@@ -164,6 +162,9 @@ private:
 	struct FileMetadata {
 		int64_t file_size = 0;
 	};
+
+	// Initialize global configurations and global objects (i.e. metadata cache, profiler, etc) in a thread-safe manner.
+	void InitializeGlobalConfig(optional_ptr<FileOpener> opener);
 
 	// Read from [location] on [nr_bytes] for the given [handle] into [buffer].
 	// Return the actual number of bytes to read.

--- a/src/include/histogram.hpp
+++ b/src/include/histogram.hpp
@@ -16,6 +16,11 @@ public:
 	// [min_val] is inclusive, and [max_val] is exclusive.
 	Histogram(double min_val, double max_val, int num_bkt);
 
+	Histogram(const Histogram &) = delete;
+	Histogram &operator=(const Histogram &) = delete;
+	Histogram(Histogram &&) = delete;
+	Histogram &operator=(Histogram &&) = delete;
+
 	// Set the distribution stats name and unit, used for formatting purpose.
 	void SetStatsDistribution(std::string name, std::string unit);
 

--- a/src/noop_cache_reader.cpp
+++ b/src/noop_cache_reader.cpp
@@ -7,11 +7,11 @@ void NoopCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
                                    idx_t requested_bytes_to_read, idx_t file_size) {
 	auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
 	auto *internal_filesystem = disk_cache_handle.GetInternalFileSystem();
-	const string oper_id = profile_collector->GetOperId();
-	profile_collector->RecordOperationStart(oper_id);
+	const string oper_id = profile_collector->GenerateOperId();
+	profile_collector->RecordOperationStart(BaseProfileCollector::IoOperation::kRead, oper_id);
 	internal_filesystem->Read(*disk_cache_handle.internal_file_handle, buffer, requested_bytes_to_read,
 	                          requested_start_offset);
-	profile_collector->RecordOperationEnd(oper_id);
+	profile_collector->RecordOperationEnd(BaseProfileCollector::IoOperation::kRead, oper_id);
 }
 
 } // namespace duckdb


### PR DESCRIPTION
Addresses https://github.com/dentiny/duck-read-cache-fs/issues/119

Test SQL:
```sh
D SET cache_httpfs_profile_type='temp';
D EXPLAIN ANALYZE SELECT i,j FROM read_parquet('s3://duckdb-cache-fs/test_folder/**/*.parquet', hive_partitioning = true, union_by_name=True);
┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││    Query Profiling Information    ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
EXPLAIN ANALYZE SELECT i,j FROM read_parquet('s3://duckdb-cache-fs/test_folder/**/*.parquet', hive_partitioning = true, union_by_name=True);
┌─────────────────────────────────────┐
│┌───────────────────────────────────┐│
││         HTTPFS HTTP Stats         ││
││                                   ││
││            in: 3.5 KiB            ││
││            out: 0 bytes           ││
││              #HEAD: 1             ││
││              #GET: 5              ││
││              #PUT: 0              ││
││              #POST: 0             ││
│└───────────────────────────────────┘│
└─────────────────────────────────────┘
┌────────────────────────────────────────────────┐
│┌──────────────────────────────────────────────┐│
││               Total Time: 1.68s              ││
│└──────────────────────────────────────────────┘│
└────────────────────────────────────────────────┘
┌───────────────────────────┐
│           QUERY           │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│      EXPLAIN_ANALYZE      │
│    ────────────────────   │
│           0 Rows          │
│          (0.00s)          │
└─────────────┬─────────────┘
┌─────────────┴─────────────┐
│         TABLE_SCAN        │
│    ────────────────────   │
│         Function:         │
│        READ_PARQUET       │
│                           │
│        Projections:       │
│             i             │
│             j             │
│                           │
│          100 Rows         │
│          (0.42s)          │
└───────────────────────────┘
D COPY (SELECT cache_httpfs_get_profile()) TO '/tmp/output.txt';
```

And profile result:
```sql
cache_httpfs_get_profile()
"For temp profile collector and stats for on_disk_cache_reader (unit in milliseconds)
metadata cache hit count = 8
metadata cache miss count = 1
data block cache hit count = 2
data block cache miss count = 1

open operation latency is Max latency = 419.000000 millisec
Min latency = 6.000000 millisec
Mean latency = 143.666667 millisec
Distribution latency [0.000000, 10.000000) millisec: 66.666667 %
Distribution latency [410.000000, 420.000000) millisec: 33.333333 %

read operation latency is Max latency = 119.000000 millisec
Min latency = 119.000000 millisec
Mean latency = 119.000000 millisec
Distribution latency [110.000000, 120.000000) millisec: 100.000000 %

glob operation latency is Max latency = 444.000000 millisec
Min latency = 444.000000 millisec
Mean latency = 444.000000 millisec
Distribution latency [440.000000, 450.000000) millisec: 100.000000 %
"
```