### PR TITLE
Revive glob cache

### DIFF
--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -277,7 +277,7 @@ private:
 	                                                         FileHandleCacheKeyEqual>;
 	unique_ptr<FileHandleCache> file_handle_cache;
 	// Glob cache, which maps from path to filenames.
-	using GlobCache = ThreadSafeSharedLruConstCache<string, vector<string>>;
+	using GlobCache = ThreadSafeSharedLruConstCache<string, vector<OpenFileInfo>>;
 	unique_ptr<GlobCache> glob_cache;
 };
 

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -84,9 +84,7 @@ void TestReadWithMockFileSystem() {
 	// One of the file handles resides in cache, another one gets closed and destructed.
 	REQUIRE(close_invocation == 1);
 	REQUIRE(dtor_invocation == 1);
-	// TODO(hjiang): Re-implement glob cache, revert the change after that.
-	// REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 1);
-	REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 2);
+	REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 1);
 
 	// Destructing the cache filesystem cleans file handle cache, which in turns close and destruct all cached file
 	// handles.
@@ -157,9 +155,7 @@ TEST_CASE("Test clear cache", "[mock filesystem test]") {
 
 	// Retry one cached IO operation.
 	perform_io_operation();
-	// TODO(hjiang): Re-implement glob cache, revert the change after that.
-	// REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 3);
-	REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 4);
+	REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 3);
 	REQUIRE(mock_filesystem_ptr->GetFileOpenInvocation() == 3);
 }
 


### PR DESCRIPTION
duckdb v1.3.0 changes `glob` interface, so to pass compilation I disable it temporarily in the previous upgrade PR.
This PR revives and adds it back. Another TODO might be leverage the file open info.