### PR TITLE
[utils] Get files on modification timestamp

### DIFF
--- a/src/utils/include/filesystem_utils.hpp
+++ b/src/utils/include/filesystem_utils.hpp
@@ -3,8 +3,10 @@
 #pragma once
 
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/map.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 
@@ -28,5 +30,8 @@ idx_t GetOverallFileSystemDiskSpace(const string &path);
 
 // Return whether we could cache content in the filesystem specified by the given [path].
 bool CanCacheOnDisk(const string &path);
+
+// Get all on-disk cache files and sorted them in their creation timestamp.
+map<time_t, string> GetOnDiskFilesUnder(const vector<string>& folders);
 
 } // namespace duckdb


### PR DESCRIPTION
Add a util function to get all cache files under cache directories, sorted by their creation timestamp.
This util is made for LRU eviction policy.