### PR TITLE
Fix invalid memory access for mock test

### DIFF
--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -80,10 +80,11 @@ void TestReadWithMockFileSystem() {
 
 	// Destructing the cache filesystem cleans file handle cache, which in turns close and destruct all cached file
 	// handles.
+	REQUIRE(mock_filesystem_ptr->GetFileOpenInvocation() == 2);
+
 	cache_filesystem = nullptr;
 	REQUIRE(close_invocation == 2);
 	REQUIRE(dtor_invocation == 2);
-	REQUIRE(mock_filesystem_ptr->GetFileOpenInvocation() == 2);
 }
 
 } // namespace


### PR DESCRIPTION
The lifecycle of mock filesystem lies in cache filesystem, so cannot access mock one after we destruct cache one.