### PR TITLE
Fix file handle cache cleanup

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -96,7 +96,6 @@ void CacheFileSystem::ClearFileHandleCache(const std::string &filepath) {
 	for (auto &cur_file_handle : file_handles) {
 		cur_file_handle->Close();
 	}
-	file_handle_cache = nullptr;
 }
 
 void CacheFileSystem::SetFileHandleCache() {


### PR DESCRIPTION
This is a bug: when cleaning up file handle cache for a particular entry, we shouldn't clear the whole cache.