### PR TITLE
Use C++11 static constexpr

### DIFF
--- a/src/base_profile_collector.cpp
+++ b/src/base_profile_collector.cpp
@@ -1,26 +1,17 @@
 #include "base_profile_collector.hpp"
 
 namespace duckdb {
-namespace {
-constexpr bool IsNonEmptyString(const char *str) {
-	return str != nullptr && str[0] != '\0';
-}
+const std::array<const char *, BaseProfileCollector::kIoOperationCount> BaseProfileCollector::OPER_NAMES = {
+    "open",
+    "read",
+    "glob",
+};
 
-template <typename T, size_t N>
-constexpr int ValidateStringArray(const std::array<T, N> &arr) {
-	for (std::size_t idx = 0; idx < N; ++idx) {
-		if (!IsNonEmptyString(arr[idx])) {
-			return static_cast<int>(idx);
-		}
-	}
-	return -1; // Indicates valid.
-}
-
-static_assert(
-    ValidateStringArray<const char *, BaseProfileCollector::kIoOperationCount>(BaseProfileCollector::OPER_NAMES) == -1,
-    "Operation name string array is invalid.");
-static_assert(ValidateStringArray<const char *, BaseProfileCollector::kCacheEntityCount>(
-                  BaseProfileCollector::CACHE_ENTITY_NAMES) == -1,
-              "Cache entity string array is invalid.");
-} // namespace
+// Cache entity name, indexed by cache entity enum.
+const std::array<const char *, BaseProfileCollector::kCacheEntityCount> BaseProfileCollector::CACHE_ENTITY_NAMES = {
+    "metadata",
+    "data",
+    "file handle",
+    "glob",
+};
 } // namespace duckdb

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -35,19 +35,9 @@ public:
 	static constexpr auto kIoOperationCount = static_cast<idx_t>(IoOperation::kUnknown);
 
 	// Operation names, indexed by operation enums.
-	inline static constexpr std::array<const char *, kIoOperationCount> OPER_NAMES = {
-	    "open",
-	    "read",
-	    "glob",
-	};
-
+	static const std::array<const char *, kIoOperationCount> OPER_NAMES;
 	// Cache entity name, indexed by cache entity enum.
-	inline static constexpr std::array<const char *, kCacheEntityCount> CACHE_ENTITY_NAMES = {
-	    "metadata",
-	    "data",
-	    "file handle",
-	    "glob",
-	};
+	static const std::array<const char *, kCacheEntityCount> CACHE_ENTITY_NAMES;
 
 	BaseProfileCollector() = default;
 	virtual ~BaseProfileCollector() = default;


### PR DESCRIPTION
Fails on community extension CI unfortunately, have to downgrade to C++11 grammar.