### PR TITLE
Fix MacOS compile error by updating Immutable buffer type

### DIFF
--- a/src/utils/include/immutable_buffer.hpp
+++ b/src/utils/include/immutable_buffer.hpp
@@ -34,7 +34,8 @@ struct ImmutableBuffer {
 	}
 	// Get size of the buffer.
 	std::size_t size() const {
-		return buf_size; }
+		return buf_size;
+	}
 	// Whether the buffer is empty.
 	bool empty() const {
 		return buf_size == 0;

--- a/src/utils/include/immutable_buffer.hpp
+++ b/src/utils/include/immutable_buffer.hpp
@@ -15,12 +15,12 @@
 namespace duckdb {
 
 struct ImmutableBuffer {
-	std::shared_ptr<char[]> buffer;
+	std::shared_ptr<char> buffer;
 	std::size_t buf_size;
 
 	ImmutableBuffer() : buffer(nullptr), buf_size(0) {
 	}
-	ImmutableBuffer(std::size_t size) : buffer(new char[size]), buf_size(size) {
+	ImmutableBuffer(std::size_t size) : buffer(new char[size], std::default_delete<char[]>()), buf_size(size) {
 	}
 
 	ImmutableBuffer(const ImmutableBuffer &) = default;
@@ -34,8 +34,7 @@ struct ImmutableBuffer {
 	}
 	// Get size of the buffer.
 	std::size_t size() const {
-		return buf_size;
-	}
+		return buf_size; }
 	// Whether the buffer is empty.
 	bool empty() const {
 		return buf_size == 0;


### PR DESCRIPTION
Fixed this MacOS compilation error by changing the `ImmutableBuffer` type from `std::shared_ptr<char[]>` to `std::shared_ptr<char>` with an appropriate array deleter. 

This resolves the type compatibility issue between `char (*)[]` and the required const char* return type for the data() method.