### PR TITLE
feat: support local endpoint for httpfs usage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+    "service": "devcontainer",
+    "workspaceFolder": "/workspaces/duck-read-cache-fs",
+    "dockerComposeFile": "docker-compose.yml",
     "customizations": {
         "vscode": {
             "extensions": [
                 "ms-vscode.cpptools",
-                "eamodio.gitlens",
+                "eamodio.gitlens"
             ]
         }
     },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,15 +26,15 @@ services:
         aliases:
           - s3.local
     ports:
-      - "9000:9000"  # S3 API
-      - "9001:9001"  # Web UI
+      - "19000:9000"  # S3 API
+      - "19001:9001"  # Web UI
 
   fake-gcs:
     image: fsouza/fake-gcs-server:latest
     hostname: gcs
     command: ["-scheme", "http", "-port", "4443"]
     ports:
-      - "4443:4443"
+      - "14443:4443"
     networks:
       shared_network:
         aliases:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/duck-read-cache-fs:cached
+    networks:
+      - shared_network
+    depends_on:
+      - minio
+      - fake-gcs
+    command: sleep infinity
+
+  minio:
+    image: minio/minio:latest
+    hostname: minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio-data:/data
+    command: ["server", "/data", "--console-address", ":9001"]
+    networks:
+      shared_network:
+        aliases:
+          - s3.local
+    ports:
+      - "9000:9000"  # S3 API
+      - "9001:9001"  # Web UI
+
+  fake-gcs:
+    image: fsouza/fake-gcs-server:latest
+    hostname: gcs
+    command: ["-scheme", "http", "-port", "4443"]
+    ports:
+      - "4443:4443"
+    networks:
+      shared_network:
+        aliases:
+          - gcs.local
+    environment:
+      - STORAGE_DIR=/data
+    volumes:
+      - fake-gcs-data:/data
+
+volumes:
+  minio-data:
+  fake-gcs-data:
+
+networks:
+  shared_network:
+    driver: bridge


### PR DESCRIPTION
### Summary
- inspired by moonlink
- able see the endpoint after re-build folder in the container

### Close issue
issue: https://github.com/dentiny/duck-read-cache-fs/issues/63

### Result
<img width="2352" height="146" alt="Screenshot 2025-08-11 at 12 42 30 AM" src="https://github.com/user-attachments/assets/db3f0c76-4a08-445c-a3f2-677080286624" />
