### PR TITLE
Fix double caching

### DIFF
--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/opener_file_system.hpp"
 #include "duckdb/main/extension_util.hpp"
+#include "duckdb/storage/external_file_cache.hpp"
 #include "fake_filesystem.hpp"
 #include "hffs.hpp"
 #include "httpfs_extension.hpp"
@@ -152,6 +153,11 @@ static void LoadInternal(DatabaseInstance &instance) {
 	CacheFsRefRegistry::Get().Reset();
 	CacheReaderManager::Get().Reset();
 	ResetGlobalConfig();
+
+	// When cache httpfs enabled, by default disable external file cache, otherwise double buffering.
+	// Users could re-enable by setting the config afterwards.
+	instance.config.options.enable_external_file_cache = false;
+	instance.GetExternalFileCache().SetEnabled(false);
 
 	// Register filesystem instance to instance.
 	// Here we register both in-memory filesystem and on-disk filesystem, and leverage global configuration to decide

--- a/test/sql/external_file_cache.test
+++ b/test/sql/external_file_cache.test
@@ -1,0 +1,31 @@
+# name: test/sql/external_file_cache.test
+# description: test external file cache is disabled by default
+# group: [sql]
+
+require cache_httpfs
+
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+
+# Check external file cache is disabled by default.
+query III
+FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
+----
+EXTERNAL_FILE_CACHE	0	0
+
+query I
+SELECT current_setting('enable_external_file_cache');
+----
+false
+
+# Check external file cache could be re-enabled, clear cache to perform uncached IO access.
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+statement ok
+SET enable_external_file_cache = true;
+
+query I
+SELECT current_setting('enable_external_file_cache');
+----
+true


### PR DESCRIPTION
Current implementation doesn't work well with duckdb native "external file cache", which is enabled by default.
So application actually suffers double caching, which is bad.

In this PR, I solve the problem by:
- Disable external file cache by default, when cache httpfs extension is loaded, since it's already covering all caching features with external cache;
- Users and application are still able to re-enable external cache by normal "SET enable_external_file_cache = true;"

Test SQL:
```sql
-- Initially external file cache is disabled by default.
D SELECT current_setting('enable_external_file_cache');
┌───────────────────────────────────────────────┐
│ current_setting('enable_external_file_cache') │
│                    boolean                    │
├───────────────────────────────────────────────┤
│ false                                         │
└───────────────────────────────────────────────┘
D FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
┌─────────────────────┬────────────────────┬─────────────────────────┐
│         tag         │ memory_usage_bytes │ temporary_storage_bytes │
│       varchar       │       int64        │          int64          │
├─────────────────────┼────────────────────┼─────────────────────────┤
│ EXTERNAL_FILE_CACHE │         0          │            0            │
└─────────────────────┴────────────────────┴─────────────────────────┘
D SELECT * FROM read_parquet('s3://moonlink-test-s3-hao/public/16384.98642/data/data-01980066-f4c3-7870-b152-2a8ac0958e8e.parquet');
┌───────┬───────────┐
│   a   │     b     │
│ int32 │  varchar  │
├───────┼───────────┤
│     1 │ val_1     │
│     2 │ val_2     │
│     3 │ val_3     │
│     4 │ val_4     │
└───────────────────┘
D FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
┌─────────────────────┬────────────────────┬─────────────────────────┐
│         tag         │ memory_usage_bytes │ temporary_storage_bytes │
│       varchar       │       int64        │          int64          │
├─────────────────────┼────────────────────┼─────────────────────────┤
│ EXTERNAL_FILE_CACHE │         0          │            0            │
└─────────────────────┴────────────────────┴─────────────────────────┘
D SELECT cache_httpfs_clear_cache();
┌────────────────────────────┐
│ cache_httpfs_clear_cache() │
│          boolean           │
├────────────────────────────┤
│ true                       │
└────────────────────────────┘

-- Re-enable external cache manually.
D SET enable_external_file_cache = true;
D SELECT * FROM read_parquet('s3://moonlink-test-s3-hao/public/16384.98642/data/data-01980066-f4c3-7870-b152-2a8ac0958e8e.parquet');
┌───────┬───────────┐
│   a   │     b     │
│ int32 │  varchar  │
├───────┼───────────┤
│     1 │ val_1     │
│     2 │ val_2     │
│     3 │ val_3     │
│     4 │ val_4     │
D FROM duckdb_memory() WHERE tag = 'EXTERNAL_FILE_CACHE';
┌─────────────────────┬────────────────────┬─────────────────────────┐
│         tag         │ memory_usage_bytes │ temporary_storage_bytes │
│       varchar       │       int64        │          int64          │
├─────────────────────┼────────────────────┼─────────────────────────┤
│ EXTERNAL_FILE_CACHE │       438272       │            0            │
└─────────────────────┴────────────────────┴─────────────────────────┘
```