### PR TITLE
Add Additional Test Cases for Last Chunk Handling in Disk Cache Filesystem

### DIFF
--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -23,7 +23,7 @@
 #include <utime.h>
 
 using namespace duckdb; // NOLINT
-
+#include <iostream>
 namespace {
 
 constexpr uint64_t TEST_FILE_SIZE = 26;
@@ -130,6 +130,44 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first and last
 	}
 }
 
+// Only last chunks is involved
+TEST_CASE("Test on disk cache filesystem with requested last chunk", "[on-disk cache filesystem test]") {
+	constexpr uint64_t test_block_size = 5;
+	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	g_cache_block_size = test_block_size;
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	auto disk_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	// First uncached read
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 25;
+		const uint64_t bytes_to_read = 1;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+
+	// Second cached read.
+	{
+		REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 25;
+		const uint64_t bytes_to_read = 1;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+		REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
+	}
+}
+
 // Three blocks involved, which include first, last and middle chunk.
 TEST_CASE("Test on disk cache filesystem with requested chunk the first, middle and last chunk",
           "[on-disk cache filesystem test]") {
@@ -164,6 +202,58 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first, middle 
 		                    start_offset);
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
 	}
+}
+
+// Requesting the first chunk(uncached) and the last chunk(uncached), followed by retrieving all chunks (hit 2
+// cache files).
+TEST_CASE("Testing the disk cache filesystem by first requesting the initial chunk and the final chunk, followed by "
+          "retrieving all chunks.",
+          "[on-disk cache filesystem test]") {
+	constexpr uint64_t test_block_size = 5;
+	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	g_cache_block_size = test_block_size;
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	auto disk_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	// First uncached read(first chunk).
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 0;
+		const uint64_t bytes_to_read = 4;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
+
+	// Second uncached read(last chunk).
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 25;
+		const uint64_t bytes_to_read = 1;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 2);
+
+	// Third cached read.
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 0;
+		const uint64_t bytes_to_read = TEST_FILE_SIZE;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 6);
 }
 
 // One block involved, it's the first meanwhile last block; requested content
@@ -240,6 +330,56 @@ TEST_CASE("Test on disk cache filesystem with requested chunk at last of file", 
 	}
 
 	// Get all cache files and check file count.
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 3);
+}
+
+// Requested chunk involves the end of the file. and the following request will only read already cached content.
+TEST_CASE("Test on disk cache filesystem by requesting the last chunk of the file then verify all chunks are cached",
+          "[on-disk cache filesystem test]") {
+	constexpr uint64_t test_block_size = 5;
+	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	g_cache_block_size = test_block_size;
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	auto disk_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 16;
+		const uint64_t bytes_to_read = 10;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 3);
+
+	// Second cached read.
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 25;
+		const uint64_t bytes_to_read = 1;
+		string content(bytes_to_read, '\0'); // effective offset range: [8, 21]
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 3);
+
+	// Third cached read
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 16;
+		const uint64_t bytes_to_read = 6;
+		string content(bytes_to_read, '\0'); // effective offset range: [23, 25]
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
 	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 3);
 }
 

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -129,7 +129,8 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first and last
 	}
 }
 
-TEST_CASE("Test on disk cache filesystem with requested last chunk", "[on-disk cache filesystem test]") {
+TEST_CASE("Test on disk cache filesystem with request for the last part of the file",
+          "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
 	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
 	g_cache_block_size = test_block_size;

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -153,10 +153,10 @@ TEST_CASE("Test on disk cache filesystem with requested last chunk", "[on-disk c
 
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
 	}
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
 
 	// Second cached read.
 	{
-		REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
 		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
 		const uint64_t start_offset = 25;
 		const uint64_t bytes_to_read = 1;
@@ -164,8 +164,8 @@ TEST_CASE("Test on disk cache filesystem with requested last chunk", "[on-disk c
 		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
 		                    start_offset);
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
-		REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
 	}
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
 }
 
 // Three blocks involved, which include first, last and middle chunk.

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -23,7 +23,7 @@
 #include <utime.h>
 
 using namespace duckdb; // NOLINT
-#include <iostream>
+
 namespace {
 
 constexpr uint64_t TEST_FILE_SIZE = 26;


### PR DESCRIPTION
This PR addresses part of issue #118 by enhancing test coverage for disk cache filesystem. 

* Reading only the last part of a file