### PR TITLE
Evict on-disk cache block based on LRU

### DIFF
--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -105,6 +105,15 @@ void SetGlobalConfig(optional_ptr<FileOpener> opener) {
 		if (disk_cache_min_bytes > 0) {
 			g_min_disk_bytes_for_cache = disk_cache_min_bytes;
 		}
+
+		// Check and update eviction policy.
+		FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_evict_policy", val);
+		const auto eviction_policy = val.ToString();
+		if (eviction_policy == *ON_DISK_CREATION_TIMESTAMP_EVICTION) {
+			*g_on_disk_eviction_policy = *ON_DISK_CREATION_TIMESTAMP_EVICTION;
+		} else if (eviction_policy == *ON_DISK_LRU_SINGLE_PROC_EVICTION) {
+			*g_on_disk_eviction_policy = *ON_DISK_LRU_SINGLE_PROC_EVICTION;
+		}
 	}
 
 	//===--------------------------------------------------------------------===//

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -204,6 +204,7 @@ void ResetGlobalConfig() {
 	// On-disk cache configuration.
 	*g_on_disk_cache_directories = {*DEFAULT_ON_DISK_CACHE_DIRECTORY};
 	g_min_disk_bytes_for_cache = DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
+	*g_on_disk_eviction_policy = *DEFAULT_ON_DISK_EVICTION_POLICY;
 
 	// In-memory cache configuration.
 	g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -239,6 +239,10 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          "By default, 5% disk space will be reserved for other usage. When min disk bytes "
 	                          "specified with a positive value, the default value will be overriden.",
 	                          LogicalType::UBIGINT, 0);
+	config.AddExtensionOption("cache_httpfs_evict_policy", "Eviction policy for on-disk cache cache blocks. By default it's creation timestamp based ('creation_timestamp'), which deletes all cache blocks created earlier than threshold. Other supported policy include 'lru_sp' (LRU for single process access), which performs LRU-based eviction, mainly made single process usage.",
+		LogicalType::VARCHAR, 
+		*DEFAULT_ON_DISK_EVICTION_POLICY
+	);
 	// TODO(hjiang): there're quite a few optimizations which could be done in the config. For example,
 	// - Each cache directories could have their own config, like min/max cache file size;
 	// - Current implementation uses static hash based distribution, which doesn't work well when directory set changes;

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -239,8 +239,12 @@ static void LoadInternal(DatabaseInstance &instance) {
 	                          "By default, 5% disk space will be reserved for other usage. When min disk bytes "
 	                          "specified with a positive value, the default value will be overriden.",
 	                          LogicalType::UBIGINT, 0);
-	config.AddExtensionOption("cache_httpfs_evict_policy", "Eviction policy for on-disk cache cache blocks. By default it's creation timestamp based ('creation_timestamp'), which deletes all cache blocks created earlier than threshold. Other supported policy include 'lru_sp' (LRU for single process access), which performs LRU-based eviction, mainly made single process usage.",
-		LogicalType::VARCHAR, 
+	config.AddExtensionOption("cache_httpfs_evict_policy", "Eviction policy for on-disk cache cache blocks. By default "
+							  "it's creation timestamp based ('creation_timestamp'), which deletes all cache blocks "
+							  "created earlier than threshold. Other supported policy include 'lru_single_proc' (LRU for"
+							  "single process access), which performs LRU-based eviction, mainly made single process"
+							  "usage.",
+		LogicalType::VARCHAR,
 		*DEFAULT_ON_DISK_EVICTION_POLICY
 	);
 	// TODO(hjiang): there're quite a few optimizations which could be done in the config. For example,

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -161,6 +161,7 @@ void EvictCacheFiles(DiskCacheReader& reader, FileSystem &local_filesystem, cons
 	// For LRU-based eviction, get the entry to remove and delete the file to release storage space.
 	D_ASSERT(*g_on_disk_eviction_policy == *ON_DISK_LRU_SINGLE_PROC_EVICTION);
 	const auto filepath_to_evict = reader.EvictCacheBlockLru();
+	// Intentionally ignore return value.
 	local_filesystem.TryRemoveFile(filepath_to_evict);
 }
 
@@ -210,7 +211,6 @@ string DiskCacheReader::EvictCacheBlockLru() {
 
 	auto filepath = std::move(cache_file_creation_timestamp_map.begin()->second);
 	cache_file_creation_timestamp_map.erase(cache_file_creation_timestamp_map.begin());
-
 	return filepath;
 }
 

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -147,6 +147,11 @@ string GetLocalCacheFilePrefix(const string &remote_file) {
 	return StringUtil::Format("%s.%s", remote_file_sha256_str, fname);
 }
 
+// Attempt to evict cache files, if file size threshold reached.
+void EvictCacheFiles() {
+
+}
+
 // Attempt to cache [chunk] to local filesystem, if there's sufficient disk space available.
 void CacheLocal(const CacheReadChunk &chunk, FileSystem &local_filesystem, const FileHandle &handle,
                 const string &cache_directory, const string &local_cache_file) {
@@ -182,6 +187,15 @@ void CacheLocal(const CacheReadChunk &chunk, FileSystem &local_filesystem, const
 } // namespace
 
 DiskCacheReader::DiskCacheReader() : local_filesystem(LocalFileSystem::CreateLocal()) {
+}
+
+string DiskCacheReader::GetCacheBlockToEvict() {
+	std::lock_guard<std::mutex> lck(cache_file_creation_timestamp_map_mutex);
+	// Initialize file creation timestamp map, which should be called only once.
+	// IO operation is performed inside of critical section intentionally, since it's required for all threads.
+	if (cache_file_creation_timestamp_map.empty()) {
+		
+	}
 }
 
 vector<DataCacheEntryInfo> DiskCacheReader::GetCacheEntriesInfo() const {

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -23,6 +23,11 @@ inline const NoDestructor<string> IN_MEM_CACHE_TYPE {"in_mem"};
 inline const std::unordered_set<string> ALL_CACHE_TYPES {*NOOP_CACHE_TYPE, *ON_DISK_CACHE_TYPE,
                                                               *IN_MEM_CACHE_TYPE};
 
+// Creation timestamp-based on-disk eviction policy.
+inline const NoDestructor<string> ON_DISK_CREATION_TIMESTAMP_EVICTION {"creation_timestamp"};
+// On-disk LRU eviction policy made for single-process usage.
+inline const NoDestructor<string> ON_DISK_LRU_SINGLE_PROC_EVICTION {"lru_sp"};
+
 // Default profile option, which performs no-op.
 inline const NoDestructor<string> NOOP_PROFILE_TYPE {"noop"};
 // Store the latest IO operation profiling result, which potentially suffers concurrent updates.
@@ -40,6 +45,9 @@ inline const NoDestructor<string> DEFAULT_ON_DISK_CACHE_DIRECTORY {"/tmp/duckdb_
 
 // Default to use on-disk cache filesystem.
 inline NoDestructor<string> DEFAULT_CACHE_TYPE {*ON_DISK_CACHE_TYPE};
+
+// Default to timestamp-based on-disk cache eviction policy.
+inline NoDestructor<string> DEFAULT_ON_DISK_EVICTION_POLICY {*ON_DISK_CREATION_TIMESTAMP_EVICTION};
 
 // To prevent go out of disk space, we set a threshold to disallow local caching if insufficient. It applies to all
 // filesystems. The value here is the decimal representation for percentage value; for example, 0.05 means 5%.
@@ -110,6 +118,7 @@ inline uint64_t g_max_subrequest_count = DEFAULT_MAX_SUBREQUEST_COUNT;
 // Sorted cache directories.
 inline NoDestructor<vector<string>> g_on_disk_cache_directories {*DEFAULT_ON_DISK_CACHE_DIRECTORY};
 inline idx_t g_min_disk_bytes_for_cache = DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
+inline NoDestructor<string> g_on_disk_eviction_policy {*DEFAULT_ON_DISK_EVICTION_POLICY};
 
 // In-memory cache configuration.
 inline idx_t g_max_in_mem_cache_block_count = DEFAULT_MAX_IN_MEM_CACHE_BLOCK_COUNT;

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -2,10 +2,14 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "base_cache_reader.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/map.hpp"
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
@@ -29,9 +33,16 @@ public:
 
 	vector<DataCacheEntryInfo> GetCacheEntriesInfo() const override;
 
+	// Get file cache block to evict.
+	string GetCacheBlockToEvict();
+
 private:
 	// Used to access local cache files.
 	unique_ptr<FileSystem> local_filesystem;
+	// Used for on-disk cache block LRU-based eviction.
+	std::mutex cache_file_creation_timestamp_map_mutex;
+	// Maps from last access timestamp to filepath.
+	map<time_t, string> cache_file_creation_timestamp_map;
 };
 
 } // namespace duckdb

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -34,7 +34,8 @@ public:
 	vector<DataCacheEntryInfo> GetCacheEntriesInfo() const override;
 
 	// Get file cache block to evict.
-	string GetCacheBlockToEvict();
+	// Notice returned filepath will be removed from LRU list, but the actual file won't be deleted.
+	string EvictCacheBlockLru();
 
 private:
 	// Used to access local cache files.


### PR DESCRIPTION
This PR adds a basic single-process based LRU cache block eviction: when there's insufficient disk space under cache directory, evict cache blocks based on their modification (aka, creation) timestamp.

Making multi-process LRU is complicated, for example, multiple processes could be writing cache blocks to the same directory. To keep LRU relatively precise, either we delay stat on insufficient disk space, or we maintain an internal background thread to keep it updated at real-time.

Related to https://github.com/dentiny/duck-read-cache-fs/issues/238