### PR TITLE
Add doc on extension interaction with external file cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Key features:
   + duckdb (under work), stats are stored in duckdb so we could leverage its rich feature for analysis purpose (i.e. use histogram to understant latency distribution)
   + profiling is by default disabled
 - 100% Compatibility with duckdb `httpfs`
-  + Extension is built upon `httpfs` extension and automatically load it beforehand, so it's fully compatible with it; we provide option `SET cache_httpfs_type='noop';` to fallback to and behave exactly as httpfs.
+  + Extension is built upon `httpfs` extension and automatically load it beforehand, so it's fully compatible with it; we provide option `SET cache_httpfs_type='noop'; SET enable_external_file_cache=true;` to fallback to and behave exactly as httpfs.
+- Interaction with duckdb internal "external file cache". Duckdb by default enables external file cache, to avoid double caching cache_httpfs extension by default disable external file cache, which could be re-enabled by `SET enable_external_file_cache=true;`.
 - Able to wrap **ALL** duckdb-compatible filesystem with one simple SQL `SELECT cache_httpfs_wrap_cache_filesystem(<your-fs>)`, and get all the benefit of caching, parallel read, IO performance stats, you name it.
 
 Caveat:

--- a/doc/example_usage.md
+++ b/doc/example_usage.md
@@ -4,6 +4,9 @@
 ```sql
 -- Later access won't be cached, but existing cache (whether it's in-memory or on-disk) will be kept.
 D SET cache_httpfs_profile_type='noop';
+-- To avoid double caching, extension by default disable external file cache;
+-- to switch and fallback to default httpfs extension behavior, re-enable external cache.
+D SET enable_external_file_cache=true;
 ```
 
 - Extension allows user to set on-disk cache file directory, it could be local filesystem or remote storage (via mount), which provides much flexibility.


### PR DESCRIPTION
Add documentation how extension interacts with external file cache.

Closes https://github.com/dentiny/duck-read-cache-fs/issues/206