### PR TITLE
Add mock test for handle close

### DIFF
--- a/src/utils/mock_filesystem.cpp
+++ b/src/utils/mock_filesystem.cpp
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <cstring>
 
-#include <fstream>
-
 namespace duckdb {
 
 bool operator<(const MockFileSystem::ReadOper &lhs, const MockFileSystem::ReadOper &rhs) {
@@ -26,25 +24,22 @@ bool operator!=(const MockFileSystem::ReadOper &lhs, const MockFileSystem::ReadO
 	return std::tie(lhs.start_offset, lhs.bytes_to_read) != std::tie(rhs.start_offset, rhs.bytes_to_read);
 }
 
-MockFileHandle::MockFileHandle(FileSystem &file_system, string path, FileOpenFlags flags)
-    : FileHandle(file_system, path, flags) {
+MockFileHandle::MockFileHandle(FileSystem &file_system, string path, FileOpenFlags flags,
+                               std::function<void()> close_callback_p, std::function<void()> dtor_callback_p)
+    : FileHandle(file_system, path, flags), close_callback(std::move(close_callback_p)),
+      dtor_callback(std::move(dtor_callback_p)) {
 	// Make sure passed-in filesystem is mock filesystem.
 	[[maybe_unused]] auto &fs = file_system.Cast<MockFileSystem>();
 }
 
 unique_ptr<FileHandle> MockFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                                                 optional_ptr<FileOpener> opener) {
-	return make_uniq<MockFileHandle>(*this, path, flags);
+	std::lock_guard<std::mutex> lck(mtx);
+	++file_open_invocation;
+	return make_uniq<MockFileHandle>(*this, path, flags, close_callback, dtor_callback);
 }
 void MockFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-
-	{
-		std::fstream f {"/tmp/debug-mock", std::ios::app | std::ios::out};
-		f << "read " << location << " " << nr_bytes << std::endl;
-		f.flush();
-		f.close();
-	}
-
+	std::lock_guard<std::mutex> lck(mtx);
 	std::memset(buffer, 'a', nr_bytes);
 	read_operations.emplace_back(ReadOper {
 	    .start_offset = location,

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -96,13 +96,13 @@ TEST_CASE("Test disk cache reader with mock filesystem", "[mock filesystem test]
 	TestReadWithMockFileSystem();
 }
 
-// TEST_CASE("Test in-memory cache reader with mock filesystem", "[mock filesystem test]") {
-// 	*g_test_cache_type = *IN_MEM_CACHE_TYPE;
-// 	g_cache_block_size = TEST_CHUNK_SIZE;
-// 	g_max_file_handle_cache_entry = 1;
-// 	LocalFileSystem::CreateLocal()->RemoveDirectory(*g_on_disk_cache_directory);
-// 	TestReadWithMockFileSystem();
-// }
+TEST_CASE("Test in-memory cache reader with mock filesystem", "[mock filesystem test]") {
+	*g_test_cache_type = *IN_MEM_CACHE_TYPE;
+	g_cache_block_size = TEST_CHUNK_SIZE;
+	g_max_file_handle_cache_entry = 1;
+	LocalFileSystem::CreateLocal()->RemoveDirectory(*g_on_disk_cache_directory);
+	TestReadWithMockFileSystem();
+}
 
 int main(int argc, char **argv) {
 	int result = Catch::Session().run(argc, argv);

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -16,7 +16,16 @@ constexpr int64_t TEST_FILESIZE = 26;
 constexpr int64_t TEST_CHUNK_SIZE = 5;
 
 void TestReadWithMockFileSystem() {
-	auto mock_filesystem = make_uniq<MockFileSystem>();
+	uint64_t close_invocation = 0;
+	uint64_t dtor_invocation = 0;
+	auto close_callback = [&close_invocation]() {
+		++close_invocation;
+	};
+	auto dtor_callback = [&dtor_invocation]() {
+		++dtor_invocation;
+	};
+
+	auto mock_filesystem = make_uniq<MockFileSystem>(std::move(close_callback), std::move(dtor_callback));
 	mock_filesystem->SetFileSize(TEST_FILESIZE);
 	auto *mock_filesystem_ptr = mock_filesystem.get();
 	auto cache_filesystem = make_uniq<CacheFileSystem>(std::move(mock_filesystem));
@@ -26,7 +35,7 @@ void TestReadWithMockFileSystem() {
 		// Make sure it's mock file handle.
 		auto handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
 		auto &cache_file_handle = handle->Cast<CacheFileSystemHandle>();
-		[[maybe_unused]] auto &mock_file_handle = cache_file_handle.internal_file_handle->Cast<MockFileHandle>();
+		auto &mock_file_handle = cache_file_handle.internal_file_handle->Cast<MockFileHandle>();
 
 		std::string buffer(TEST_FILESIZE, '\0');
 		cache_filesystem->Read(*handle, const_cast<char *>(buffer.data()), TEST_FILESIZE, /*location=*/0);
@@ -48,6 +57,11 @@ void TestReadWithMockFileSystem() {
 		auto &cache_file_handle = handle->Cast<CacheFileSystemHandle>();
 		[[maybe_unused]] auto &mock_file_handle = cache_file_handle.internal_file_handle->Cast<MockFileHandle>();
 
+		// Create a new handle, which cannot leverage the cached one.
+		auto another_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		[[maybe_unused]] auto &another_mock_handle =
+		    another_handle->Cast<CacheFileSystemHandle>().internal_file_handle->Cast<MockFileHandle>();
+
 		std::string buffer(TEST_FILESIZE, '\0');
 		cache_filesystem->Read(*handle, const_cast<char *>(buffer.data()), TEST_FILESIZE, /*location=*/0);
 		REQUIRE(buffer == std::string(TEST_FILESIZE, 'a'));
@@ -55,7 +69,21 @@ void TestReadWithMockFileSystem() {
 		mock_filesystem_ptr->ClearReadOperations();
 		auto read_operations = mock_filesystem_ptr->GetSortedReadOperations();
 		REQUIRE(read_operations.empty());
+
+		// [handle] and [another_handle] go out of scope and place back to file handle, but due to insufficient capacity
+		// only one of them will be cached and another one closed and destructed.
 	}
+
+	// One of the file handles resides in cache, another one gets closed and destructed.
+	REQUIRE(close_invocation == 1);
+	REQUIRE(dtor_invocation == 1);
+
+	// Destructing the cache filesystem cleans file handle cache, which in turns close and destruct all cached file
+	// handles.
+	cache_filesystem = nullptr;
+	REQUIRE(close_invocation == 2);
+	REQUIRE(dtor_invocation == 2);
+	REQUIRE(mock_filesystem_ptr->GetFileOpenInvocation() == 2);
 }
 
 } // namespace
@@ -68,13 +96,13 @@ TEST_CASE("Test disk cache reader with mock filesystem", "[mock filesystem test]
 	TestReadWithMockFileSystem();
 }
 
-TEST_CASE("Test in-memory cache reader with mock filesystem", "[mock filesystem test]") {
-	*g_test_cache_type = *IN_MEM_CACHE_TYPE;
-	g_cache_block_size = TEST_CHUNK_SIZE;
-	g_max_file_handle_cache_entry = 1;
-	LocalFileSystem::CreateLocal()->RemoveDirectory(*g_on_disk_cache_directory);
-	TestReadWithMockFileSystem();
-}
+// TEST_CASE("Test in-memory cache reader with mock filesystem", "[mock filesystem test]") {
+// 	*g_test_cache_type = *IN_MEM_CACHE_TYPE;
+// 	g_cache_block_size = TEST_CHUNK_SIZE;
+// 	g_max_file_handle_cache_entry = 1;
+// 	LocalFileSystem::CreateLocal()->RemoveDirectory(*g_on_disk_cache_directory);
+// 	TestReadWithMockFileSystem();
+// }
 
 int main(int argc, char **argv) {
 	int result = Catch::Session().run(argc, argv);

--- a/unit/test_exclusive_multi_lru_cache.cpp
+++ b/unit/test_exclusive_multi_lru_cache.cpp
@@ -10,8 +10,6 @@
 
 #include "exclusive_multi_lru_cache.hpp"
 
-#include <iostream>
-
 using namespace duckdb; // NOLINT
 
 namespace {


### PR DESCRIPTION
Add a mock-based unit test, to make sure all cached file handles are properly closed and destructed.
Resolves https://github.com/dentiny/duck-read-cache-fs/issues/132