### PR TITLE
Use vector instead of std::array

### DIFF
--- a/src/base_profile_collector.cpp
+++ b/src/base_profile_collector.cpp
@@ -1,14 +1,14 @@
 #include "base_profile_collector.hpp"
 
 namespace duckdb {
-const std::array<const char *, BaseProfileCollector::kIoOperationCount> BaseProfileCollector::OPER_NAMES = {
+const NoDestructor<vector<std::string>> BaseProfileCollector::OPER_NAMES {
     "open",
     "read",
     "glob",
 };
 
 // Cache entity name, indexed by cache entity enum.
-const std::array<const char *, BaseProfileCollector::kCacheEntityCount> BaseProfileCollector::CACHE_ENTITY_NAMES = {
+const NoDestructor<vector<std::string>> BaseProfileCollector::CACHE_ENTITY_NAMES {
     "metadata",
     "data",
     "file handle",

--- a/src/cache_status_query_function.cpp
+++ b/src/cache_status_query_function.cpp
@@ -164,7 +164,7 @@ unique_ptr<GlobalTableFunctionState> CacheAccessInfoQueryFuncInit(ClientContext 
 
 	// Set cache type, because there could be no cache readers available.
 	for (idx_t idx = 0; idx < BaseProfileCollector::kCacheEntityCount; ++idx) {
-		aggregated_cache_access_infos[idx].cache_type = BaseProfileCollector::CACHE_ENTITY_NAMES[idx];
+		aggregated_cache_access_infos[idx].cache_type = (*BaseProfileCollector::CACHE_ENTITY_NAMES)[idx];
 	}
 
 	// Get cache access info from all initialized cache readers.

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -5,6 +5,8 @@
 
 #include "cache_entry_info.hpp"
 #include "cache_filesystem_config.hpp"
+#include "duckdb/common/vector.hpp"
+#include "no_destructor.hpp"
 
 namespace duckdb {
 
@@ -31,13 +33,13 @@ public:
 		kGlob,
 		kUnknown,
 	};
-	static constexpr auto kCacheEntityCount = static_cast<size_t>(CacheEntity::kUnknown);
-	static constexpr auto kIoOperationCount = static_cast<size_t>(IoOperation::kUnknown);
+	static constexpr auto kCacheEntityCount = static_cast<idx_t>(CacheEntity::kUnknown);
+	static constexpr auto kIoOperationCount = static_cast<idx_t>(IoOperation::kUnknown);
 
 	// Operation names, indexed by operation enums.
-	static const std::array<const char *, kIoOperationCount> OPER_NAMES;
+	static const NoDestructor<vector<std::string>> OPER_NAMES;
 	// Cache entity name, indexed by cache entity enum.
-	static const std::array<const char *, kCacheEntityCount> CACHE_ENTITY_NAMES;
+	static const NoDestructor<vector<std::string>> CACHE_ENTITY_NAMES;
 
 	BaseProfileCollector() = default;
 	virtual ~BaseProfileCollector() = default;
@@ -102,7 +104,7 @@ public:
 		vector<CacheAccessInfo> cache_access_info;
 		cache_access_info.resize(kCacheEntityCount);
 		for (size_t idx = 0; idx < kCacheEntityCount; ++idx) {
-			cache_access_info[idx].cache_type = CACHE_ENTITY_NAMES[idx];
+			cache_access_info[idx].cache_type = (*CACHE_ENTITY_NAMES)[idx];
 		}
 		return cache_access_info;
 	}

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -98,7 +98,7 @@ vector<CacheAccessInfo> TempProfileCollector::GetCacheAccessInfo() const {
 	cache_access_info.reserve(kCacheEntityCount);
 	for (idx_t idx = 0; idx < kCacheEntityCount; ++idx) {
 		cache_access_info.emplace_back(CacheAccessInfo {
-		    .cache_type = CACHE_ENTITY_NAMES[idx],
+		    .cache_type = (*CACHE_ENTITY_NAMES)[idx],
 		    .cache_hit_count = cache_access_count[idx * 2],
 		    .cache_miss_count = cache_access_count[idx * 2 + 1],
 		});
@@ -117,8 +117,8 @@ std::pair<std::string, uint64_t> TempProfileCollector::GetHumanReadableStats() {
 		stats = StringUtil::Format("%s\n"
 		                           "%s cache hit count = %d\n"
 		                           "%s cache miss count = %d\n",
-		                           stats, CACHE_ENTITY_NAMES[cur_entity_idx], cache_access_count[cur_entity_idx * 2],
-		                           CACHE_ENTITY_NAMES[cur_entity_idx], cache_access_count[cur_entity_idx * 2 + 1]);
+		                           stats, (*CACHE_ENTITY_NAMES)[cur_entity_idx], cache_access_count[cur_entity_idx * 2],
+		                           (*CACHE_ENTITY_NAMES)[cur_entity_idx], cache_access_count[cur_entity_idx * 2 + 1]);
 	}
 
 	// Record IO operation latency.
@@ -129,7 +129,7 @@ std::pair<std::string, uint64_t> TempProfileCollector::GetHumanReadableStats() {
 		}
 		stats = StringUtil::Format("%s\n"
 		                           "%s operation latency is %s",
-		                           stats, OPER_NAMES[cur_oper_idx], cur_histogram->FormatString());
+		                           stats, (*OPER_NAMES)[cur_oper_idx], cur_histogram->FormatString());
 	}
 
 	return std::make_pair(std::move(stats), latest_timestamp);


### PR DESCRIPTION
```sh
/duckdb_build_dir/src/include/base_profile_collector.hpp:105:79: error: no match for 'operator[]' (operand types are 'const std::array<const char*, 4>' and 'size_t' {aka 'long unsigned int'})
  105 |                         cache_access_info[idx].cache_type = CACHE_ENTITY_NAMES[idx];
      |                                                                               ^
```