### PR TITLE
Avoid profiling and caching for non-glob path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(EXTENSION_SOURCES
     src/temp_profile_collector.cpp
     src/utils/fake_filesystem.cpp
     src/utils/filesystem_utils.cpp
+    src/utils/string_utils.cpp
     src/utils/thread_pool.cpp
     src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp
@@ -112,6 +113,9 @@ target_link_libraries(test_histogram ${EXTENSION_NAME})
 
 add_executable(test_thread_pool unit/test_thread_pool.cpp)
 target_link_libraries(test_thread_pool ${EXTENSION_NAME})
+
+add_executable(test_string_utils unit/test_string_utils.cpp)
+target_link_libraries(test_string_utils ${EXTENSION_NAME})
 
 add_executable(test_shared_lru_cache unit/test_shared_lru_cache.cpp)
 target_link_libraries(test_shared_lru_cache ${EXTENSION_NAME})

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -3,6 +3,7 @@
 #include "disk_cache_reader.hpp"
 #include "in_memory_cache_reader.hpp"
 #include "noop_cache_reader.hpp"
+#include "string_utils.hpp"
 #include "temp_profile_collector.hpp"
 
 namespace duckdb {
@@ -143,6 +144,12 @@ vector<string> CacheFileSystem::Glob(const string &path, FileOpener *opener) {
 	InitializeGlobalConfig(opener);
 	if (glob_cache == nullptr) {
 		return GlobImpl(path, opener);
+	}
+
+	// If it's a string without glob expression, we neither record IO latency, nor place it into cache, otherwise
+	// latency distribution and glob cache will be populated.
+	if (!IsGlobExpression(path)) {
+		return internal_filesystem->Glob(path, opener);
 	}
 
 	bool glob_cache_hit = true;

--- a/src/utils/include/string_utils.hpp
+++ b/src/utils/include/string_utils.hpp
@@ -1,0 +1,12 @@
+// String related operations.
+
+#pragma once
+
+#include <string>
+
+namespace duckdb {
+
+// Return whether the given [expr] is a glob expression.
+bool IsGlobExpression(const std::string &expr);
+
+} // namespace duckdb

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -1,0 +1,10 @@
+#include "string_utils.hpp"
+
+namespace duckdb {
+
+// Reference: https://en.wikipedia.org/wiki/Glob_(programming)
+bool IsGlobExpression(const std::string &expr) {
+	return expr.find_first_of("[]*?") != std::string::npos;
+}
+
+} // namespace duckdb

--- a/test/sql/cache_access_info.test
+++ b/test/sql/cache_access_info.test
@@ -2,6 +2,8 @@
 # description: test cache access info
 # group: [cache_httpfs]
 
+# Notice: we don't really test glob cache operation, because HTTP filesystem doesn't support real GLOB.
+
 require cache_httpfs
 
 query III
@@ -29,7 +31,7 @@ SELECT * FROM cache_httpfs_cache_access_info_query();
 metadata	2	1
 data	0	1
 file handle	0	1
-glob	0	1
+glob	0	0
 
 # Query second time should show cache hit.
 statement ok
@@ -41,7 +43,7 @@ SELECT * FROM cache_httpfs_cache_access_info_query();
 metadata	5	1
 data	1	1
 file handle	1	1
-glob	1	1
+glob	0	0
 
 statement ok
 SELECT cache_httpfs_clear_profile();

--- a/unit/test_string_utils.cpp
+++ b/unit/test_string_utils.cpp
@@ -1,0 +1,18 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "string_utils.hpp"
+
+using namespace duckdb; // NOLINT
+
+TEST_CASE("Test is glob expression", "[string utils test]") {
+	REQUIRE(!IsGlobExpression("/tmp/filename"));
+	REQUIRE(IsGlobExpression("/tmp/*"));
+	REQUIRE(IsGlobExpression("/tmp/[abc]"));
+	REQUIRE(IsGlobExpression("/tmp/a.b?"));
+}
+
+int main(int argc, char **argv) {
+	int result = Catch::Session().run(argc, argv);
+	return result;
+}


### PR DESCRIPTION
I found even the given `path` is not glob expression, there's still glob operation.
Reference: https://github.com/dentiny/duck-read-cache-fs/issues/144
For these paths, we don't need to perform cache and profile, otherwise it's poluting cache and stats.