### PR TITLE
Provide SQL function to access cache access info

### DIFF
--- a/src/cache_entry_info.cpp
+++ b/src/cache_entry_info.cpp
@@ -4,9 +4,14 @@
 
 namespace duckdb {
 
-bool operator<(const CacheEntryInfo &lhs, const CacheEntryInfo &rhs) {
+bool operator<(const DataCacheEntryInfo &lhs, const DataCacheEntryInfo &rhs) {
 	return std::tie(lhs.cache_filepath, lhs.remote_filename, lhs.start_offset, lhs.end_offset, lhs.cache_type) <
 	       std::tie(rhs.cache_filepath, rhs.remote_filename, rhs.start_offset, rhs.end_offset, rhs.cache_type);
+}
+
+bool operator<(const CacheAccessInfo &lhs, const CacheAccessInfo &rhs) {
+	return std::tie(lhs.cache_type, lhs.cache_hit_count, lhs.cache_miss_count) <
+	       std::tie(rhs.cache_type, rhs.cache_hit_count, rhs.cache_miss_count);
 }
 
 } // namespace duckdb

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -121,6 +121,25 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_metadata_cache_entry_timeout_millisec", val);
 		g_metadata_cache_entry_timeout_millisec = val.GetValue<uint64_t>();
 	}
+
+	//===--------------------------------------------------------------------===//
+	// File handle cache configuration
+	//===--------------------------------------------------------------------===//
+
+	// Check and update configurations for metadata cache enablement.
+	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_enable_file_handle_cache", val);
+	g_enable_file_handle_cache = val.GetValue<bool>();
+
+	// Check and update file handle cache config if enabled.
+	if (g_enable_file_handle_cache) {
+		// Check and update cache entry size.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_file_handle_cache_entry_size", val);
+		g_max_file_handle_cache_entry = val.GetValue<uint64_t>();
+
+		// Check and update cache entry timeout.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_file_handle_cache_entry_timeout_millisec", val);
+		g_file_handle_cache_entry_timeout_millisec = val.GetValue<uint64_t>();
+	}
 }
 
 void ResetGlobalConfig() {
@@ -144,6 +163,11 @@ void ResetGlobalConfig() {
 	g_enable_metadata_cache = DEFAULT_ENABLE_METADATA_CACHE;
 	g_max_metadata_cache_entry = DEFAULT_MAX_METADATA_CACHE_ENTRY;
 	g_metadata_cache_entry_timeout_millisec = DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC;
+
+	// File handle cache configuration.
+	g_enable_file_handle_cache = DEFAULT_ENABLE_FILE_HANDLE_CACHE;
+	g_max_file_handle_cache_entry = DEFAULT_MAX_FILE_HANDLE_CACHE_ENTRY;
+	g_file_handle_cache_entry_timeout_millisec = DEFAULT_FILE_HANDLE_CACHE_ENTRY_TIMEOUT_MILLISEC;
 
 	// Reset testing options.
 	g_test_insufficient_disk_space = false;

--- a/src/cache_status_query_function.cpp
+++ b/src/cache_status_query_function.cpp
@@ -1,6 +1,7 @@
 #include "cache_status_query_function.hpp"
 
 #include <algorithm>
+#include <array>
 
 #include "cache_entry_info.hpp"
 #include "cache_filesystem.hpp"
@@ -18,15 +19,19 @@ namespace duckdb {
 
 namespace {
 
-struct CacheStatusData : public GlobalTableFunctionState {
-	vector<CacheEntryInfo> cache_entries_info;
+//===--------------------------------------------------------------------===//
+// Data cache status query function
+//===--------------------------------------------------------------------===//
+
+struct DataCacheStatusData : public GlobalTableFunctionState {
+	vector<DataCacheEntryInfo> cache_entries_info;
 
 	// Used to record the progress of emission.
 	uint64_t offset = 0;
 };
 
-unique_ptr<FunctionData> CacheStatusQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
-                                                  vector<LogicalType> &return_types, vector<string> &names) {
+unique_ptr<FunctionData> DataCacheStatusQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
 	D_ASSERT(return_types.empty());
 	D_ASSERT(names.empty());
 
@@ -56,8 +61,9 @@ unique_ptr<FunctionData> CacheStatusQueryFuncBind(ClientContext &context, TableF
 	return nullptr;
 }
 
-unique_ptr<GlobalTableFunctionState> CacheStatusQueryFuncInit(ClientContext &context, TableFunctionInitInput &input) {
-	auto result = make_uniq<CacheStatusData>();
+unique_ptr<GlobalTableFunctionState> DataCacheStatusQueryFuncInit(ClientContext &context,
+                                                                  TableFunctionInitInput &input) {
+	auto result = make_uniq<DataCacheStatusData>();
 	auto &entries_info = result->cache_entries_info;
 
 	// Initialize disk cache reader to access on-disk cache file, even if it's not initialized before.
@@ -81,8 +87,8 @@ unique_ptr<GlobalTableFunctionState> CacheStatusQueryFuncInit(ClientContext &con
 	return std::move(result);
 }
 
-void CacheStatusQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &data = data_p.global_state->Cast<CacheStatusData>();
+void DataCacheStatusQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<DataCacheStatusData>();
 
 	// All entries have been emitted.
 	if (data.offset >= data.cache_entries_info.size()) {
@@ -115,15 +121,118 @@ void CacheStatusQueryTableFunc(ClientContext &context, TableFunctionInput &data_
 	output.SetCardinality(count);
 }
 
+//===--------------------------------------------------------------------===//
+// Cache access information query function
+//===--------------------------------------------------------------------===//
+
+struct CacheAccessInfoData : public GlobalTableFunctionState {
+	// Index-ed by [CacheEntity].
+	vector<CacheAccessInfo> cache_access_info;
+
+	// Used to record the progress of emission.
+	uint64_t offset = 0;
+};
+
+unique_ptr<FunctionData> CacheAccessInfoQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+
+	return_types.reserve(3);
+	names.reserve(3);
+
+	// Cache type.
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("cache_type");
+
+	// Cache hit count.
+	return_types.emplace_back(LogicalType::UBIGINT);
+	names.emplace_back("cache_hit_count");
+
+	// Cache miss count.
+	return_types.emplace_back(LogicalType::UBIGINT);
+	names.emplace_back("cache_miss_count");
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> CacheAccessInfoQueryFuncInit(ClientContext &context,
+                                                                  TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheAccessInfoData>();
+	auto &aggregated_cache_access_infos = result->cache_access_info;
+	aggregated_cache_access_infos.resize(BaseProfileCollector::kCacheEntityCount);
+
+	// Set cache type, because there could be no cache readers available.
+	for (idx_t idx = 0; idx < BaseProfileCollector::kCacheEntityCount; ++idx) {
+		aggregated_cache_access_infos[idx].cache_type = BaseProfileCollector::CACHE_ENTITY_NAMES[idx];
+	}
+
+	// Get cache access info from all initialized cache readers.
+	auto &cache_reader_manager = CacheReaderManager::Get();
+	const auto cache_readers = cache_reader_manager.GetCacheReaders();
+	for (auto *cur_cache_reader : cache_readers) {
+		auto *profiler_collector = cur_cache_reader->GetProfileCollector();
+		if (profiler_collector == nullptr) {
+			continue;
+		}
+		auto cache_access_info = profiler_collector->GetCacheAccessInfo();
+		D_ASSERT(cache_access_info.size() == BaseProfileCollector::kCacheEntityCount);
+		for (idx_t idx = 0; idx < BaseProfileCollector::kCacheEntityCount; ++idx) {
+			auto &cur_cache_access_info = cache_access_info[idx];
+			aggregated_cache_access_infos[idx].cache_hit_count += cur_cache_access_info.cache_hit_count;
+			aggregated_cache_access_infos[idx].cache_miss_count += cur_cache_access_info.cache_miss_count;
+		}
+	}
+
+	return std::move(result);
+}
+
+void CacheAccessInfoQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheAccessInfoData>();
+
+	// All entries have been emitted.
+	if (data.offset >= data.cache_access_info.size()) {
+		return;
+	}
+
+	// Start filling in the result buffer.
+	idx_t count = 0;
+	while (data.offset < data.cache_access_info.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.cache_access_info[data.offset++];
+		idx_t col = 0;
+
+		// Cache type.
+		output.SetValue(col++, count, entry.cache_type);
+
+		// Cache hit count.
+		output.SetValue(col++, count, Value::BIGINT(NumericCast<uint64_t>(entry.cache_hit_count)));
+
+		// Cache miss count.
+		output.SetValue(col++, count, Value::BIGINT(NumericCast<uint64_t>(entry.cache_miss_count)));
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
+
 } // namespace
 
-TableFunction GetCacheStatusQueryFunc() {
-	TableFunction cache_status_query_func {/*name=*/"cache_httpfs_cache_status_query",
-	                                       /*arguments=*/ {},
-	                                       /*function=*/CacheStatusQueryTableFunc,
-	                                       /*bind=*/CacheStatusQueryFuncBind,
-	                                       /*init_global=*/CacheStatusQueryFuncInit};
-	return cache_status_query_func;
+TableFunction GetDataCacheStatusQueryFunc() {
+	TableFunction data_cache_status_query_func {/*name=*/"cache_httpfs_cache_status_query",
+	                                            /*arguments=*/ {},
+	                                            /*function=*/DataCacheStatusQueryTableFunc,
+	                                            /*bind=*/DataCacheStatusQueryFuncBind,
+	                                            /*init_global=*/DataCacheStatusQueryFuncInit};
+	return data_cache_status_query_func;
+}
+
+TableFunction GetCacheAccessInfoQueryFunc() {
+	TableFunction cache_access_info_query_func {/*name=*/"cache_httpfs_cache_access_info_query",
+	                                            /*arguments=*/ {},
+	                                            /*function=*/CacheAccessInfoQueryTableFunc,
+	                                            /*bind=*/CacheAccessInfoQueryFuncBind,
+	                                            /*init_global=*/CacheAccessInfoQueryFuncInit};
+	return cache_access_info_query_func;
 }
 
 } // namespace duckdb

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -156,12 +156,12 @@ void CacheLocal(const CacheReadChunk &chunk, FileSystem &local_filesystem, const
 DiskCacheReader::DiskCacheReader() : local_filesystem(LocalFileSystem::CreateLocal()) {
 }
 
-vector<CacheEntryInfo> DiskCacheReader::GetCacheEntriesInfo() const {
-	vector<CacheEntryInfo> cache_entries_info;
+vector<DataCacheEntryInfo> DiskCacheReader::GetCacheEntriesInfo() const {
+	vector<DataCacheEntryInfo> cache_entries_info;
 	local_filesystem->ListFiles(
 	    *g_on_disk_cache_directory, [&cache_entries_info](const std::string &fname, bool /*unused*/) {
 		    auto remote_file_info = GetRemoteFileInfo(fname);
-		    cache_entries_info.emplace_back(CacheEntryInfo {
+		    cache_entries_info.emplace_back(DataCacheEntryInfo {
 		        .cache_filepath = StringUtil::Format("%s/%s", *g_on_disk_cache_directory, fname),
 		        .remote_filename = std::get<0>(remote_file_info),
 		        .start_offset = std::get<1>(remote_file_info),

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -145,16 +145,16 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 	io_threads.Wait();
 }
 
-vector<CacheEntryInfo> InMemoryCacheReader::GetCacheEntriesInfo() const {
+vector<DataCacheEntryInfo> InMemoryCacheReader::GetCacheEntriesInfo() const {
 	if (cache == nullptr) {
 		return {};
 	}
 
 	auto keys = cache->Keys();
-	vector<CacheEntryInfo> cache_entries_info;
+	vector<DataCacheEntryInfo> cache_entries_info;
 	cache_entries_info.reserve(keys.size());
 	for (auto &cur_key : keys) {
-		cache_entries_info.emplace_back(CacheEntryInfo {
+		cache_entries_info.emplace_back(DataCacheEntryInfo {
 		    .cache_filepath = "(no disk cache)",
 		    .remote_filename = std::move(cur_key.fname),
 		    .start_offset = cur_key.start_off,

--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -28,7 +28,7 @@ public:
 
 	// Get status information for all cache entries for the current cache reader. Entries are returned in a random
 	// order.
-	virtual vector<CacheEntryInfo> GetCacheEntriesInfo() const = 0;
+	virtual vector<DataCacheEntryInfo> GetCacheEntriesInfo() const = 0;
 
 	// Clear all cache.
 	virtual void ClearCache() = 0;
@@ -44,6 +44,10 @@ public:
 	void SetProfileCollector(BaseProfileCollector *profile_collector_p) {
 		profile_collector = profile_collector_p;
 		profile_collector->SetCacheReaderType(GetName());
+	}
+
+	BaseProfileCollector *GetProfileCollector() const {
+		return profile_collector;
 	}
 
 	template <class TARGET>

--- a/src/include/cache_entry_info.hpp
+++ b/src/include/cache_entry_info.hpp
@@ -5,7 +5,8 @@
 
 namespace duckdb {
 
-struct CacheEntryInfo {
+// Entry information for data cache, which applies to both in-memory cache and on-disk cache.
+struct DataCacheEntryInfo {
 	std::string cache_filepath;
 	std::string remote_filename;
 	uint64_t start_offset = 0; // Inclusive.
@@ -13,6 +14,15 @@ struct CacheEntryInfo {
 	std::string cache_type;    // Either in-memory or on-disk.
 };
 
-bool operator<(const CacheEntryInfo &lhs, const CacheEntryInfo &rhs);
+bool operator<(const DataCacheEntryInfo &lhs, const DataCacheEntryInfo &rhs);
+
+// Cache access information, which applies to metadata and file handle cache.
+struct CacheAccessInfo {
+	std::string cache_type;
+	uint64_t cache_hit_count = 0;
+	uint64_t cache_miss_count = 0;
+};
+
+bool operator<(const CacheAccessInfo &lhs, const CacheAccessInfo &rhs);
 
 } // namespace duckdb

--- a/src/include/cache_status_query_function.hpp
+++ b/src/include/cache_status_query_function.hpp
@@ -7,6 +7,9 @@
 namespace duckdb {
 
 // Get the table function to query cache status.
-TableFunction GetCacheStatusQueryFunc();
+TableFunction GetDataCacheStatusQueryFunc();
+
+// Get the table function to query cache access status.
+TableFunction GetCacheAccessInfoQueryFunc();
 
 } // namespace duckdb

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -27,7 +27,7 @@ public:
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 
-	vector<CacheEntryInfo> GetCacheEntriesInfo() const override;
+	vector<DataCacheEntryInfo> GetCacheEntriesInfo() const override;
 
 private:
 	// Used to access local cache files.

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -28,7 +28,7 @@ public:
 	void ClearCache(const string &fname) override;
 	void ReadAndCache(FileHandle &handle, char *buffer, uint64_t requested_start_offset,
 	                  uint64_t requested_bytes_to_read, uint64_t file_size) override;
-	vector<CacheEntryInfo> GetCacheEntriesInfo() const override;
+	vector<DataCacheEntryInfo> GetCacheEntriesInfo() const override;
 
 private:
 	using InMemCache =

--- a/src/include/noop_cache_reader.hpp
+++ b/src/include/noop_cache_reader.hpp
@@ -22,7 +22,7 @@ public:
 	void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset, idx_t requested_bytes_to_read,
 	                  idx_t file_size) override;
 
-	vector<CacheEntryInfo> GetCacheEntriesInfo() const override {
+	vector<DataCacheEntryInfo> GetCacheEntriesInfo() const override {
 		return {};
 	}
 

--- a/src/include/temp_profile_collector.hpp
+++ b/src/include/temp_profile_collector.hpp
@@ -24,6 +24,7 @@ public:
 	std::string GetProfilerType() override {
 		return *TEMP_PROFILE_TYPE;
 	}
+	vector<CacheAccessInfo> GetCacheAccessInfo() const override;
 	void Reset() override;
 	std::pair<std::string, uint64_t> GetHumanReadableStats() override;
 
@@ -31,20 +32,6 @@ private:
 	struct OperationStats {
 		// Accounted as time elapsed since unix epoch in milliseconds.
 		int64_t start_timestamp = 0;
-	};
-
-	// Operation names, indexed by operation enums.
-	inline static constexpr std::array<const char *, kIoOperationCount> OPER_NAMES = {
-	    "open",
-	    "read",
-	    "glob",
-	};
-
-	// Cache entity name, indexed by cache entity enum.
-	inline static constexpr std::array<const char *, kCacheEntityCount> CACHE_ENTITY_NAMES = {
-	    "metadata",
-	    "data",
-	    "file handle",
 	};
 
 	using OperationStatsMap = unordered_map<string /*oper_id*/, OperationStats>;
@@ -56,6 +43,6 @@ private:
 	// Latest access timestamp in milliseconds since unix epoch.
 	uint64_t latest_timestamp = 0;
 
-	std::mutex stats_mutex;
+	mutable std::mutex stats_mutex;
 };
 } // namespace duckdb

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -91,6 +91,20 @@ void TempProfileCollector::Reset() {
 	latest_timestamp = 0;
 }
 
+vector<CacheAccessInfo> TempProfileCollector::GetCacheAccessInfo() const {
+	std::lock_guard<std::mutex> lck(stats_mutex);
+	vector<CacheAccessInfo> cache_access_info;
+	cache_access_info.reserve(kCacheEntityCount);
+	for (idx_t idx = 0; idx < kCacheEntityCount; ++idx) {
+		cache_access_info.emplace_back(CacheAccessInfo {
+		    .cache_type = CACHE_ENTITY_NAMES[idx],
+		    .cache_hit_count = cache_access_count[idx * 2],
+		    .cache_miss_count = cache_access_count[idx * 2 + 1],
+		});
+	}
+	return cache_access_info;
+}
+
 std::pair<std::string, uint64_t> TempProfileCollector::GetHumanReadableStats() {
 	std::lock_guard<std::mutex> lck(stats_mutex);
 

--- a/test/sql/cache_access_info.test
+++ b/test/sql/cache_access_info.test
@@ -1,0 +1,51 @@
+# name: test/sql/cache_access_info.test
+# description: test cache access info
+# group: [cache_httpfs]
+
+require cache_httpfs
+
+query III
+SELECT * FROM cache_httpfs_cache_access_info_query();
+----
+metadata	0	0
+data	0	0
+file handle	0	0
+
+# Start to record profile.
+statement ok
+SET cache_httpfs_profile_type='temp';
+
+# Test uncached query.
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+
+query III
+SELECT * FROM cache_httpfs_cache_access_info_query();
+----
+metadata	2	1
+data	0	1
+file handle	0	1
+
+# Query second time should show cache hit.
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+
+query III
+SELECT * FROM cache_httpfs_cache_access_info_query();
+----
+metadata	5	1
+data	1	1
+file handle	1	1
+
+statement ok
+SELECT cache_httpfs_clear_profile();
+
+query III
+SELECT * FROM cache_httpfs_cache_access_info_query();
+----
+metadata	0	0
+data	0	0
+file handle	0	0

--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -20,10 +20,10 @@ SET cache_httpfs_cache_directory='/tmp/duckdb_cache_httpfs_cache';
 statement ok
 SELECT cache_httpfs_clear_cache();
 
-#query I
-#SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
-#----
-#0
+query I
+SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+----
+0
 
 # Test uncached query.
 query IIIIII


### PR DESCRIPTION
This PR provide cache access information via SQL function (with no latency distribution, which is too verbose).
Example SQL and effect:
```sql
D SELECT * FROM cache_httpfs_cache_access_info_query();
┌─────────────┬─────────────────┬──────────────────┐
│ cache_type  │ cache_hit_count │ cache_miss_count │
│   varchar   │     uint64      │      uint64      │
├─────────────┼─────────────────┼──────────────────┤
│ metadata    │               8 │                1 │
│ data        │               2 │                1 │
│ file handle │               0 │                3 │
└─────────────┴─────────────────┴──────────────────┘
```
