### PR TITLE
Add devcontainer setup for repository

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+RUN yes | unminimize
+
+RUN apt update \
+ && apt install -y \
+    bison \
+    clang-format \
+    cmake \
+    curl \
+    dstat \
+    flex \
+    g++ \
+    gdb \
+    git \
+    htop \
+    libicu-dev \
+    libreadline-dev \
+    libssl-dev \
+    locales \
+    man \
+    pkg-config \
+    sudo \
+    vim \
+    zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "eamodio.gitlens",
+            ]
+        }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE"
+    ],
+    "features": {
+        "ghcr.io/devcontainers/features/sshd:1": {}
+    }
+}
+


### PR DESCRIPTION
Devcontainer is useful to ease development environment setup, and widely used in a number of well-known projects, like [pg_mooncake](https://github.com/nbiscaro/pg_mooncake/tree/ad0b28d1873bffb8c835e1a52d472d91c9a95de3/.devcontainer).