### PR TITLE
Fix file handle cache deletion

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -52,6 +52,14 @@ void CacheFileSystem::SetMetadataCache() {
 
 void CacheFileSystem::SetFileHandleCache() {
 	if (!g_enable_file_handle_cache) {
+		// If file handle cache exists, get all existing file handles and close them.
+		if (file_handle_cache != nullptr) {
+			auto file_handles = file_handle_cache->ClearAndGetValues();
+			for (auto &cur_file_handle : file_handles) {
+				cur_file_handle->Close();
+			}
+		}
+
 		file_handle_cache = nullptr;
 		return;
 	}

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -50,17 +50,20 @@ void CacheFileSystem::SetMetadataCache() {
 	}
 }
 
+void CacheFileSystem::ClearFileHandleCache() {
+	if (file_handle_cache == nullptr) {
+		return;
+	}
+	auto file_handles = file_handle_cache->ClearAndGetValues();
+	for (auto &cur_file_handle : file_handles) {
+		cur_file_handle->Close();
+	}
+	file_handle_cache = nullptr;
+}
+
 void CacheFileSystem::SetFileHandleCache() {
 	if (!g_enable_file_handle_cache) {
-		// If file handle cache exists, get all existing file handles and close them.
-		if (file_handle_cache != nullptr) {
-			auto file_handles = file_handle_cache->ClearAndGetValues();
-			for (auto &cur_file_handle : file_handles) {
-				cur_file_handle->Close();
-			}
-		}
-
-		file_handle_cache = nullptr;
+		ClearFileHandleCache();
 		return;
 	}
 	if (file_handle_cache == nullptr) {

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -59,7 +59,9 @@ public:
 	explicit CacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
 	    : internal_filesystem(std::move(internal_filesystem_p)), cache_reader_manager(CacheReaderManager::Get()) {
 	}
-	~CacheFileSystem() override = default;
+	~CacheFileSystem() override {
+		ClearFileHandleCache();
+	}
 
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
@@ -224,6 +226,9 @@ private:
 
 	// Initialize file handle cache.
 	void SetFileHandleCache();
+
+	// Clear file handle cache and close all file handle resource inside.
+	void ClearFileHandleCache();
 
 	// Get file handle from cache, or open if it doesn't exist.
 	// Return cached file handle.


### PR DESCRIPTION
Followup PR for https://github.com/dentiny/duck-read-cache-fs/pull/133 and fix a bug:
- When we clear a file handle cache, we should close all resource for the file handles inside;
- Otherwise we have resource leak.