### PR TITLE
Add cache directory config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})
 add_executable(test_large_file_disk_reader unit/test_large_file_disk_reader.cpp)
 target_link_libraries(test_large_file_disk_reader ${EXTENSION_NAME})
 
+add_executable(test_disk_cache_with_multi_directories
+               unit/test_disk_cache_with_multi_directories.cpp)
+target_link_libraries(test_disk_cache_with_multi_directories ${EXTENSION_NAME})
+
 add_executable(test_in_memory_cache_filesystem
                unit/test_in_memory_cache_filesystem.cpp)
 target_link_libraries(test_in_memory_cache_filesystem ${EXTENSION_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ include_directories(src/include)
 include_directories(duckdb-httpfs/extension/httpfs/include)
 include_directories(duckdb/third_party/httplib)
 
-# TODO(hjiang): httpfs has wasm client implementation, which is intentionally ignored.
+# TODO(hjiang): httpfs has wasm client implementation, which is intentionally
+# ignored.
 set(EXTENSION_SOURCES
     src/cache_entry_info.cpp
     src/cache_filesystem.cpp

--- a/benchmark/read_s3_object.cpp
+++ b/benchmark/read_s3_object.cpp
@@ -66,7 +66,9 @@ void ReadUncachedWholeFile(uint64_t block_size) {
 	StandardBufferManager buffer_manager {*db.instance, "/tmp/cache_httpfs_fs_benchmark"};
 	auto s3fs = make_uniq<S3FileSystem>(buffer_manager);
 
-	FileSystem::CreateLocal()->RemoveDirectory(*g_on_disk_cache_directory);
+	for (const auto &cur_cache_dir : *g_on_disk_cache_directories) {
+		LocalFileSystem::CreateLocal()->RemoveDirectory(cur_cache_dir);
+	}
 	auto disk_cache_fs = make_uniq<CacheFileSystem>(std::move(s3fs));
 
 	auto client_context = make_shared_ptr<ClientContext>(db.instance);

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -89,6 +89,7 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		//
 		// TODO(hjiang): Parse cache directory might be expensive, consider adding a cache besides.
 		auto new_on_disk_cache_directories = GetCacheDirectoryConfig(opener);
+		D_ASSERT(!new_on_disk_cache_directories.empty());
 		if (new_on_disk_cache_directories != *g_on_disk_cache_directories) {
 			for (const auto& cur_cache_dir : new_on_disk_cache_directories) {
 				LocalFileSystem::CreateLocal()->CreateDirectory(cur_cache_dir);

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -17,6 +17,8 @@ constexpr char CACHE_DIRECTORIES_CONFIG_SPLITTER = ';';
 // Parse directory configuration string into directories.
 vector<string> ParseCacheDirectoryConfig(const std::string& directory_config_str) {
 	auto directories = StringUtil::Split(directory_config_str, /*delimiter=*/";");
+	// Sort the cache directories, so for different directories config value with same directory sets, ordering doesn't affect cache status.
+	std::sort(directories.begin(), directories.end());
 	return directories;
 }
 

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -5,8 +5,22 @@
 #include <utility>
 
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
+
+namespace {
+
+// Cache directories configs split token.s
+constexpr char CACHE_DIRECTORIES_CONFIG_SPLITTER = ';';
+
+// Parse directory configuration string into directories.
+vector<string> ParseCacheDirectoryConfig(const std::string& directory_config_str) {
+	auto directories = StringUtil::Split(directory_config_str, /*delimiter=*/";");
+	return directories;
+}
+
+}  // namespace
 
 void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 	if (opener == nullptr) {
@@ -14,7 +28,9 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		if (!g_test_cache_type->empty()) {
 			*g_cache_type = *g_test_cache_type;
 		}
-		LocalFileSystem::CreateLocal()->CreateDirectory(*g_on_disk_cache_directory);
+		for (const auto& cur_cache_dir : *g_on_disk_cache_directories) {
+			LocalFileSystem::CreateLocal()->CreateDirectory(cur_cache_dir);
+		}
 		return;
 	}
 
@@ -70,11 +86,14 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 	// Check and update configurations for on-disk cache type.
 	if (*g_cache_type == *ON_DISK_CACHE_TYPE) {
 		// Check and update cache directory if necessary.
-		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_directory", val);
-		auto new_on_disk_cache_directory = val.ToString();
-		if (new_on_disk_cache_directory != *g_on_disk_cache_directory) {
-			*g_on_disk_cache_directory = std::move(new_on_disk_cache_directory);
-			LocalFileSystem::CreateLocal()->CreateDirectory(*g_on_disk_cache_directory);
+		//
+		// TODO(hjiang): Parse cache directory might be expensive, consider adding a cache besides.
+		auto new_on_disk_cache_directories = GetCacheDirectoryConfig(opener);
+		if (new_on_disk_cache_directories != *g_on_disk_cache_directories) {
+			for (const auto& cur_cache_dir : new_on_disk_cache_directories) {
+				LocalFileSystem::CreateLocal()->CreateDirectory(cur_cache_dir);
+			}
+			*g_on_disk_cache_directories = std::move(new_on_disk_cache_directories);
 		}
 
 		// Check and update min bytes for disk cache.
@@ -171,7 +190,7 @@ void ResetGlobalConfig() {
 	g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
 
 	// On-disk cache configuration.
-	*g_on_disk_cache_directory = *DEFAULT_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {*DEFAULT_ON_DISK_CACHE_DIRECTORY};
 	g_min_disk_bytes_for_cache = DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
 
 	// In-memory cache configuration.
@@ -205,6 +224,26 @@ uint64_t GetThreadCountForSubrequests(uint64_t io_request_count) {
 		return MinValue<uint64_t>(io_request_count, MAX_THREAD_COUNT);
 	}
 	return MinValue<uint64_t>(io_request_count, g_max_subrequest_count);
+}
+
+std::vector<std::string> GetCacheDirectoryConfig(optional_ptr<FileOpener> opener) {
+	Value val;
+
+	// Attempt to get cache directories config first.
+	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_directories_config", val);
+	auto new_cache_directories_config = val.ToString();
+	if (!new_cache_directories_config.empty()) {
+		// Cache directory parameter will be ignored, if directory config specified. 
+		auto directories = ParseCacheDirectoryConfig(new_cache_directories_config);
+		return directories;
+	}
+
+	// Then fallback to parse cache directory.
+	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_directory", val);
+	auto new_on_disk_cache_directory = val.ToString();
+	vector<string> directories;
+	directories.emplace_back(std::move(new_on_disk_cache_directory));
+	return directories;
 }
 
 } // namespace duckdb

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -234,6 +234,10 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          "By default, 5% disk space will be reserved for other usage. When min disk bytes "
 	                          "specified with a positive value, the default value will be overriden.",
 	                          LogicalType::UBIGINT, 0);
+	// TODO(hjiang): there're quite a few optimizations which could be done in the config. For example,
+	// - Each cache directories could have their own config, like min/max cache file size;
+	// - Current implementation uses static hash based distribution, which doesn't work well when directory set changes;
+	// there're a few ways to resolve this problem, for example, fallback to other cache directories and check; change distribution logic.
 	config.AddExtensionOption("cache_httpfs_cache_directories_config",
 								"Advanced configuration for on-disk cache directories. It supports multiple directories, separated by semicolons (';'). Cache blocks will be evenly distributed under different directories deterministically."
 								"Between different runs, it's expected to provide same cache directories, while ordering is not required."

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -240,8 +240,8 @@ static void LoadInternal(DatabaseInstance &instance) {
 	// - Current implementation uses static hash based distribution, which doesn't work well when directory set changes;
 	// there're a few ways to resolve this problem, for example, fallback to other cache directories and check; change distribution logic.
 	config.AddExtensionOption("cache_httpfs_cache_directories_config",
-								"Advanced configuration for on-disk cache directories. It supports multiple directories, separated by semicolons (';'). Cache blocks will be evenly distributed under different directories deterministically."
-								"Between different runs, it's expected to provide same cache directories, while ordering is not required."
+								"Advanced configuration for on-disk cache. It supports multiple directories, separated by semicolons (';'). Cache blocks will be evenly distributed under different directories deterministically."
+								"Between different runs, it's expected to provide same cache directories, otherwise it's not guaranteed cache files still exist and accessible."
 								"Overrides 'cache_httpfs_cache_directory' if set.",
 								LogicalType::VARCHAR,
 								std::string{});

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -69,13 +69,14 @@ static void GetOnDiskDataCacheSize(const DataChunk &args, ExpressionState &state
 	auto local_filesystem = LocalFileSystem::CreateLocal();
 
 	int64_t total_cache_size = 0;
-	const auto& cur_cache_dir = (*g_on_disk_cache_directories)[0];
-	local_filesystem->ListFiles(
-	    cur_cache_dir, [&local_filesystem, &total_cache_size, &cur_cache_dir](const string &fname, bool /*unused*/) {
-		    const string file_path = StringUtil::Format("%s/%s", cur_cache_dir, fname);
-		    auto file_handle = local_filesystem->OpenFile(file_path, FileOpenFlags::FILE_FLAGS_READ);
-		    total_cache_size += local_filesystem->GetFileSize(*file_handle);
-	    });
+	for (const auto& cur_cache_dir : *g_on_disk_cache_directories) {
+		local_filesystem->ListFiles(
+			cur_cache_dir, [&local_filesystem, &total_cache_size, &cur_cache_dir](const string &fname, bool /*unused*/) {
+				const string file_path = StringUtil::Format("%s/%s", cur_cache_dir, fname);
+				auto file_handle = local_filesystem->OpenFile(file_path, FileOpenFlags::FILE_FLAGS_READ);
+				total_cache_size += local_filesystem->GetFileSize(*file_handle);
+		});
+	}
 	result.Reference(Value(total_cache_size));
 }
 

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -24,6 +24,14 @@ namespace duckdb {
 
 namespace {
 
+// Cache directory and cache filepath for certain request.
+struct CacheFileDestination {
+	// Index for all cache directories.
+	idx_t cache_directory_idx = 0;
+	// Local cache filepath.
+	string cache_filepath;
+};
+
 // All read requests are split into chunks, and executed in parallel.
 // A [CacheReadChunk] represents a chunked IO request and its corresponding partial IO request.
 struct CacheReadChunk {
@@ -79,15 +87,25 @@ string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
 // under one directory, and get all cache files with commands like `ls`.
 //
 // Considering the naming format, it's worth noting it might _NOT_ work for local files, including mounted filesystems.
-string GetLocalCacheFile(const string &cache_directory, const string &remote_file, idx_t start_offset,
+CacheFileDestination GetLocalCacheFile(const vector<string> &cache_directories, const string &remote_file, idx_t start_offset,
                          idx_t bytes_to_read) {
+	D_ASSERT(!cache_directories.empty());
+
 	duckdb::hash_bytes remote_file_sha256_val;
 	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
 	const string remote_file_sha256_str = Sha256ToHexString(remote_file_sha256_val);
-
 	const string fname = StringUtil::GetFileName(remote_file);
-	return StringUtil::Format("%s/%s-%s-%llu-%llu", cache_directory, remote_file_sha256_str, fname, start_offset,
+
+	const uint64_t hash_val = std::hash<std::string>{}(remote_file_sha256_str);
+    const idx_t cache_directory_idx = hash_val % cache_directories.size();
+	const auto& cur_cache_dir = cache_directories[cache_directory_idx];
+
+	auto cache_filepath = StringUtil::Format("%s/%s-%s-%llu-%llu", cur_cache_dir, remote_file_sha256_str, fname, start_offset,
 	                          bytes_to_read);
+	return CacheFileDestination {
+		.cache_directory_idx = 	cache_directory_idx,
+		.cache_filepath = std::move(cache_filepath),
+	};
 }
 
 // Get remote file information from the given local cache [fname].
@@ -246,15 +264,14 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 			SetThreadName("RdCachRdThd");
 
 			// Check local cache first, see if we could do a cached read.
-			const auto& on_disk_cache_dir = (*g_on_disk_cache_directories)[0];
-			const auto local_cache_file =
-			    GetLocalCacheFile(on_disk_cache_dir, handle.GetPath(), cache_read_chunk.aligned_start_offset,
+			auto cache_destination =
+			    GetLocalCacheFile(*g_on_disk_cache_directories, handle.GetPath(), cache_read_chunk.aligned_start_offset,
 			                      cache_read_chunk.chunk_size);
 
 			// Attempt to open the file directly, so a successfully opened file handle won't be deleted by cleanup
 			// thread and lead to data race.
 			auto file_handle = local_filesystem->OpenFile(
-			    local_cache_file, FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
+			    cache_destination.cache_filepath, FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
 			if (file_handle != nullptr) {
 				profile_collector->RecordCacheAccess(BaseProfileCollector::CacheEntity::kData,
 				                                     BaseProfileCollector::CacheAccess::kCacheHit);
@@ -264,12 +281,12 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 				cache_read_chunk.CopyBufferToRequestedMemory();
 
 				// Update access and modification timestamp for the cache file, so it won't get evicted.
-				const int ret_code = utime(local_cache_file.data(), /*times=*/nullptr);
+				const int ret_code = utime(cache_destination.cache_filepath.data(), /*times=*/nullptr);
 				// It's possible the cache file has been requested to delete by eviction thread, so `ENOENT` is a
 				// tolarable error.
 				if (ret_code != 0 && errno != ENOENT) {
 					throw IOException("Fails to update %s's access and modification timestamp because %s",
-					                  local_cache_file, strerror(errno));
+					                  cache_destination.cache_filepath, strerror(errno));
 				}
 				return;
 			}
@@ -290,7 +307,8 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 			cache_read_chunk.CopyBufferToRequestedMemory();
 
 			// Attempt to cache file locally.
-			CacheLocal(cache_read_chunk, *local_filesystem, handle, on_disk_cache_dir, local_cache_file);
+			const auto& cache_directory = (*g_on_disk_cache_directories)[cache_destination.cache_directory_idx];
+			CacheLocal(cache_read_chunk, *local_filesystem, handle, cache_directory, cache_destination.cache_filepath);
 		});
 	}
 	io_threads.Wait();

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -103,7 +103,7 @@ CacheFileDestination GetLocalCacheFile(const vector<string> &cache_directories, 
 	auto cache_filepath = StringUtil::Format("%s/%s-%s-%llu-%llu", cur_cache_dir, remote_file_sha256_str, fname, start_offset,
 	                          bytes_to_read);
 	return CacheFileDestination {
-		.cache_directory_idx = 	cache_directory_idx,
+		.cache_directory_idx = cache_directory_idx,
 		.cache_filepath = std::move(cache_filepath),
 	};
 }

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -6,7 +6,9 @@
 #include <unordered_set>
 
 #include "duckdb/common/file_opener.hpp"
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/vector.hpp"
 #include "no_destructor.hpp"
 #include "size_literals.hpp"
 
@@ -15,29 +17,29 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // Config constant
 //===--------------------------------------------------------------------===//
-inline const NoDestructor<std::string> NOOP_CACHE_TYPE {"noop"};
-inline const NoDestructor<std::string> ON_DISK_CACHE_TYPE {"on_disk"};
-inline const NoDestructor<std::string> IN_MEM_CACHE_TYPE {"in_mem"};
-inline const std::unordered_set<std::string> ALL_CACHE_TYPES {*NOOP_CACHE_TYPE, *ON_DISK_CACHE_TYPE,
+inline const NoDestructor<string> NOOP_CACHE_TYPE {"noop"};
+inline const NoDestructor<string> ON_DISK_CACHE_TYPE {"on_disk"};
+inline const NoDestructor<string> IN_MEM_CACHE_TYPE {"in_mem"};
+inline const std::unordered_set<string> ALL_CACHE_TYPES {*NOOP_CACHE_TYPE, *ON_DISK_CACHE_TYPE,
                                                               *IN_MEM_CACHE_TYPE};
 
 // Default profile option, which performs no-op.
-inline const NoDestructor<std::string> NOOP_PROFILE_TYPE {"noop"};
+inline const NoDestructor<string> NOOP_PROFILE_TYPE {"noop"};
 // Store the latest IO operation profiling result, which potentially suffers concurrent updates.
-inline const NoDestructor<std::string> TEMP_PROFILE_TYPE {"temp"};
+inline const NoDestructor<string> TEMP_PROFILE_TYPE {"temp"};
 // Store the IO operation profiling results into duckdb table, which unblocks advanced analysis.
-inline const NoDestructor<std::string> PERSISTENT_PROFILE_TYPE {"duckdb"};
-inline const NoDestructor<std::unordered_set<std::string>> ALL_PROFILE_TYPES {*NOOP_PROFILE_TYPE, *TEMP_PROFILE_TYPE,
+inline const NoDestructor<string> PERSISTENT_PROFILE_TYPE {"duckdb"};
+inline const NoDestructor<std::unordered_set<string>> ALL_PROFILE_TYPES {*NOOP_PROFILE_TYPE, *TEMP_PROFILE_TYPE,
                                                                               *PERSISTENT_PROFILE_TYPE};
 
 //===--------------------------------------------------------------------===//
 // Default configuration
 //===--------------------------------------------------------------------===//
 inline const idx_t DEFAULT_CACHE_BLOCK_SIZE = 512_KiB;
-inline const NoDestructor<std::string> DEFAULT_ON_DISK_CACHE_DIRECTORY {"/tmp/duckdb_cache_httpfs_cache"};
+inline const NoDestructor<string> DEFAULT_ON_DISK_CACHE_DIRECTORY {"/tmp/duckdb_cache_httpfs_cache"};
 
 // Default to use on-disk cache filesystem.
-inline NoDestructor<std::string> DEFAULT_CACHE_TYPE {*ON_DISK_CACHE_TYPE};
+inline NoDestructor<string> DEFAULT_CACHE_TYPE {*ON_DISK_CACHE_TYPE};
 
 // To prevent go out of disk space, we set a threshold to disallow local caching if insufficient. It applies to all
 // filesystems. The value here is the decimal representation for percentage value; for example, 0.05 means 5%.
@@ -71,7 +73,7 @@ inline static constexpr size_t DEFAULT_MAX_GLOB_CACHE_ENTRY = 64;
 inline static constexpr uint64_t DEFAULT_GLOB_CACHE_ENTRY_TIMEOUT_MILLISEC = 1800ULL * 1000 /*30min*/;
 
 // Default option for profile type.
-inline NoDestructor<std::string> DEFAULT_PROFILE_TYPE {*NOOP_PROFILE_TYPE};
+inline NoDestructor<string> DEFAULT_PROFILE_TYPE {*NOOP_PROFILE_TYPE};
 
 // Default max number of parallel subrequest for a single filesystem read request. 0 means no limit.
 inline uint64_t DEFAULT_MAX_SUBREQUEST_COUNT = 0;
@@ -99,12 +101,12 @@ inline idx_t DEFAULT_MIN_DISK_BYTES_FOR_CACHE = 0;
 // Global configuration.
 inline idx_t g_cache_block_size = DEFAULT_CACHE_BLOCK_SIZE;
 inline bool g_ignore_sigpipe = DEFAULT_IGNORE_SIGPIPE;
-inline NoDestructor<std::string> g_cache_type {*DEFAULT_CACHE_TYPE};
-inline NoDestructor<std::string> g_profile_type {*DEFAULT_PROFILE_TYPE};
+inline NoDestructor<string> g_cache_type {*DEFAULT_CACHE_TYPE};
+inline NoDestructor<string> g_profile_type {*DEFAULT_PROFILE_TYPE};
 inline uint64_t g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
 
 // On-disk cache configuration.
-inline NoDestructor<std::string> g_on_disk_cache_directory {*DEFAULT_ON_DISK_CACHE_DIRECTORY};
+inline NoDestructor<vector<string>> g_on_disk_cache_directories {*DEFAULT_ON_DISK_CACHE_DIRECTORY};
 inline idx_t g_min_disk_bytes_for_cache = DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
 
 // In-memory cache configuration.
@@ -128,7 +130,7 @@ inline idx_t g_glob_cache_entry_timeout_millisec = DEFAULT_GLOB_CACHE_ENTRY_TIME
 
 // Used for testing purpose, which has a higher priority over [g_cache_type], and won't be reset.
 // TODO(hjiang): A better is bake configuration into `FileOpener`.
-inline NoDestructor<std::string> g_test_cache_type {""};
+inline NoDestructor<string> g_test_cache_type {""};
 
 // Used for testing purpose, which disable on-disk cache if true.
 inline bool g_test_insufficient_disk_space = false;
@@ -136,6 +138,9 @@ inline bool g_test_insufficient_disk_space = false;
 //===--------------------------------------------------------------------===//
 // Util function for filesystem configurations.
 //===--------------------------------------------------------------------===//
+
+// Get on-disk directories config.
+std::vector<string> GetCacheDirectoryConfig(optional_ptr<FileOpener> opener);
 
 // Set global cache filesystem configuration.
 void SetGlobalConfig(optional_ptr<FileOpener> opener);

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -106,6 +106,8 @@ inline NoDestructor<string> g_profile_type {*DEFAULT_PROFILE_TYPE};
 inline uint64_t g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
 
 // On-disk cache configuration.
+//
+// Sorted cache directories.
 inline NoDestructor<vector<string>> g_on_disk_cache_directories {*DEFAULT_ON_DISK_CACHE_DIRECTORY};
 inline idx_t g_min_disk_bytes_for_cache = DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
 

--- a/src/utils/include/filesystem_utils.hpp
+++ b/src/utils/include/filesystem_utils.hpp
@@ -4,6 +4,7 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/string.hpp"
 
 namespace duckdb {
 
@@ -16,16 +17,16 @@ namespace duckdb {
 void EvictStaleCacheFiles(FileSystem &local_filesystem, const string &cache_directory);
 
 // Get the number of files under the given local filesystem [folder].
-int GetFileCountUnder(const std::string &folder);
+int GetFileCountUnder(const string &folder);
 
 // Get all files under the given local filesystem [folder] in alphabetically
 // ascending order.
-vector<std::string> GetSortedFilesUnder(const std::string &folder);
+vector<string> GetSortedFilesUnder(const string &folder);
 
 // Get all disk space in bytes for the filesystem indicated by the given [path].
-idx_t GetOverallFileSystemDiskSpace(const std::string &path);
+idx_t GetOverallFileSystemDiskSpace(const string &path);
 
 // Return whether we could cache content in the filesystem specified by the given [path].
-bool CanCacheOnDisk(const std::string &path);
+bool CanCacheOnDisk(const string &path);
 
 } // namespace duckdb

--- a/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
+++ b/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
@@ -9,9 +9,6 @@ require parquet
 statement ok
 SET cache_httpfs_type='on_disk';
 
-statement ok
-SELECT cache_httpfs_clear_cache();
-
 # Unset default cache directory to check whether directories config work.
 statement ok
 SET cache_httpfs_cache_directory=''
@@ -19,14 +16,28 @@ SET cache_httpfs_cache_directory=''
 statement ok
 SET cache_httpfs_cache_directories_config='/tmp/duckdb_cache_httpfs_cache_1;/tmp/duckdb_cache_httpfs_cache_2';
 
-# Test uncached query.
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+# Check no cache entry after clearing cache.
+query I
+SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+----
+0
+
 query I
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
-# Test cached query.
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.parquet');
 ----
-251
+7433139
+
+# Check no cache entry after clearing cache.
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
+----
+/tmp/duckdb_cache_httpfs_cache_1/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	stock/exchanges.csv	0	16222	on-disk
+/tmp/duckdb_cache_httpfs_cache_2/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-126877696-178807	taxi_2019_04.parquet	126877696	127056503	on-disk

--- a/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
+++ b/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
@@ -1,0 +1,32 @@
+# name: test/sql/disk_cache_filesystem_with_multi_cache_dir.test
+# description: test cache filesystem with on-disk cache and multiple cache directories
+# group: [sql]
+
+require cache_httpfs
+
+require parquet
+
+statement ok
+SET cache_httpfs_type='on_disk';
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+# Unset default cache directory to check whether directories config work.
+statement ok
+SET cache_httpfs_cache_directory=''
+
+statement ok
+SET cache_httpfs_cache_directories_config='/tmp/duckdb_cache_httpfs_cache_1;/tmp/duckdb_cache_httpfs_cache_2';
+
+# Test uncached query.
+query I
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+----
+251
+
+# Test cached query.
+query I
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+----
+251

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -101,7 +101,9 @@ TEST_CASE("Test disk cache reader with mock filesystem", "[mock filesystem test]
 	*g_test_cache_type = *ON_DISK_CACHE_TYPE;
 	g_cache_block_size = TEST_CHUNK_SIZE;
 	g_max_file_handle_cache_entry = 1;
-	LocalFileSystem::CreateLocal()->RemoveDirectory(*g_on_disk_cache_directory);
+	for (const auto &cur_cache_dir : *g_on_disk_cache_directories) {
+		LocalFileSystem::CreateLocal()->RemoveDirectory(cur_cache_dir);
+	}
 	TestReadWithMockFileSystem();
 }
 
@@ -109,7 +111,9 @@ TEST_CASE("Test in-memory cache reader with mock filesystem", "[mock filesystem 
 	*g_test_cache_type = *IN_MEM_CACHE_TYPE;
 	g_cache_block_size = TEST_CHUNK_SIZE;
 	g_max_file_handle_cache_entry = 1;
-	LocalFileSystem::CreateLocal()->RemoveDirectory(*g_on_disk_cache_directory);
+	for (const auto &cur_cache_dir : *g_on_disk_cache_directories) {
+		LocalFileSystem::CreateLocal()->RemoveDirectory(cur_cache_dir);
+	}
 	TestReadWithMockFileSystem();
 }
 

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -61,7 +61,7 @@ TEST_CASE("Test on default cache directory", "[on-disk cache filesystem test]") 
 TEST_CASE("Test on disk cache filesystem with requested chunk the first meanwhile last chunk",
           "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 26;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -97,7 +97,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first meanwhil
 TEST_CASE("Test on disk cache filesystem with requested chunk the first and last chunk",
           "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -132,7 +132,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first and last
 TEST_CASE("Test on disk cache filesystem with request for the last part of the file",
           "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -171,7 +171,7 @@ TEST_CASE("Test on disk cache filesystem with request for the last part of the f
 TEST_CASE("Test on disk cache filesystem with requested chunk the first, middle and last chunk",
           "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -207,7 +207,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk the first, middle 
 // doesn't involve the end of the file.
 TEST_CASE("Test on disk cache filesystem with requested chunk first and last one", "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -242,7 +242,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk first and last one
 // Requested chunk involves the end of the file.
 TEST_CASE("Test on disk cache filesystem with requested chunk at last of file", "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -283,7 +283,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk at last of file", 
 // Requested chunk involves the middle of the file.
 TEST_CASE("Test on disk cache filesystem with requested chunk at middle of file", "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -324,7 +324,7 @@ TEST_CASE("Test on disk cache filesystem with requested chunk at middle of file"
 // All chunks cached locally, later access shouldn't create new cache file.
 TEST_CASE("Test on disk cache filesystem no new cache file after a full cache", "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 5;
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();
@@ -404,7 +404,7 @@ TEST_CASE("Test on insufficient disk space", "[on-disk cache filesystem test]") 
 	SCOPE_EXIT {
 		ResetGlobalConfig();
 	};
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
 
 	auto on_disk_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());

--- a/unit/test_disk_cache_with_multi_directories.cpp
+++ b/unit/test_disk_cache_with_multi_directories.cpp
@@ -83,6 +83,10 @@ TEST_CASE("Test for cache directory config with multiple directories", "[on-disk
 	}
 	REQUIRE(non_empty_directory_count > 1);
 
+	// Check default cache directory is not accessed.
+	auto default_file_count = GetFileCountUnder(*DEFAULT_ON_DISK_CACHE_DIRECTORY);
+	REQUIRE(default_file_count == 0);
+
 	// Second cached read.
 	{
 		string content(TEST_FILE_SIZE, '\0');
@@ -102,14 +106,21 @@ TEST_CASE("Test for cache directory config with multiple directories", "[on-disk
 		file_counts_second_read[idx] = file_count;
 	}
 	REQUIRE(file_counts_first_read == file_counts_second_read);
+
+	// Check default cache directory is not accessed.
+	default_file_count = GetFileCountUnder(*DEFAULT_ON_DISK_CACHE_DIRECTORY);
+	REQUIRE(default_file_count == 0);
 }
 
 int main(int argc, char **argv) {
 	// Set global cache type for testing.
 	*g_test_cache_type = *ON_DISK_CACHE_TYPE;
 
-	// Create test files.
+	// Remove default cache directory.
 	auto local_filesystem = LocalFileSystem::CreateLocal();
+	local_filesystem->RemoveDirectory(*DEFAULT_ON_DISK_CACHE_DIRECTORY);
+
+	// Create test files.
 	for (const auto &cur_file : TEST_FILES) {
 		auto file_handle = local_filesystem->OpenFile(cur_file, FileOpenFlags::FILE_FLAGS_WRITE |
 		                                                            FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);

--- a/unit/test_disk_cache_with_multi_directories.cpp
+++ b/unit/test_disk_cache_with_multi_directories.cpp
@@ -1,0 +1,130 @@
+// Similar to on-disk reader unit test, this unit test checks situations where multiple cache directories are specified.
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "cache_filesystem_config.hpp"
+#include "disk_cache_reader.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/thread.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "filesystem_utils.hpp"
+#include "scope_guard.hpp"
+
+#include <utime.h>
+
+using namespace duckdb; // NOLINT
+
+namespace {
+constexpr uint64_t TEST_FILE_SIZE = 26;
+constexpr idx_t TEST_FILE_COUNT = 100;
+const auto TEST_FILE_CONTENT = []() {
+	string content(TEST_FILE_SIZE, '\0');
+	for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
+		content[idx] = 'a' + idx;
+	}
+	return content;
+}();
+const auto TEST_FILES = []() {
+	vector<string> test_files;
+	test_files.reserve(TEST_FILE_COUNT);
+	for (idx_t idx = 0; idx < TEST_FILE_COUNT; ++idx) {
+		test_files.emplace_back(StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID())));
+	}
+	return test_files;
+}();
+const auto TEST_ON_DISK_CACHE_DIRECTORIES = []() {
+	vector<string> cache_directories;
+	cache_directories.reserve(TEST_FILE_COUNT);
+	for (idx_t idx = 0; idx < TEST_FILE_COUNT; ++idx) {
+		cache_directories.emplace_back(StringUtil::Format("/tmp/duckdb_test_cache_httpfs_cache_%d", idx));
+	}
+	return cache_directories;
+}();
+} // namespace
+
+TEST_CASE("Test for cache directory config with multiple directories", "[on-disk cache filesystem test]") {
+	g_cache_block_size = TEST_FILE_SIZE;
+	*g_on_disk_cache_directories = TEST_ON_DISK_CACHE_DIRECTORIES;
+	auto delete_cache_directories = []() {
+		for (const auto &cur_cache_dir : *g_on_disk_cache_directories) {
+			LocalFileSystem::CreateLocal()->RemoveDirectory(cur_cache_dir);
+		}
+	};
+
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+		delete_cache_directories();
+	};
+
+	delete_cache_directories();
+	auto disk_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	// First uncached read.
+	{
+		string content(TEST_FILE_SIZE, '\0');
+		for (const auto &cur_file : TEST_FILES) {
+			auto handle = disk_cache_fs->OpenFile(cur_file, FileOpenFlags::FILE_FLAGS_READ);
+			disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
+			                    /*nr_bytes=*/TEST_FILE_SIZE,
+			                    /*location=*/0);
+			REQUIRE(content == TEST_FILE_CONTENT);
+		}
+	}
+
+	// Check more than one cache directories are not empty.
+	vector<int> file_counts_first_read(TEST_FILE_COUNT, 0);
+	int non_empty_directory_count = 0;
+	for (idx_t idx = 0; idx < TEST_FILE_COUNT; ++idx) {
+		const auto file_count = GetFileCountUnder((*g_on_disk_cache_directories)[idx]);
+		file_counts_first_read[idx] = file_count;
+		non_empty_directory_count += static_cast<int>(file_count > 0);
+	}
+	REQUIRE(non_empty_directory_count > 1);
+
+	// Second cached read.
+	{
+		string content(TEST_FILE_SIZE, '\0');
+		for (const auto &cur_file : TEST_FILES) {
+			auto handle = disk_cache_fs->OpenFile(cur_file, FileOpenFlags::FILE_FLAGS_READ);
+			disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
+			                    /*nr_bytes=*/TEST_FILE_SIZE,
+			                    /*location=*/0);
+			REQUIRE(content == TEST_FILE_CONTENT);
+		}
+	}
+
+	// Check second read has 100% cache hit so no cache files changed.
+	vector<int> file_counts_second_read(TEST_FILE_COUNT, 0);
+	for (idx_t idx = 0; idx < TEST_FILE_COUNT; ++idx) {
+		const auto file_count = GetFileCountUnder((*g_on_disk_cache_directories)[idx]);
+		file_counts_second_read[idx] = file_count;
+	}
+	REQUIRE(file_counts_first_read == file_counts_second_read);
+}
+
+int main(int argc, char **argv) {
+	// Set global cache type for testing.
+	*g_test_cache_type = *ON_DISK_CACHE_TYPE;
+
+	// Create test files.
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	for (const auto &cur_file : TEST_FILES) {
+		auto file_handle = local_filesystem->OpenFile(cur_file, FileOpenFlags::FILE_FLAGS_WRITE |
+		                                                            FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
+		                        TEST_FILE_SIZE, /*location=*/0);
+		file_handle->Sync();
+		file_handle->Close();
+	}
+
+	int result = Catch::Session().run(argc, argv);
+
+	// Delete test files.
+	for (const auto &cur_file : TEST_FILES) {
+		local_filesystem->RemoveFile(cur_file);
+	}
+
+	return result;
+}

--- a/unit/test_large_file_disk_reader.cpp
+++ b/unit/test_large_file_disk_reader.cpp
@@ -37,7 +37,7 @@ const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache";
 
 TEST_CASE("Read all bytes in one read operation", "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 22; // Intentionally not a divisor of file size.
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();

--- a/unit/test_large_file_inmem_reader.cpp
+++ b/unit/test_large_file_inmem_reader.cpp
@@ -37,7 +37,7 @@ const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache";
 
 TEST_CASE("Read all bytes in one read operation", "[on-disk cache filesystem test]") {
 	constexpr uint64_t test_block_size = 22; // Intentionally not a divisor of file size.
-	*g_on_disk_cache_directory = TEST_ON_DISK_CACHE_DIRECTORY;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
 	g_cache_block_size = test_block_size;
 	SCOPE_EXIT {
 		ResetGlobalConfig();


### PR DESCRIPTION
This PR adds cache directory config, which allows multiple cache directories;
and opens the possibilities to allow per-directory configuration in the future.

TODO items:
- Optimize cache directory parsing, current implementation does string parsing on every config access;
- Optimize situation where even after cache directories change, old cache files can still be accessed if possible.

Closes https://github.com/dentiny/duck-read-cache-fs/issues/215