### PR TITLE
Temporarily disable wrap filesystem

### DIFF
--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -120,25 +120,25 @@ static void ResetProfileStats(const DataChunk &args, ExpressionState &state, Vec
 
 // Wrap the filesystem with extension cache filesystem.
 // Throw exception if the requested filesystem hasn't been registered into duckdb instance.
-static void WrapCacheFileSystem(const DataChunk &args, ExpressionState &state, Vector &result) {
-	D_ASSERT(args.ColumnCount() == 1);
-	const string filesystem_name = args.GetValue(/*col_idx=*/0, /*index=*/0).ToString();
+// static void WrapCacheFileSystem(const DataChunk &args, ExpressionState &state, Vector &result) {
+// 	D_ASSERT(args.ColumnCount() == 1);
+// 	const string filesystem_name = args.GetValue(/*col_idx=*/0, /*index=*/0).ToString();
 
-	// duckdb instance has a opener filesystem, which is a wrapper around virtual filesystem.
-	auto &opener_filesystem = duckdb_instance->GetFileSystem().Cast<OpenerFileSystem>();
-	auto &vfs = opener_filesystem.GetFileSystem();
-	auto internal_filesystem = vfs.ExtractSubSystem(filesystem_name);
-	if (internal_filesystem == nullptr) {
-		throw InvalidInputException("Filesystem %s hasn't been registered yet!", filesystem_name);
-	}
+// 	// duckdb instance has a opener filesystem, which is a wrapper around virtual filesystem.
+// 	auto &opener_filesystem = duckdb_instance->GetFileSystem().Cast<OpenerFileSystem>();
+// 	auto &vfs = opener_filesystem.GetFileSystem();
+// 	auto internal_filesystem = vfs.ExtractSubSystem(filesystem_name);
+// 	if (internal_filesystem == nullptr) {
+// 		throw InvalidInputException("Filesystem %s hasn't been registered yet!", filesystem_name);
+// 	}
 
-	auto cache_filesystem = make_uniq<CacheFileSystem>(std::move(internal_filesystem));
-	CacheFsRefRegistry::Get().Register(cache_filesystem.get());
-	vfs.RegisterSubSystem(std::move(cache_filesystem));
+// 	auto cache_filesystem = make_uniq<CacheFileSystem>(std::move(internal_filesystem));
+// 	CacheFsRefRegistry::Get().Register(cache_filesystem.get());
+// 	vfs.RegisterSubSystem(std::move(cache_filesystem));
 
-	constexpr bool SUCCESS = true;
-	result.Reference(Value(SUCCESS));
-}
+// 	constexpr bool SUCCESS = true;
+// 	result.Reference(Value(SUCCESS));
+// }
 
 // Cached httpfs cannot co-exist with non-cached version, because duckdb virtual filesystem doesn't provide a native fs
 // wrapper nor priority system, so co-existence doesn't guarantee cached version is actually used.
@@ -284,10 +284,10 @@ static void LoadInternal(DatabaseInstance &instance) {
 	// D. LOAD azure;
 	// -- Wrap filesystem with its name.
 	// D. SELECT cache_httpfs_wrap_cache_filesystem('AzureBlobStorageFileSystem');
-	ScalarFunction wrap_cache_filesystem_function("cache_httpfs_wrap_cache_filesystem",
-	                                              /*arguments=*/ {LogicalTypeId::VARCHAR},
-	                                              /*return_type=*/LogicalTypeId::BOOLEAN, WrapCacheFileSystem);
-	ExtensionUtil::RegisterFunction(instance, wrap_cache_filesystem_function);
+	// ScalarFunction wrap_cache_filesystem_function("cache_httpfs_wrap_cache_filesystem",
+	//                                               /*arguments=*/ {LogicalTypeId::VARCHAR},
+	//                                               /*return_type=*/LogicalTypeId::BOOLEAN, WrapCacheFileSystem);
+	// ExtensionUtil::RegisterFunction(instance, wrap_cache_filesystem_function);
 
 	// Register on-disk data cache file size stat function.
 	ScalarFunction get_ondisk_data_cache_size_function("cache_httpfs_get_ondisk_data_cache_size", /*arguments=*/ {},

--- a/test/sql/wrap_cache_filesystem.test
+++ b/test/sql/wrap_cache_filesystem.test
@@ -4,36 +4,36 @@
 
 require cache_httpfs
 
-statement error
-SELECT cache_httpfs_wrap_cache_filesystem('unregistered_filesystem');
-----
-Invalid Input Error: Filesystem unregistered_filesystem hasn't been registered yet!
+# statement error
+# SELECT cache_httpfs_wrap_cache_filesystem('unregistered_filesystem');
+# ----
+# Invalid Input Error: Filesystem unregistered_filesystem hasn't been registered yet!
 
-statement ok
-SELECT cache_httpfs_wrap_cache_filesystem('cache_httpfs_fake_filesystem');
+# statement ok
+# SELECT cache_httpfs_wrap_cache_filesystem('cache_httpfs_fake_filesystem');
 
-statement ok
-SELECT cache_httpfs_clear_cache();
+# statement ok
+# SELECT cache_httpfs_clear_cache();
 
-# Check read through fake filesystem works fine.
-statement ok
-COPY (SELECT * FROM read_csv('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv')) TO '/tmp/cache_httpfs_fake_filesystem/stock-exchanges.csv';
+# # Check read through fake filesystem works fine.
+# statement ok
+# COPY (SELECT * FROM read_csv('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv')) TO '/tmp/cache_httpfs_fake_filesystem/stock-exchanges.csv';
 
-# Clear cache after COPY, because reading from httfs already leads to local cache files.
-statement ok
-SELECT cache_httpfs_clear_cache();
+# # Clear cache after COPY, because reading from httfs already leads to local cache files.
+# statement ok
+# SELECT cache_httpfs_clear_cache();
 
-query I
-SELECT COUNT(*) FROM read_csv('/tmp/cache_httpfs_fake_filesystem/stock-exchanges.csv');
-----
-251
+# query I
+# SELECT COUNT(*) FROM read_csv('/tmp/cache_httpfs_fake_filesystem/stock-exchanges.csv');
+# ----
+# 251
 
-# Check local cache files.
-# File count = 16KiB / 64KiB = 1
-query I
-SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
-----
-1
+# # Check local cache files.
+# # File count = 16KiB / 64KiB = 1
+# query I
+# SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
+# ----
+# 1
 
-statement ok
-SELECT cache_httpfs_clear_cache();
+# statement ok
+# SELECT cache_httpfs_clear_cache();


### PR DESCRIPTION
As of today, latest duckdb release v1.2.1 doesn't support sub-filesystem extraction: https://github.com/duckdb/duckdb/pull/16226; so wrapping other filesystems doesn't compile at duckdb CI pipeline.

Because I'm not sure whether it will be supported in v1.2.2, so I temporarily disable the related function to unblock new version release; after it's supported in duckdb official release version, I will do a new patch release.