### PR TITLE
Add list filesystem sql function

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -163,7 +163,7 @@ bool CacheFileSystem::IsManuallySet() {
 }
 
 std::string CacheFileSystem::GetName() const {
-	return StringUtil::Format("cache_httpfs with %s", internal_filesystem->GetName());
+	return StringUtil::Format("cache_httpfs_%s", internal_filesystem->GetName());
 }
 
 unique_ptr<FileHandle> CacheFileSystem::CreateCacheFileHandleForRead(unique_ptr<FileHandle> internal_file_handle) {

--- a/test/sql/extension.test
+++ b/test/sql/extension.test
@@ -15,6 +15,14 @@ SELECT COUNT(*) FROM duckdb_extensions() WHERE extension_name = 'cache_httpfs';
 ----
 1
 
+query I
+SELECT unnest(cache_httpfs_list_registered_filesystems());
+----
+cache_httpfs_HTTPFileSystem
+cache_httpfs_HuggingFaceFileSystem
+cache_httpfs_S3FileSystem
+cache_httpfs_fake_filesystem
+
 statement ok
 SELECT cache_httpfs_clear_cache();
 


### PR DESCRIPTION
This PR does two things:
- Add a SQL function to list all registered filesystems, so users are able to know what to wrap
- Simplify httpfs filesystem registration -- current implementation attempts unregister which should be replaced by extraction operation