### PR TITLE
[minor] Avoid destruct non-trivially destructible global variables

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -1,4 +1,5 @@
 #include "cache_filesystem.hpp"
+
 #include "cache_filesystem_config.hpp"
 #include "disk_cache_reader.hpp"
 #include "in_memory_cache_reader.hpp"

--- a/src/cache_filesystem_ref_registry.cpp
+++ b/src/cache_filesystem_ref_registry.cpp
@@ -5,8 +5,8 @@
 namespace duckdb {
 
 /*static*/ CacheFsRefRegistry &CacheFsRefRegistry::Get() {
-	static CacheFsRefRegistry registry;
-	return registry;
+	static auto *registry = new CacheFsRefRegistry();
+	return *registry;
 }
 
 void CacheFsRefRegistry::Register(CacheFileSystem *fs) {

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -1,9 +1,10 @@
 #define DUCKDB_EXTENSION_MAIN
 
+#include "cache_httpfs_extension.hpp"
+
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
 #include "cache_filesystem_ref_registry.hpp"
-#include "cache_httpfs_extension.hpp"
 #include "cache_reader_manager.hpp"
 #include "cache_status_query_function.hpp"
 #include "crypto.hpp"

--- a/src/cache_reader_manager.cpp
+++ b/src/cache_reader_manager.cpp
@@ -1,5 +1,6 @@
-#include "base_cache_reader.hpp"
 #include "cache_reader_manager.hpp"
+
+#include "base_cache_reader.hpp"
 #include "disk_cache_reader.hpp"
 #include "in_memory_cache_reader.hpp"
 #include "noop_cache_reader.hpp"
@@ -7,8 +8,8 @@
 namespace duckdb {
 
 /*static*/ CacheReaderManager &CacheReaderManager::Get() {
-	static CacheReaderManager cache_reader_manager {};
-	return cache_reader_manager;
+	static auto *cache_reader_manager = new CacheReaderManager();
+	return *cache_reader_manager;
 }
 
 void CacheReaderManager::InitializeDiskCacheReader() {

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -1,8 +1,9 @@
-#include "duckdb/common/thread.hpp"
+#include "in_memory_cache_reader.hpp"
+
 #include "crypto.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/thread.hpp"
 #include "duckdb/common/types/uuid.hpp"
-#include "in_memory_cache_reader.hpp"
 #include "utils/include/resize_uninitialized.hpp"
 #include "utils/include/filesystem_utils.hpp"
 #include "utils/include/thread_pool.hpp"

--- a/src/noop_cache_reader.cpp
+++ b/src/noop_cache_reader.cpp
@@ -1,5 +1,6 @@
-#include "cache_filesystem.hpp"
 #include "noop_cache_reader.hpp"
+
+#include "cache_filesystem.hpp"
 
 namespace duckdb {
 

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -1,5 +1,6 @@
-#include "duckdb/common/types/uuid.hpp"
 #include "temp_profile_collector.hpp"
+
+#include "duckdb/common/types/uuid.hpp"
 #include "utils/include/no_destructor.hpp"
 #include "utils/include/time_utils.hpp"
 

--- a/src/utils/fake_filesystem.cpp
+++ b/src/utils/fake_filesystem.cpp
@@ -1,5 +1,6 @@
-#include "duckdb/common/string_util.hpp"
 #include "fake_filesystem.hpp"
+
+#include "duckdb/common/string_util.hpp"
 #include "no_destructor.hpp"
 
 namespace duckdb {


### PR DESCRIPTION
Pretty minor change, avoid destruct non-trivially destructible global variables, and cleanup header file inclusion order.