### PR TITLE
Add modification timestamp to metadata cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(EXTENSION_SOURCES
     src/utils/filesystem_utils.cpp
     src/utils/mock_filesystem.cpp
     src/utils/thread_pool.cpp
+    src/utils/time_utils.cpp
     src/utils/thread_utils.cpp
     duckdb-httpfs/extension/httpfs/create_secret_functions.cpp
     duckdb-httpfs/extension/httpfs/crypto.cpp
@@ -161,13 +162,12 @@ target_link_libraries(test_cache_filesystem_with_mock ${EXTENSION_NAME})
 add_executable(test_no_destructor unit/test_no_destructor.cpp)
 target_link_libraries(test_no_destructor ${EXTENSION_NAME})
 
-# Benchmark
-add_executable(read_s3_object benchmark/read_s3_object.cpp)
-target_link_libraries(read_s3_object ${EXTENSION_NAME})
+# Benchmark add_executable(read_s3_object benchmark/read_s3_object.cpp)
+# target_link_libraries(read_s3_object ${EXTENSION_NAME})
 
-add_executable(sequential_read_benchmark
-               benchmark/sequential_read_benchmark.cpp)
-target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
+# add_executable(sequential_read_benchmark
+# benchmark/sequential_read_benchmark.cpp)
+# target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
 
-add_executable(random_read_benchmark benchmark/random_read_benchmark.cpp)
-target_link_libraries(random_read_benchmark ${EXTENSION_NAME})
+# add_executable(random_read_benchmark benchmark/random_read_benchmark.cpp)
+# target_link_libraries(random_read_benchmark ${EXTENSION_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,12 +162,12 @@ target_link_libraries(test_cache_filesystem_with_mock ${EXTENSION_NAME})
 add_executable(test_no_destructor unit/test_no_destructor.cpp)
 target_link_libraries(test_no_destructor ${EXTENSION_NAME})
 
-# Benchmark add_executable(read_s3_object benchmark/read_s3_object.cpp)
-# target_link_libraries(read_s3_object ${EXTENSION_NAME})
+# Benchmark
+add_executable(read_s3_object benchmark/read_s3_object.cpp)
+target_link_libraries(read_s3_object ${EXTENSION_NAME})
 
-# add_executable(sequential_read_benchmark
-# benchmark/sequential_read_benchmark.cpp)
-# target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
+add_executable(sequential_read_benchmark benchmark/sequential_read_benchmark.cpp)
+target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
 
-# add_executable(random_read_benchmark benchmark/random_read_benchmark.cpp)
-# target_link_libraries(random_read_benchmark ${EXTENSION_NAME})
+add_executable(random_read_benchmark benchmark/random_read_benchmark.cpp)
+target_link_libraries(random_read_benchmark ${EXTENSION_NAME})

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(cache_httpfs
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    LOAD_TESTS
+    DONT_LOAD
 )
 
 # Any extra extensions that should be built

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,7 +3,7 @@
 # Extension from this repo
 duckdb_extension_load(cache_httpfs
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
-    DONT_LOAD
+    LOAD_TESTS
 )
 
 # Any extra extensions that should be built

--- a/src/utils/include/mock_filesystem.hpp
+++ b/src/utils/include/mock_filesystem.hpp
@@ -63,6 +63,10 @@ public:
 		++get_file_size_invocation;
 		return file_size;
 	}
+	time_t GetLastModifiedTime(FileHandle &handle) override {
+		++get_last_mod_time_invocation;
+		return last_modification_time;
+	}
 	void Seek(FileHandle &handle, idx_t location) override {
 	}
 	std::string GetName() const override {
@@ -76,6 +80,9 @@ public:
 	void SetFileSize(int64_t file_size_p) {
 		file_size = file_size_p;
 	}
+	void SetLastModificationTime(time_t last_modification_time_p) {
+		last_modification_time = last_modification_time_p;
+	}
 	vector<ReadOper> GetSortedReadOperations();
 	uint64_t GetFileOpenInvocation() const {
 		return file_open_invocation;
@@ -86,12 +93,16 @@ public:
 	uint64_t GetSizeInvocation() const {
 		return get_file_size_invocation;
 	}
+	uint64_t GetLastModTimeInvocation() const {
+		return get_last_mod_time_invocation;
+	}
 	void ClearReadOperations() {
 		read_operations.clear();
 	}
 
 private:
 	int64_t file_size = 0;
+	time_t last_modification_time = static_cast<time_t>(0);
 	// Glob returns value for each invocation.
 	std::deque<OpenFileInfo> glob_returns;
 	std::function<void()> close_callback;
@@ -100,6 +111,7 @@ private:
 	uint64_t file_open_invocation = 0;     // Number of `FileOpen` gets called.
 	uint64_t glob_invocation = 0;          // Number of `Glob` gets called.
 	uint64_t get_file_size_invocation = 0; // Number of `GetFileSize` get called.
+	uint64_t get_last_mod_time_invocation = 0; // Number of `GetLastModificationTime` called.
 	vector<ReadOper> read_operations;
 	std::mutex mtx;
 };

--- a/src/utils/include/time_utils.hpp
+++ b/src/utils/include/time_utils.hpp
@@ -2,8 +2,11 @@
 
 #pragma once
 
+#include "duckdb/common/types/timestamp.hpp"
+
 #include <chrono>
 #include <cstdint>
+#include <ctime>
 
 namespace duckdb {
 
@@ -33,5 +36,8 @@ inline int64_t GetSystemNowNanoSecSinceEpoch() {
 inline int64_t GetSystemNowMilliSecSinceEpoch() {
 	return GetSystemNowNanoSecSinceEpoch() / kMilliToNanos;
 }
+
+// Convert from duckdb [`timestamp_t`] to [`time_t`].
+time_t DuckdbTimestampToTimeT(timestamp_t timestamp);
 
 } // namespace duckdb

--- a/src/utils/time_utils.cpp
+++ b/src/utils/time_utils.cpp
@@ -1,0 +1,20 @@
+#include "duckdb/common/types/timestamp.hpp"
+#include "time_utils.hpp"
+
+namespace duckdb {
+
+time_t DuckdbTimestampToTimeT(timestamp_t timestamp) {
+	auto components = Timestamp::GetComponents(timestamp);
+	struct tm tm {};
+	tm.tm_year = components.year - 1900;
+	tm.tm_mon = components.month - 1;
+	tm.tm_mday = components.day;
+	tm.tm_hour = components.hour;
+	tm.tm_min = components.minute;
+	tm.tm_sec = components.second;
+	tm.tm_isdst = 0;
+	time_t result = mktime(&tm);
+	return result;
+}
+
+}  // namespace duckdb

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -115,7 +115,7 @@ TEST_CASE("Test file size cache for glob invocation", "[mock filesystem test]") 
 	// Ref:
 	// https://github.com/duckdb/duckdb-httpfs/blob/cb5b2825eff68fc91f47e917ba88bf2ed84c2dd3/extension/httpfs/s3fs.cpp#L1171
 	string size_str = "10";
-	string last_modification_time_str = "2024-11-09T11:38:08.000Z";
+	string last_modification_time_str = "2024-11-09T11:38:08.000Z"; // Unix timestamp 1731152288.
 	auto extended_file_info = make_shared_ptr<ExtendedOpenFileInfo>();
 	extended_file_info->options.emplace("file_size", Value(size_str).DefaultCastAs(LogicalType::UBIGINT));
 	extended_file_info->options.emplace("last_modified",
@@ -136,9 +136,11 @@ TEST_CASE("Test file size cache for glob invocation", "[mock filesystem test]") 
 	cache_filesystem->Glob(FILE_PATTERN_WITH_GLOB);
 	auto file_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
 	const int64_t file_size = cache_filesystem->GetFileSize(*file_handle);
+	const time_t last_modification_time = cache_filesystem->GetLastModifiedTime(*file_handle);
 
 	// Check invocation results.
 	REQUIRE(file_size == 10);
+	REQUIRE(last_modification_time == static_cast<time_t>(1731152288));
 	REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 1);
 	REQUIRE(mock_filesystem_ptr->GetSizeInvocation() == 0);
 	REQUIRE(mock_filesystem_ptr->GetLastModTimeInvocation() == 0);

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -153,16 +153,10 @@ TEST_CASE("Test file attribute for glob invocation", "[mock filesystem test]") {
 	auto dtor_callback = []() {
 	};
 	auto mock_filesystem = make_uniq<MockFileSystem>(std::move(close_callback), std::move(dtor_callback));
-
-	// An implementation detail: file path to glob needs to contain glob characters, otherwise cache filesystem doesn't
-	// try to cache anything.
-	const string FILE_PATTERN_WITH_GLOB = "*";
-
-	// Set an incorrect file size for mock file system, to make sure it's not called.
 	mock_filesystem->SetFileSize(20);
 	mock_filesystem->SetLastModificationTime(static_cast<time_t>(1731152288));
 
-	// Perform glob and get file size operation.
+	// Get file size and last modification timestamp.
 	auto *mock_filesystem_ptr = mock_filesystem.get();
 	auto cache_filesystem = make_uniq<CacheFileSystem>(std::move(mock_filesystem));
 	auto file_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);


### PR DESCRIPTION
This PR adds more file attributes to file metadata cache, not only file size.

I think the most difficult part is duckdb filesystem API, which should have a `Stat` call to get all file attributes.
I opened a discussion thread upstream: https://github.com/duckdb/duckdb/discussions/18489