### PR TITLE
Bump up IO request size

### DIFF
--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -33,7 +33,7 @@ inline const NoDestructor<std::unordered_set<std::string>> ALL_PROFILE_TYPES {*N
 //===--------------------------------------------------------------------===//
 // Default configuration
 //===--------------------------------------------------------------------===//
-inline const idx_t DEFAULT_CACHE_BLOCK_SIZE = 64_KiB;
+inline const idx_t DEFAULT_CACHE_BLOCK_SIZE = 512_KiB;
 inline const NoDestructor<std::string> DEFAULT_ON_DISK_CACHE_DIRECTORY {"/tmp/duckdb_cache_httpfs_cache"};
 
 // Default to use on-disk cache filesystem.


### PR DESCRIPTION
This PR bumps up IO request size from 64KiB to 512Kib (8x), which also serves as cache block size.
From my past experience, 2MiB request size is usually the sweetspot for object storage system, I didn't make it in this PR because:
- Could lead to larger latency and more wasted memory due to alignment;
- Increasing from 64KiB to 2MiB is a 32x boost, I would like to make it a multi-step rollout process to reduce unexpectation.

Related to issue https://github.com/dentiny/duck-read-cache-fs/issues/214