### PR TITLE
Add static assert for cache entity array and operation name array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 
 set(EXTENSION_SOURCES
+    src/base_profile_collector.cpp
     src/cache_entry_info.cpp
     src/cache_filesystem.cpp
     src/cache_filesystem_config.cpp

--- a/src/base_profile_collector.cpp
+++ b/src/base_profile_collector.cpp
@@ -1,0 +1,27 @@
+#include "base_profile_collector.hpp"
+
+namespace duckdb {
+
+namespace {
+constexpr bool IsNonEmptyString(const char *str) {
+	return str != nullptr && str[0] != '\0';
+}
+
+template <typename T, size_t N>
+constexpr int ValidateStringArray(const std::array<T, N> &arr) {
+	for (std::size_t idx = 0; idx < N; ++idx) {
+		if (!IsNonEmptyString(arr[idx])) {
+			return static_cast<int>(idx);
+		}
+	}
+	return -1; // Indicates valid.
+}
+
+static_assert(
+    ValidateStringArray<const char *, BaseProfileCollector::kIoOperationCount>(BaseProfileCollector::OPER_NAMES) == -1,
+    "Operation name string array is invalid.");
+static_assert(ValidateStringArray<const char *, BaseProfileCollector::kCacheEntityCount>(
+                  BaseProfileCollector::CACHE_ENTITY_NAMES) == -1,
+              "Cache entity string array is invalid.");
+} // namespace
+} // namespace duckdb


### PR DESCRIPTION
As titled, use static assertion to avoid we missing new items in the future.