### PR TITLE
Cache filesystem provides interfaces to clear all cache and clear cache by name

### DIFF
--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -81,6 +81,14 @@ public:
 		return internal_filesystem.get();
 	}
 
+	// Clear all cache inside of cache filesystem (i.e. glob cache, file handle cache, metadata cache).
+	// It's worth noting data block cache won't get deleted.
+	void ClearCache();
+
+	// Clear cache entries inside of cache filesystem (i.e. glob cache, file handle cache, metadata cache).
+	// It's worth noting data block cache won't get deleted.
+	void ClearCache(const std::string &filepath);
+
 	// For other API calls, delegate to [internal_filesystem] to handle.
 	unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) override {
 		auto file_handle = internal_filesystem->OpenCompressedFile(std::move(handle), write);
@@ -242,6 +250,9 @@ private:
 
 	// Clear file handle cache and close all file handle resource inside.
 	void ClearFileHandleCache();
+
+	// Clear file handle cache by filepath, and close deleted file handle resource inside.
+	void ClearFileHandleCache(const std::string &filepath);
 
 	// Get file handle from cache, or open if it doesn't exist.
 	// Return cached file handle.

--- a/src/utils/include/mock_filesystem.hpp
+++ b/src/utils/include/mock_filesystem.hpp
@@ -46,7 +46,12 @@ public:
 
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) override;
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
+		++glob_invocation;
+		return {};
+	}
 	int64_t GetFileSize(FileHandle &handle) override {
+		++get_file_size_invocation;
 		return file_size;
 	}
 	void Seek(FileHandle &handle, idx_t location) override {
@@ -62,6 +67,9 @@ public:
 	uint64_t GetFileOpenInvocation() const {
 		return file_open_invocation;
 	}
+	uint64_t GetGlobInvocation() const {
+		return glob_invocation;
+	}
 	void ClearReadOperations() {
 		read_operations.clear();
 	}
@@ -71,7 +79,9 @@ private:
 	std::function<void()> close_callback;
 	std::function<void()> dtor_callback;
 
-	uint64_t file_open_invocation = 0; // Number of `FileOpen` gets called.
+	uint64_t file_open_invocation = 0;     // Number of `FileOpen` gets called.
+	uint64_t glob_invocation = 0;          // Number of `Glob` gets called.
+	uint64_t get_file_size_invocation = 0; // Number of `GetFileSize` get called.
 	vector<ReadOper> read_operations;
 	std::mutex mtx;
 };

--- a/unit/test_cache_filesystem.cpp
+++ b/unit/test_cache_filesystem.cpp
@@ -25,6 +25,16 @@ const auto TEST_FILE_CONTENT = []() {
 }();
 const auto TEST_DIRECTORY = "/tmp/duckdb_test_cache";
 const auto TEST_FILENAME = StringUtil::Format("/tmp/duckdb_test_cache/%s", UUID::ToString(UUID::GenerateRandomUUID()));
+
+void PerformIoOperation(CacheFileSystem *cache_filesystem) {
+	// Perform glob operation.
+	REQUIRE(cache_filesystem->Glob(TEST_FILENAME) == vector<string> {TEST_FILENAME});
+	// Perform open file operation.
+	auto file_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+	// Perform get file size operation.
+	REQUIRE(cache_filesystem->GetFileSize(*file_handle) == TEST_FILE_SIZE);
+}
+
 } // namespace
 
 TEST_CASE("Test glob operation", "[cache filesystem test]") {
@@ -36,6 +46,31 @@ TEST_CASE("Test glob operation", "[cache filesystem test]") {
 	auto cache_filesystem = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
 	REQUIRE(cache_filesystem->Glob(TEST_FILENAME) == vector<string> {TEST_FILENAME});
 	REQUIRE(cache_filesystem->Glob("/tmp/duckdb_test_cache/*") == vector<string> {TEST_FILENAME});
+}
+
+TEST_CASE("Test clear cache", "[cache filesystem test]") {
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+	g_enable_glob_cache = true;
+	g_enable_file_handle_cache = true;
+	g_enable_metadata_cache = true;
+
+	auto cache_filesystem = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	// Perform a series of IO operations without cache.
+	PerformIoOperation(cache_filesystem.get());
+
+	// Clear all cache and perform the same operation again.
+	cache_filesystem->ClearCache();
+	PerformIoOperation(cache_filesystem.get());
+
+	// Clear cache via filepath and retry the same operations.
+	cache_filesystem->ClearCache(TEST_FILENAME);
+	PerformIoOperation(cache_filesystem.get());
+
+	// Retry the same IO operations again.
+	PerformIoOperation(cache_filesystem.get());
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Followup for https://github.com/dentiny/duck-read-cache-fs/pull/161, which leverages the clear cache function inside of cache filesystem. In the next PR I will expose them to SQL function.