### PR TITLE
Integrate exclusive multi cache into cache filesystem

### DIFF
--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -7,7 +7,7 @@
 #include "cache_reader_manager.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/unique_ptr.hpp"
-#include "exclusive_lru_cache.hpp"
+#include "exclusive_multi_lru_cache.hpp"
 #include "shared_lru_cache.hpp"
 
 #include <mutex>
@@ -248,8 +248,8 @@ private:
 	unique_ptr<MetadataCache> metadata_cache;
 	// File handle cache, which maps from file name to uncached file handle.
 	// Cache is used here to avoid HEAD HTTP request on read operations.
-	using FileHandleCache =
-	    ThreadSafeExclusiveLruCache<FileHandleCacheKey, FileHandle, FileHandleCacheKeyHash, FileHandleCacheKeyEqual>;
+	using FileHandleCache = ThreadSafeExclusiveMultiLruCache<FileHandleCacheKey, FileHandle, FileHandleCacheKeyHash,
+	                                                         FileHandleCacheKeyEqual>;
 	unique_ptr<FileHandleCache> file_handle_cache;
 };
 


### PR DESCRIPTION
Followup PR for https://github.com/dentiny/duck-read-cache-fs/pull/136

I checked with SQL queries
```sql
D SET cache_httpfs_profile_type='temp';
D COPY (SELECT cache_httpfs_get_profile()) TO '/tmp/output-2.txt';
D EXPLAIN ANALYZE SELECT i,j FROM read_parquet('s3://duckdb-cache-fs/test_folder/**/*.parquet', hive_partitioning = true, union_by_name=True);
```
and confirm cache works as expected.