### PR TITLE
Fix segfault for file handle cache

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -18,12 +18,18 @@ FileSystem *CacheFileSystemHandle::GetInternalFileSystem() const {
 }
 
 CacheFileSystemHandle::~CacheFileSystemHandle() {
+	// For read file handles, we place them back to file handle cache if file handle enabled.
 	if (flags.OpenForReading()) {
 		auto &cache_filesystem = file_system.Cast<CacheFileSystem>();
+		if (cache_filesystem.file_handle_cache == nullptr) {
+			return;
+		}
+
 		CacheFileSystem::FileHandleCacheKey cache_key {
 		    .path = GetPath(),
 		    .flags = GetFlags() | FileFlags::FILE_FLAGS_PARALLEL_ACCESS,
 		};
+
 		// Reset file handle state (i.e. file offset) before placing into cache.
 		internal_file_handle->Reset();
 		auto evicted_handle =

--- a/test/sql/cache_access_info.test
+++ b/test/sql/cache_access_info.test
@@ -55,3 +55,40 @@ metadata	0	0
 data	0	0
 file handle	0	0
 glob	0	0
+
+# Disable all non data cache fron now on.
+statement ok
+SET cache_httpfs_enable_metadata_cache=false;
+
+statement ok
+SET cache_httpfs_enable_glob_cache=false;
+
+statement ok
+SET cache_httpfs_enable_file_handle_cache=false;
+
+statement ok
+SET cache_httpfs_type='noop';
+
+# After disabling cache, uncached read first time.
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+
+query III
+SELECT * FROM cache_httpfs_cache_access_info_query();
+----
+metadata	0	0
+data	0	0
+file handle	0	0
+glob	0	0
+
+# After disabling cache, uncached read second time.
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+
+query III
+SELECT * FROM cache_httpfs_cache_access_info_query();
+----
+metadata	0	0
+data	0	0
+file handle	0	0
+glob	0	0


### PR DESCRIPTION
We only place file handle to cache only when enabled, otherwise segfault (could be triggered by newly added sql test).
Also add test to verify the effect when all caches are disabled.