### PR TITLE
Provide a table function to list all wrapped DuckDB filesystems

### DIFF
--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -314,8 +314,7 @@ static void LoadInternal(DatabaseInstance &instance) {
 	// Create default cache directory.
 	LocalFileSystem::CreateLocal()->CreateDirectory(*DEFAULT_ON_DISK_CACHE_DIRECTORY);
 
-	// Register wrapped cache filesystems.
-
+	// Register wrapped cache filesystems info.
 	ExtensionUtil::RegisterFunction(instance, GetWrappedCacheFileSystemsFunc());
 
 	// Fill in extension load information.

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -314,6 +314,10 @@ static void LoadInternal(DatabaseInstance &instance) {
 	// Create default cache directory.
 	LocalFileSystem::CreateLocal()->CreateDirectory(*DEFAULT_ON_DISK_CACHE_DIRECTORY);
 
+	// Register wrapped cache filesystems.
+
+	ExtensionUtil::RegisterFunction(instance, GetWrappedCacheFileSystemsFunc());
+
 	// Fill in extension load information.
 	std::string description = StringUtil::Format(
 	    "Adds a read cache filesystem to DuckDB, which acts as a wrapper of duckdb-compatible filesystems.");

--- a/src/cache_status_query_function.cpp
+++ b/src/cache_status_query_function.cpp
@@ -215,6 +215,65 @@ void CacheAccessInfoQueryTableFunc(ClientContext &context, TableFunctionInput &d
 	output.SetCardinality(count);
 }
 
+//===--------------------------------------------------------------------===//
+// Wrapped cache filesystem query function
+//===--------------------------------------------------------------------===//
+struct WrappedFilesystemsData : public GlobalTableFunctionState {
+	vector<string> wrapped_filesystems;
+
+	// Used to record the progress of emission.
+	uint64_t offset = 0;
+};
+
+unique_ptr<FunctionData> WrappedCacheFileSystemsFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                         vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+
+	return_types.reserve(1);
+	names.reserve(1);
+
+	// Wrapped cache filesystem name.
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("wrapped_filesystems");
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> WrappedCacheFileSystemsFuncInit(ClientContext &context,
+                                                                     TableFunctionInitInput &input) {
+	auto result = make_uniq<WrappedFilesystemsData>();
+	auto &wrapped_filesystems = result->wrapped_filesystems;
+	auto cache_filesystem_instances = CacheFsRefRegistry::Get().GetAllCacheFs();
+
+	for (auto *cur_cache_fs : cache_filesystem_instances) {
+		wrapped_filesystems.emplace_back(cur_cache_fs->GetName());
+	}
+
+	return std::move(result);
+}
+
+void WrappedCacheFileSystemsTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<WrappedFilesystemsData>();
+
+	// All entries have been emitted.
+	if (data.offset >= data.wrapped_filesystems.size()) {
+		return;
+	}
+
+	// Start filling in the result buffer.
+	idx_t count = 0;
+	while (data.offset < data.wrapped_filesystems.size() && count < STANDARD_VECTOR_SIZE) {
+		auto &entry = data.wrapped_filesystems[data.offset++];
+		idx_t col = 0;
+
+		// Wrapped cache filesystem name.
+		output.SetValue(col, count, entry);
+
+		count++;
+	}
+	output.SetCardinality(count);
+}
 } // namespace
 
 TableFunction GetDataCacheStatusQueryFunc() {
@@ -235,4 +294,12 @@ TableFunction GetCacheAccessInfoQueryFunc() {
 	return cache_access_info_query_func;
 }
 
+TableFunction GetWrappedCacheFileSystemsFunc() {
+	TableFunction wrapped_cache_filesystems_query_func {/*name=*/"cache_httpfs_get_cache_filesystems",
+	                                                    /*arguments=*/ {},
+	                                                    /*function=*/WrappedCacheFileSystemsTableFunc,
+	                                                    /*bind=*/WrappedCacheFileSystemsFuncBind,
+	                                                    /*init_global=*/WrappedCacheFileSystemsFuncInit};
+	return wrapped_cache_filesystems_query_func;
+}
 } // namespace duckdb

--- a/src/cache_status_query_function.cpp
+++ b/src/cache_status_query_function.cpp
@@ -245,9 +245,10 @@ unique_ptr<GlobalTableFunctionState> WrappedCacheFileSystemsFuncInit(ClientConte
 	auto result = make_uniq<WrappedFilesystemsData>();
 	auto &wrapped_filesystems = result->wrapped_filesystems;
 	auto cache_filesystem_instances = CacheFsRefRegistry::Get().GetAllCacheFs();
+	wrapped_filesystems.reserve(cache_filesystem_instances.size());
 
 	for (auto *cur_cache_fs : cache_filesystem_instances) {
-		wrapped_filesystems.emplace_back(cur_cache_fs->GetName());
+		wrapped_filesystems.emplace_back(cur_cache_fs->GetInternalFileSystem()->GetName());
 	}
 
 	return std::move(result);

--- a/src/include/cache_status_query_function.hpp
+++ b/src/include/cache_status_query_function.hpp
@@ -12,4 +12,6 @@ TableFunction GetDataCacheStatusQueryFunc();
 // Get the table function to query cache access status.
 TableFunction GetCacheAccessInfoQueryFunc();
 
+TableFunction GetWrappedCacheFileSystemsFunc();
+
 } // namespace duckdb

--- a/src/include/cache_status_query_function.hpp
+++ b/src/include/cache_status_query_function.hpp
@@ -12,6 +12,7 @@ TableFunction GetDataCacheStatusQueryFunc();
 // Get the table function to query cache access status.
 TableFunction GetCacheAccessInfoQueryFunc();
 
+// Get the table function to query wrapped cache filesystems.
 TableFunction GetWrappedCacheFileSystemsFunc();
 
 } // namespace duckdb

--- a/test/sql/wrapped_filesystems_info.test
+++ b/test/sql/wrapped_filesystems_info.test
@@ -5,9 +5,9 @@
 require cache_httpfs
 
 query I
-SELECT * FROM cache_httpfs_get_cache_filesystems();
+SELECT * FROM cache_httpfs_get_cache_filesystems() ORDER BY wrapped_filesystems;
 ----
-cache_httpfs with HTTPFileSystem
-cache_httpfs with HuggingFaceFileSystem
-cache_httpfs with S3FileSystem
+HTTPFileSystem
+HuggingFaceFileSystem
+S3FileSystem
 

--- a/test/sql/wrapped_filesystems_info.test
+++ b/test/sql/wrapped_filesystems_info.test
@@ -1,0 +1,13 @@
+# name: test/sql/wrapped_filesystems_info.test
+# description: test wrapped filesystems info
+# group: [cache_httpfs]
+
+require cache_httpfs
+
+query I
+SELECT * FROM cache_httpfs_get_cache_filesystems();
+----
+cache_httpfs with HTTPFileSystem
+cache_httpfs with HuggingFaceFileSystem
+cache_httpfs with S3FileSystem
+


### PR DESCRIPTION
Implement https://github.com/dentiny/duck-read-cache-fs/issues/183

```sql
SELECT * FROM cache_httpfs_get_cache_filesystems();
----
cache_httpfs with HTTPFileSystem
cache_httpfs with HuggingFaceFileSystem
cache_httpfs with S3FileSystem
```