### PR TITLE
Extract and cache file size from open file info

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -8,6 +8,11 @@
 
 namespace duckdb {
 
+namespace {
+// For certain filesystems, file open info contains "file_size" field in the extended stats map.
+constexpr const char* FILE_SIZE_INFO_KEY = "file_size";
+}  // namespace
+
 CacheFileSystemHandle::CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs)
     : FileHandle(fs, internal_file_handle_p->GetPath(), internal_file_handle_p->GetFlags()),
       internal_file_handle(std::move(internal_file_handle_p)) {
@@ -175,6 +180,24 @@ vector<OpenFileInfo> CacheFileSystem::GlobImpl(const string &path, FileOpener *o
 	profile_collector->RecordOperationStart(BaseProfileCollector::IoOperation::kGlob, oper_id);
 	auto open_file_info = internal_filesystem->Glob(path, opener);
 	profile_collector->RecordOperationEnd(BaseProfileCollector::IoOperation::kGlob, oper_id);
+
+	// Certain filesystem (i.e., s3 filesystem) populates file size within extended file info, make an attempt to extract file size.
+	if (metadata_cache != nullptr) {
+		for (const auto& cur_file_info : open_file_info) {
+			const auto& filepath = cur_file_info.path;
+			const auto& cur_extended_file_info = *cur_file_info.extended_info;
+			auto iter = cur_extended_file_info.options.find(FILE_SIZE_INFO_KEY);
+			if (iter == cur_extended_file_info.options.end()) {
+				continue;
+			}
+			auto& value = iter->second;
+			FileMetadata file_metadata {
+				.file_size = value.GetValue<int64_t>(),
+			};
+			metadata_cache->Put(filepath, make_shared_ptr<FileMetadata>(std::move(file_metadata)));
+		}
+	}
+
 	return open_file_info;
 }
 


### PR DESCRIPTION
This PR attempts to extract file size attribute from glob return values, so it could be reused later.