### PR TITLE
Add extention load info

### DIFF
--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -313,6 +313,11 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	// Create default cache directory.
 	LocalFileSystem::CreateLocal()->CreateDirectory(*DEFAULT_ON_DISK_CACHE_DIRECTORY);
+
+	// Fill in extension load information.
+	std::string description = StringUtil::Format(
+	    "Adds a read cache filesystem to DuckDB, which acts as a wrapper of duckdb-compatible filesystems.");
+	ExtensionUtil::RegisterExtension(instance, /*name=*/"cache_httpfs", ExtensionLoadedInfo {std::move(description)});
 }
 
 void CacheHttpfsExtension::Load(DuckDB &db) {

--- a/test/sql/extension.test
+++ b/test/sql/extension.test
@@ -9,6 +9,11 @@ Catalog Error: Scalar Function with name cache_httpfs_get_ondisk_data_cache_size
 
 require cache_httpfs
 
+query I
+SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name = 'cache_httpfs';
+----
+1
+
 statement ok
 SELECT cache_httpfs_clear_cache();
 

--- a/test/sql/extension.test
+++ b/test/sql/extension.test
@@ -9,8 +9,9 @@ Catalog Error: Scalar Function with name cache_httpfs_get_ondisk_data_cache_size
 
 require cache_httpfs
 
+# Make sure extension description is correctly populated.
 query I
-SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name = 'cache_httpfs';
+SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name = 'cache_httpfs' AND description IS NOT NULL AND description <> '';
 ----
 1
 


### PR DESCRIPTION
Related issue https://github.com/duckdb/duckdb/discussions/17005

Before change
```sql
D SELECT * FROM duckdb_extensions() WHERE extension_name = 'cache_httpfs';
┌────────────────┬─────────┬───────────┬──────────────┬─────────────┬───────────┬───────────────────┬───────────────────┬────────────────┐
│ extension_name │ loaded  │ installed │ install_path │ description │  aliases  │ extension_version │   install_mode    │ installed_from │
│    varchar     │ boolean │  boolean  │   varchar    │   varchar   │ varchar[] │      varchar      │      varchar      │    varchar     │
├────────────────┼─────────┼───────────┼──────────────┼─────────────┼───────────┼───────────────────┼───────────────────┼────────────────┤
│ cache_httpfs   │ true    │ true      │ (BUILT-IN)   │             │ []        │ v0.2.1            │ STATICALLY_LINKED │                │
└────────────────┴─────────┴───────────┴──────────────┴─────────────┴───────────┴───────────────────┴───────────────────┴────────────────┘
```

After change
```sql
D SELECT * FROM duckdb_extensions() WHERE extension_name = 'cache_httpfs';
┌────────────────┬─────────┬───────────┬──────────────┬─────────────────────────────────────────────────────────────┬───────────┬───────────────────┬───────────────────┬────────────────┐
│ extension_name │ loaded  │ installed │ install_path │                         description                         │  aliases  │ extension_version │   install_mode    │ installed_from │
│    varchar     │ boolean │  boolean  │   varchar    │                           varchar                           │ varchar[] │      varchar      │      varchar      │    varchar     │
├────────────────┼─────────┼───────────┼──────────────┼─────────────────────────────────────────────────────────────┼───────────┼───────────────────┼───────────────────┼────────────────┤
│ cache_httpfs   │ true    │ true      │ (BUILT-IN)   │ Adds a read cache filesystem to DuckDB, which acts as a w…  │ []        │ 708de5d           │ STATICALLY_LINKED │                │
└────────────────┴─────────┴───────────┴──────────────┴─────────────────────────────────────────────────────────────┴───────────┴───────────────────┴───────────────────┴────────────────┘
```