### PR TITLE
Fix compilation musl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 
 set(EXTENSION_SOURCES
-    src/base_profile_collector.cpp
     src/cache_entry_info.cpp
     src/cache_filesystem.cpp
     src/cache_filesystem_config.cpp

--- a/src/base_profile_collector.cpp
+++ b/src/base_profile_collector.cpp
@@ -1,3 +1,0 @@
-#include "base_profile_collector.hpp"
-
-namespace duckdb {} // namespace duckdb

--- a/src/base_profile_collector.cpp
+++ b/src/base_profile_collector.cpp
@@ -1,17 +1,3 @@
 #include "base_profile_collector.hpp"
 
-namespace duckdb {
-const std::array<const char *, BaseProfileCollector::kIoOperationCount> BaseProfileCollector::OPER_NAMES = {
-    "open",
-    "read",
-    "glob",
-};
-
-// Cache entity name, indexed by cache entity enum.
-const std::array<const char *, BaseProfileCollector::kCacheEntityCount> BaseProfileCollector::CACHE_ENTITY_NAMES = {
-    "metadata",
-    "data",
-    "file handle",
-    "glob",
-};
-} // namespace duckdb
+namespace duckdb {} // namespace duckdb


### PR DESCRIPTION
Duckdb needs to support musl libc, which doesn't seem to support `operator[]` for `std::array<>` somwhow, so I use `std::vector` instead.

Related
- release instruction: https://github.com/dentiny/duck-read-cache-fs/blob/main/CONTRIBUTING.md#release-process
- issue: https://github.com/duckdb/extension-ci-tools/issues/163