### PR TITLE
Increase default file handle cache size

### DIFF
--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -52,7 +52,7 @@ inline constexpr idx_t DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT = 256;
 inline constexpr idx_t DEFAULT_IN_MEM_BLOCK_CACHE_TIMEOUT_MILLISEC = 3600ULL * 1000 /*1hour*/;
 
 // Max number of cache entries for file metadata cache.
-inline static constexpr size_t DEFAULT_MAX_METADATA_CACHE_ENTRY = 125;
+inline static constexpr size_t DEFAULT_MAX_METADATA_CACHE_ENTRY = 250;
 
 // Timeout in milliseconds of cache entries for file metadata cache.
 inline static constexpr uint64_t DEFAULT_METADATA_CACHE_ENTRY_TIMEOUT_MILLISEC = 3600ULL * 1000 /*1hour*/;


### PR DESCRIPTION
I receive user feedback on unexpected high HEAD request, which I suspect caused by insufficient cache entry size.

When I was initially working on the file handle cache, the only target is to save some `OpenFile` IO operation;
but recently I realized http file handle, for example, actually caches a lot of useful states. For example,
- File attributes, including file size, etag and last modification timestamp
- It also includes a simple TCP connection pool (though without IO multiplexing support)

This PR increases the default file handle cache size, from default 125 entries to 250 entries.
Also increases default metadata cache size from 125 to 250 as well.