### PR TITLE
Get evicted value from lru cache

### DIFF
--- a/src/utils/include/exclusive_lru_cache.hpp
+++ b/src/utils/include/exclusive_lru_cache.hpp
@@ -134,6 +134,18 @@ public:
 		}
 	}
 
+	// Clear the cache and get all values, application could perform their processing logic upon these values.
+	vector<unique_ptr<Val>> ClearAndGetValues() {
+		vector<unique_ptr<Val>> values;
+		values.reserve(entry_map.size());
+		for (auto &[_, cur_entry] : entry_map) {
+			values.emplace_back(std::move(cur_entry.value));
+		}
+		entry_map.clear();
+		lru_list.clear();
+		return values;
+	}
+
 	// Accessors for cache parameters.
 	size_t MaxEntries() const {
 		return max_entries;
@@ -219,6 +231,12 @@ public:
 	unique_ptr<Val> GetAndPop(const Key &key) {
 		std::unique_lock<std::mutex> lock(mu);
 		return internal_cache.GetAndPop(key);
+	}
+
+	// Clear the cache and get all values, application could perform their processing logic upon these values.
+	vector<unique_ptr<Val>> ClearAndGetValues() {
+		std::unique_lock<std::mutex> lock(mu);
+		return internal_cache.ClearAndGetValues();
 	}
 
 	// Clear the cache.

--- a/src/utils/include/exclusive_lru_cache.hpp
+++ b/src/utils/include/exclusive_lru_cache.hpp
@@ -51,7 +51,12 @@ public:
 	~ExclusiveLruCache() = default;
 
 	// Insert `value` with key `key`. This will replace any previous entry with the same key.
-	void Put(Key key, unique_ptr<Val> value) {
+	// Return evicted value if any.
+	//
+	// Reasoning for returning the value back to caller:
+	// 1. Caller is able to do processing for the value.
+	// 2. For thread-safe lru cache, processing could be moved out of critical section.
+	unique_ptr<Val> Put(Key key, unique_ptr<Val> value) {
 		lru_list.emplace_front(key);
 		Entry new_entry {
 		    .value = std::move(value),
@@ -61,11 +66,18 @@ public:
 		auto key_cref = std::cref(lru_list.front());
 		entry_map[key_cref] = std::move(new_entry);
 
+		unique_ptr<Val> evicted_val = nullptr;
 		if (max_entries > 0 && lru_list.size() > max_entries) {
 			const auto &stale_key = lru_list.back();
-			entry_map.erase(stale_key);
+			auto iter = entry_map.find(stale_key);
+			D_ASSERT(iter != entry_map.end());
+			evicted_val = std::move(iter->second.value);
+
+			entry_map.erase(iter);
 			lru_list.pop_back();
 		}
+
+		return evicted_val;
 	}
 
 	// Delete the entry with key `key`. Return true if the entry was found for `key`, false if the entry was not found.
@@ -190,9 +202,9 @@ public:
 	~ThreadSafeExclusiveLruCache() = default;
 
 	// Insert `value` with key `key`. This will replace any previous entry with the same key.
-	void Put(Key key, unique_ptr<Val> value) {
+	unique_ptr<Val> Put(Key key, unique_ptr<Val> value) {
 		std::lock_guard<std::mutex> lock(mu);
-		internal_cache.Put(std::move(key), std::move(value));
+		return internal_cache.Put(std::move(key), std::move(value));
 	}
 
 	// Delete the entry with key `key`. Return true if the entry was found for `key`, false if the entry was not found.

--- a/unit/test_exclusive_lru_cache.cpp
+++ b/unit/test_exclusive_lru_cache.cpp
@@ -63,7 +63,8 @@ TEST_CASE("CustomizedStruct", "[exclusive lru test]") {
 	MapKey key;
 	key.fname = "hello";
 	key.off = 10;
-	cache.Put(key, make_uniq<std::string>("world"));
+	auto evicted = cache.Put(key, make_uniq<std::string>("world"));
+	REQUIRE(evicted == nullptr);
 
 	MapKey lookup_key;
 	lookup_key.fname = key.fname;
@@ -75,9 +76,12 @@ TEST_CASE("CustomizedStruct", "[exclusive lru test]") {
 
 TEST_CASE("Clear with filter test", "[exclusive lru test]") {
 	ThreadSafeExclusiveLruCache<std::string, std::string> cache {/*max_entries_p=*/3, /*timeout_millisec_p=*/0};
-	cache.Put("key1", make_uniq<std::string>("val1"));
-	cache.Put("key2", make_uniq<std::string>("val2"));
-	cache.Put("key3", make_uniq<std::string>("val3"));
+	auto evicted = cache.Put("key1", make_uniq<std::string>("val1"));
+	REQUIRE(evicted == nullptr);
+	evicted = cache.Put("key2", make_uniq<std::string>("val2"));
+	REQUIRE(evicted == nullptr);
+	evicted = cache.Put("key3", make_uniq<std::string>("val3"));
+	REQUIRE(evicted == nullptr);
 	cache.Clear([](const std::string &key) { return key >= "key2"; });
 
 	// Still valid keys.
@@ -96,7 +100,8 @@ TEST_CASE("Put and get with timeout test", "[exclusive lru test]") {
 	using CacheType = ThreadSafeExclusiveLruCache<std::string, std::string>;
 
 	CacheType cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/500};
-	cache.Put("key", make_uniq<std::string>("val"));
+	auto evicted = cache.Put("key", make_uniq<std::string>("val"));
+	REQUIRE(evicted == nullptr);
 
 	// Getting key-value pair right afterwards is able to get the value.
 	auto val = cache.GetAndPop("key");
@@ -107,6 +112,20 @@ TEST_CASE("Put and get with timeout test", "[exclusive lru test]") {
 	std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 	val = cache.GetAndPop("key");
 	REQUIRE(val == nullptr);
+}
+
+TEST_CASE("Evicted value test", "[exclusive lru test]") {
+	using CacheType = ThreadSafeExclusiveLruCache<std::string, std::string>;
+
+	CacheType cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/0};
+	auto evicted = cache.Put("key1", make_uniq<std::string>("val1"));
+	REQUIRE(evicted == nullptr);
+
+	evicted = cache.Put("key2", make_uniq<std::string>("val2"));
+	REQUIRE(*evicted == "val1");
+
+	evicted = cache.Put("key3", make_uniq<std::string>("val3"));
+	REQUIRE(*evicted == "val2");
 }
 
 int main(int argc, char **argv) {

--- a/unit/test_exclusive_lru_cache.cpp
+++ b/unit/test_exclusive_lru_cache.cpp
@@ -126,6 +126,10 @@ TEST_CASE("Evicted value test", "[exclusive lru test]") {
 
 	evicted = cache.Put("key3", make_uniq<std::string>("val3"));
 	REQUIRE(*evicted == "val2");
+
+	auto values = cache.ClearAndGetValues();
+	REQUIRE(values.size() == 1);
+	REQUIRE(*values[0] == "val3");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
I'm working on file handle cache, one thing I found is
- Internal file handle is cached in file handle cache;
- On cache file handle destruction, internal file handle is reset and placed into handle cache;
- To make internal file handle re-usable, cache handle's close function does nothing.

=> We have no way to close internal file handle, which leads to resource leak (i.e. fd).

The way I proposed here is 
- When a new item is kicked out due to LRU eviction policy, we get the value back;
- So we could get the file handle and close out of critical section.