### PR TITLE
Initial implementation for file handle cache

### DIFF
--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -115,7 +115,7 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 	if (g_enable_metadata_cache) {
 		// Check and update cache entry size.
 		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_metadata_cache_entry_size", val);
-		g_max_metadata_entry = val.GetValue<uint64_t>();
+		g_max_metadata_cache_entry = val.GetValue<uint64_t>();
 
 		// Check and update cache entry timeout.
 		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_metadata_cache_entry_timeout_millisec", val);
@@ -142,7 +142,7 @@ void ResetGlobalConfig() {
 
 	// Metadata cache configuration.
 	g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
-	g_max_metadata_entry = DEFAULT_MAX_METADATA_ENTRY;
+	g_max_metadata_cache_entry = DEFAULT_MAX_METADATA_CACHE_ENTRY;
 	g_metadata_cache_entry_timeout_millisec = DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC;
 
 	// Reset testing options.

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -226,10 +226,12 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          "Whether metadata cache is enable for cache filesystem. By default enabled.",
 	                          LogicalTypeId::BOOLEAN, DEFAULT_ENABLE_METADATA_CACHE);
 	config.AddExtensionOption("cache_httpfs_metadata_cache_entry_size", "Max cache size for metadata LRU cache.",
-	                          LogicalTypeId::UBIGINT, Value::UBIGINT(DEFAULT_MAX_METADATA_ENTRY));
+	                          LogicalTypeId::UBIGINT, Value::UBIGINT(DEFAULT_MAX_METADATA_CACHE_ENTRY));
 	config.AddExtensionOption("cache_httpfs_metadata_cache_entry_timeout_millisec",
 	                          "Cache entry timeout in milliseconds for metadata LRU cache.", LogicalTypeId::UBIGINT,
 	                          Value::UBIGINT(DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC));
+
+	// TODO(hjiang): Expose config settings and related functions for file handle cache.
 
 	// Register cache cleanup function for both in-memory and on-disk cache.
 	ScalarFunction clear_cache_function("cache_httpfs_clear_cache", /*arguments=*/ {},

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -14,8 +14,10 @@ namespace duckdb {
 class BaseProfileCollector {
 public:
 	enum class CacheEntity {
-		kMetadata, // File metadata.
-		kData,     // File data block.
+		kMetadata,   // File metadata.
+		kData,       // File data block.
+		kFileHandle, // File handle.
+		kUnknown,
 	};
 	enum class CacheAccess {
 		kCacheHit,
@@ -27,6 +29,7 @@ public:
 		kGlob,
 		kUnknown,
 	};
+	static constexpr auto kCacheEntityCount = static_cast<idx_t>(CacheEntity::kUnknown);
 	static constexpr auto kIoOperationCount = static_cast<idx_t>(IoOperation::kUnknown);
 
 	BaseProfileCollector() = default;

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -7,9 +7,11 @@
 #include "cache_reader_manager.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "exclusive_lru_cache.hpp"
 #include "shared_lru_cache.hpp"
 
 #include <mutex>
+#include <tuple>
 
 namespace duckdb {
 
@@ -17,13 +19,35 @@ namespace duckdb {
 class CacheFileSystem;
 
 // File handle used for cache filesystem.
+//
+// On resource destruction functions (dtor and `Close`), we take different routes on read and write handles.
+// A brief summary on how file handle cache is implemented: the key is a wrapper around open flag and path; the value is
+// the internal file handle.
+// - On cache file handle destruction, if it's read handle, we reset the handle for later reuse and place the internal
+// handle into cache; otherwise we do nothing.
+// - On cache file handle close operation, if it's write handle, we delegate the call to internal handle; we ignore
+// close operation for read handles, because they could be reused, and close usually indicates resource release (i.e.
+// close a file descriptor).
+//
+// For the above design, we suffer resource leak because internal handles are never closed.
+// The way cache file handle resolves this problem is:
+// - When a value is kicked out of exclusive LRU cache due to eviction policy, it's returned to cache file system, so we
+// could close it out of critical section.
+// - Before the file handle cache is destructed (i.e. it could be user requesting to disable file handle cache), we get
+// all values inside of the cache and close them one by one.
+
 class CacheFileSystemHandle : public FileHandle {
 public:
 	CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs);
-	~CacheFileSystemHandle() override = default;
-	void Close() override {
-		internal_file_handle->Close();
-	}
+
+	// On cache file handle destruction (for read handles), we place internal file handle to file handle cache to later
+	// reuse.
+	~CacheFileSystemHandle() override;
+
+	// On close, internal file handle could release resource (i.e. close socket file descriptor), which interrupts with
+	// file handle cache. So for read handle, we simply do nothing.
+	void Close() override;
+
 	// Get internal filesystem for cache filesystem.
 	FileSystem *GetInternalFileSystem() const;
 
@@ -159,8 +183,27 @@ public:
 	}
 
 private:
+	friend class CacheFileSystemHandle;
+
 	struct FileMetadata {
 		int64_t file_size = 0;
+	};
+
+	struct FileHandleCacheKey {
+		string path;
+		FileOpenFlags flags; // flags have parallel access enabled.
+	};
+	struct FileHandleCacheKeyEqual {
+		bool operator()(const FileHandleCacheKey &lhs, const FileHandleCacheKey &rhs) const {
+			const idx_t lhs_flag_value = lhs.flags.GetFlagsInternal();
+			const idx_t rhs_flag_value = rhs.flags.GetFlagsInternal();
+			return std::tie(lhs.path, lhs_flag_value) == std::tie(rhs.path, rhs_flag_value);
+		}
+	};
+	struct FileHandleCacheKeyHash {
+		std::size_t operator()(const FileHandleCacheKey &key) const {
+			return std::hash<std::string> {}(key.path) ^ std::hash<idx_t> {}(key.flags.GetFlagsInternal());
+		}
 	};
 
 	// Initialize global configurations and global objects (i.e. metadata cache, profiler, etc) in a thread-safe manner.
@@ -179,6 +222,14 @@ private:
 	// Initialize metadata cache.
 	void SetMetadataCache();
 
+	// Initialize file handle cache.
+	void SetFileHandleCache();
+
+	// Get file handle from cache, or open if it doesn't exist.
+	// Return cached file handle.
+	unique_ptr<FileHandle> GetOrCreateFileHandleForRead(const string &path, FileOpenFlags flags,
+	                                                    optional_ptr<FileOpener> opener);
+
 	// Mutex to protect concurrent access.
 	std::mutex cache_reader_mutex;
 	// Used to access remote files.
@@ -187,9 +238,14 @@ private:
 	CacheReaderManager &cache_reader_manager;
 	// Used to profile operations.
 	unique_ptr<BaseProfileCollector> profile_collector;
-	using MetadataCache = ThreadSafeSharedLruConstCache<string, FileMetadata>;
 	// Metadata cache, which maps from file name to metadata.
+	using MetadataCache = ThreadSafeSharedLruConstCache<string, FileMetadata>;
 	unique_ptr<MetadataCache> metadata_cache;
+	// File handle cache, which maps from file name to uncached file handle.
+	// Cache is used here to avoid HEAD HTTP request on read operations.
+	using FileHandleCache =
+	    ThreadSafeExclusiveLruCache<FileHandleCacheKey, FileHandle, FileHandleCacheKeyHash, FileHandleCacheKeyEqual>;
+	unique_ptr<FileHandleCache> file_handle_cache;
 };
 
 } // namespace duckdb

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -50,13 +50,19 @@ inline constexpr idx_t DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
 inline constexpr idx_t DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC = 3600ULL * 1000 /*1hour*/;
 
 // Max number of cache entries for file metadata cache.
-inline static constexpr size_t DEFAULT_MAX_METADATA_ENTRY = 125;
+inline static constexpr size_t DEFAULT_MAX_METADATA_CACHE_ENTRY = 125;
 
 // Timeout in milliseconds of cache entries for file metadata cache.
 inline static constexpr uint64_t DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC = 3600ULL * 1000 /*1hour*/;
 
-// Number of seconds which we define as the threshold of staleness.
+// Number of seconds which we define as the threshold of staleness for metadata entries.
 inline constexpr idx_t CACHE_FILE_STALENESS_SECOND = 24 * 3600; // 1 day
+
+// Max number of cache entries for file handle cache.
+inline static constexpr size_t DEFAULT_MAX_FILE_HANDLE_CACHE_ENTRY = 125;
+
+// Timeout in milliseconds of cache entries for file handle cache.
+inline static constexpr uint64_t DEFAULT_FILE_HANDLE_CACHE_ENTRY_TIMEOUT_MILLISEC = 3600ULL * 1000 /*1hour*/;
 
 // Default option for profile type.
 inline NoDestructor<std::string> DEFAULT_PROFILE_TYPE {*NOOP_PROFILE_TYPE};
@@ -66,6 +72,9 @@ inline uint64_t DEFAULT_MAX_SUBREQUEST_COUNT = 0;
 
 // Default enable metadata cache.
 inline bool DEFAULT_ENABLE_METADATA_CACHE = true;
+
+// Default enable file handle cache.
+inline bool DEFAULT_ENABLE_FILE_HANDLE_CACHE = true;
 
 // Default not ignore SIGPIPE in the extension.
 inline bool DEFAULT_IGNORE_SIGPIPE = false;
@@ -95,8 +104,13 @@ inline idx_t g_in_mem_cache_block_timeout_millisec = DEFAULT_IN_MEM_BLOCK_CACHE_
 
 // Metadata cache configuration.
 inline bool g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
-inline idx_t g_max_metadata_entry = DEFAULT_MAX_METADATA_ENTRY;
+inline idx_t g_max_metadata_cache_entry = DEFAULT_MAX_METADATA_CACHE_ENTRY;
 inline idx_t g_metadata_cache_entry_timeout_millisec = DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC;
+
+// File handle cache configuration.
+inline bool g_enable_file_handle_cache = DEFAULT_ENABLE_FILE_HANDLE_CACHE;
+inline idx_t g_max_file_handle_cache_entry = DEFAULT_MAX_FILE_HANDLE_CACHE_ENTRY;
+inline idx_t g_file_handle_cache_entry_timeout_millisec = DEFAULT_FILE_HANDLE_CACHE_ENTRY_TIMEOUT_MILLISEC;
 
 // Used for testing purpose, which has a higher priority over [g_cache_type], and won't be reset.
 // TODO(hjiang): A better is bake configuration into `FileOpener`.

--- a/src/include/temp_profile_collector.hpp
+++ b/src/include/temp_profile_collector.hpp
@@ -40,12 +40,19 @@ private:
 	    "glob",
 	};
 
+	// Cache entity name, indexed by cache entity enum.
+	inline static constexpr std::array<const char *, kCacheEntityCount> CACHE_ENTITY_NAMES = {
+	    "metadata",
+	    "data",
+	    "file handle",
+	};
+
 	using OperationStatsMap = unordered_map<string /*oper_id*/, OperationStats>;
 	std::array<OperationStatsMap, kIoOperationCount> operation_events;
 	// Only records finished operations, which maps from io operation to histogram.
 	std::array<unique_ptr<Histogram>, kIoOperationCount> histograms;
 	// Aggregated cache access condition.
-	std::array<uint64_t, 4> cache_access_count {};
+	std::array<uint64_t, kCacheEntityCount * 2 /*for cache hit and miss*/> cache_access_count {};
 	// Latest access timestamp in milliseconds since unix epoch.
 	uint64_t latest_timestamp = 0;
 

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -93,14 +93,20 @@ void TempProfileCollector::Reset() {
 
 std::pair<std::string, uint64_t> TempProfileCollector::GetHumanReadableStats() {
 	std::lock_guard<std::mutex> lck(stats_mutex);
-	auto stats = StringUtil::Format("For temp profile collector and stats for %s (unit in milliseconds)\n"
-	                                "metadata cache hit count = %d\n"
-	                                "metadata cache miss count = %d\n"
-	                                "data block cache hit count = %d\n"
-	                                "data block cache miss count = %d\n",
-	                                cache_reader_type, cache_access_count[0], cache_access_count[1],
-	                                cache_access_count[2], cache_access_count[3]);
 
+	string stats =
+	    StringUtil::Format("For temp profile collector and stats for %s (unit in milliseconds)\n", cache_reader_type);
+
+	// Record cache miss and cache hit count.
+	for (idx_t cur_entity_idx = 0; cur_entity_idx < kCacheEntityCount; ++cur_entity_idx) {
+		stats = StringUtil::Format("%s\n"
+		                           "%s cache hit count = %d\n"
+		                           "%s cache miss count = %d\n",
+		                           stats, CACHE_ENTITY_NAMES[cur_entity_idx], cache_access_count[cur_entity_idx * 2],
+		                           CACHE_ENTITY_NAMES[cur_entity_idx], cache_access_count[cur_entity_idx * 2 + 1]);
+	}
+
+	// Record IO operation latency.
 	for (idx_t cur_oper_idx = 0; cur_oper_idx < kIoOperationCount; ++cur_oper_idx) {
 		const auto &cur_histogram = histograms[cur_oper_idx];
 		if (cur_histogram->counts() == 0) {

--- a/src/utils/include/exclusive_lru_cache.hpp
+++ b/src/utils/include/exclusive_lru_cache.hpp
@@ -41,12 +41,7 @@ public:
 	// @param timeout_millisec_p: Timeout in milliseconds for entries, exceeding which invalidates the cache entries; 0
 	// means no timeout.
 	ExclusiveLruCache(size_t max_entries_p, uint64_t timeout_millisec_p)
-	    : ExclusiveLruCache(max_entries_p, timeout_millisec_p, /*eviction_callback_p=*/[](Val &) {}) {
-	}
-	// @param eviction_callback_p: callback which applies to evicted values.
-	ExclusiveLruCache(size_t max_entries_p, uint64_t timeout_millisec_p, std::function<void(Val &)> eviction_callback_p)
-	    : max_entries(max_entries_p), timeout_millisec(timeout_millisec_p),
-	      eviction_callback(std::move(eviction_callback_p)) {
+	    : max_entries(max_entries_p), timeout_millisec(timeout_millisec_p) {
 	}
 
 	// Disable copy and move.
@@ -192,9 +187,6 @@ private:
 
 	// The LRU list of entries. The front of the list identifies the most recently accessed entry.
 	std::list<Key> lru_list;
-
-	// Callback which applies on evicted value.
-	std::function<void(Val &)> eviction_callback;
 };
 
 // Same interfaces as `ExclusiveLruCache`, but all cached values are `const` specified to avoid concurrent updates.

--- a/src/utils/include/exclusive_lru_cache.hpp
+++ b/src/utils/include/exclusive_lru_cache.hpp
@@ -41,7 +41,12 @@ public:
 	// @param timeout_millisec_p: Timeout in milliseconds for entries, exceeding which invalidates the cache entries; 0
 	// means no timeout.
 	ExclusiveLruCache(size_t max_entries_p, uint64_t timeout_millisec_p)
-	    : max_entries(max_entries_p), timeout_millisec(timeout_millisec_p) {
+	    : ExclusiveLruCache(max_entries_p, timeout_millisec_p, /*eviction_callback_p=*/[](Val &) {}) {
+	}
+	// @param eviction_callback_p: callback which applies to evicted values.
+	ExclusiveLruCache(size_t max_entries_p, uint64_t timeout_millisec_p, std::function<void(Val &)> eviction_callback_p)
+	    : max_entries(max_entries_p), timeout_millisec(timeout_millisec_p),
+	      eviction_callback(std::move(eviction_callback_p)) {
 	}
 
 	// Disable copy and move.
@@ -169,9 +174,11 @@ private:
 	using EntryMap = std::unordered_map<KeyConstRef, Entry, RefHash<KeyHash>, RefEq<KeyEqual>>;
 
 	// Delete key-value pairs indicated by the given entry map iterator [iter] from cache.
-	void DeleteImpl(typename EntryMap::iterator iter) {
+	unique_ptr<Val> DeleteImpl(typename EntryMap::iterator iter) {
+		auto value = std::move(iter->second.value);
 		lru_list.erase(iter->second.lru_iterator);
 		entry_map.erase(iter);
+		return value;
 	}
 
 	// The maximum number of entries in the cache. A value of 0 means there is no limit on entry count.
@@ -185,6 +192,9 @@ private:
 
 	// The LRU list of entries. The front of the list identifies the most recently accessed entry.
 	std::list<Key> lru_list;
+
+	// Callback which applies on evicted value.
+	std::function<void(Val &)> eviction_callback;
 };
 
 // Same interfaces as `ExclusiveLruCache`, but all cached values are `const` specified to avoid concurrent updates.


### PR DESCRIPTION
This PR implements the initial version of file handle cache.
Cache entries are populated when cache file handle gets destructed, then internal file handle resets and place into cache.

Testing SQL commands:
```sql
D SET cache_httpfs_profile_type='temp';
D EXPLAIN ANALYZE SELECT i,j FROM read_parquet('s3://duckdb-cache-fs/test_folder/**/*.parquet', hive_partitioning = true, union_by_name=True);
D COPY (SELECT cache_httpfs_get_profile()) TO '/tmp/output-1.txt';
```
Repeat the SQL statements for a few times, I did observe cache file handles are reused later.

There're two TODO items:
- Add file handle cache related config settings and functions;
- Consider if we need to store multiple file handles by one key, which turns out to be useful for the above SQL.