### PR TITLE
Add a counter util

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,12 +165,13 @@ target_link_libraries(test_cache_filesystem_with_mock ${EXTENSION_NAME})
 add_executable(test_no_destructor unit/test_no_destructor.cpp)
 target_link_libraries(test_no_destructor ${EXTENSION_NAME})
 
-# # Benchmark
-# add_executable(read_s3_object benchmark/read_s3_object.cpp)
-# target_link_libraries(read_s3_object ${EXTENSION_NAME})
+# Benchmark
+add_executable(read_s3_object benchmark/read_s3_object.cpp)
+target_link_libraries(read_s3_object ${EXTENSION_NAME})
 
-# add_executable(sequential_read_benchmark benchmark/sequential_read_benchmark.cpp)
-# target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
+add_executable(sequential_read_benchmark
+               benchmark/sequential_read_benchmark.cpp)
+target_link_libraries(sequential_read_benchmark ${EXTENSION_NAME})
 
-# add_executable(random_read_benchmark benchmark/random_read_benchmark.cpp)
-# target_link_libraries(random_read_benchmark ${EXTENSION_NAME})
+add_executable(random_read_benchmark benchmark/random_read_benchmark.cpp)
+target_link_libraries(random_read_benchmark ${EXTENSION_NAME})

--- a/src/utils/include/counter.hpp
+++ b/src/utils/include/counter.hpp
@@ -11,6 +11,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include "duckdb/common/assert.hpp"
+
 namespace duckdb {
 
 template <typename Key, typename KeyHash = std::hash<Key>, typename KeyEqual = std::equal_to<Key>> 
@@ -29,7 +31,7 @@ public:
     // Increment the count for the given [key], and return the new count.
     template <typename KeyLike>
     unsigned Increment(KeyLike&& key) {
-        const auto new_count = ++counter[std::forward<Key>(key)];
+        const auto new_count = ++counter[std::forward<KeyLike>(key)];
         return new_count;
     }
 
@@ -86,14 +88,14 @@ public:
     template <typename KeyLike>
     unsigned Decrement(KeyLike&& key) {
         std::lock_guard<std::mutex> lck(mu);
-        return counter.Decrement(key);
+        return counter.Decrement(std::forward<KeyLike>(key));
     }
 
     // Get the count for the given [key].
     template <typename KeyLike>
     unsigned GetCount(KeyLike&& key) {
         std::lock_guard<std::mutex> lck(mu);
-        return counter.GetCount(key);
+        return counter.GetCount(std::forward<KeyLike>(key));
     }
 
 private:

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -146,7 +146,7 @@ TEST_CASE("Test file metadata cache for glob invocation", "[mock filesystem test
 	REQUIRE(mock_filesystem_ptr->GetLastModTimeInvocation() == 0);
 }
 
-// Testing scenario: when any file attribute is accessed, all of them should be cached. 
+// Testing scenario: when any file attribute is accessed, all of them should be cached.
 TEST_CASE("Test file attribute for glob invocation", "[mock filesystem test]") {
 	auto close_callback = []() {
 	};

--- a/unit/test_counter.cpp
+++ b/unit/test_counter.cpp
@@ -25,21 +25,21 @@ struct MapKeyHash {
 
 TEST_CASE("IncrementAndDecrement", "[counter test]") {
 	ThreadSafeCounter<std::string> counter {};
-    REQUIRE(counter.Increment("key") == 1);
-    REQUIRE(counter.GetCount("key") == 1);
-    REQUIRE(counter.Decrement("key") == 0);
-    REQUIRE(counter.GetCount("key") == 0);
+	REQUIRE(counter.Increment("key") == 1);
+	REQUIRE(counter.GetCount("key") == 1);
+	REQUIRE(counter.Decrement("key") == 0);
+	REQUIRE(counter.GetCount("key") == 0);
 }
 
 TEST_CASE("CounterWithCustomizedKey", "[counter test]") {
-    ThreadSafeCounter<MapKey, MapKeyHash, MapKeyEqual> counter {};
-    MapKey key;
+	ThreadSafeCounter<MapKey, MapKeyHash, MapKeyEqual> counter {};
+	MapKey key;
 	key.fname = "hello";
 	key.off = 10;
-    REQUIRE(counter.Increment(key) == 1);
-    REQUIRE(counter.GetCount(key) == 1);
-    REQUIRE(counter.Decrement(key) == 0);
-    REQUIRE(counter.GetCount(key) == 0);
+	REQUIRE(counter.Increment(key) == 1);
+	REQUIRE(counter.GetCount(key) == 1);
+	REQUIRE(counter.Decrement(key) == 0);
+	REQUIRE(counter.GetCount(key) == 0);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
There're two types of cache, one stores constant shared resource, another stores exclusive resource.
For the later, simple cache miss rate is not enough to tell whether we need to increase or decrease cache size;
to provide better observability, I plan to add another stats: cached_file_handle_in_use, which requires a counter.