### PR TITLE
Record disk cache read latency

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -316,7 +316,10 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 				DUCKDB_LOG_READ_CACHE_HIT((handle));
 				void *addr = !cache_read_chunk.content.empty() ? const_cast<char *>(cache_read_chunk.content.data())
 				                                               : cache_read_chunk.requested_start_addr;
+				const string oper_id = profile_collector->GenerateOperId();
+				profile_collector->RecordOperationStart(BaseProfileCollector::IoOperation::kDiskCacheRead, oper_id);
 				local_filesystem->Read(*file_handle, addr, cache_read_chunk.chunk_size, /*location=*/0);
+				profile_collector->RecordOperationEnd(BaseProfileCollector::IoOperation::kDiskCacheRead, oper_id);
 				cache_read_chunk.CopyBufferToRequestedMemory();
 
 				// Update access and modification timestamp for the cache file, so it won't get evicted.

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -35,6 +35,8 @@ public:
 		kOpen,
 		kRead,
 		kGlob,
+		// Disk cache read and copy.
+		kDiskCacheRead,
 		kUnknown,
 	};
 	static constexpr auto kCacheEntityCount = static_cast<size_t>(CacheEntity::kUnknown);
@@ -87,11 +89,12 @@ public:
 	// TODO(hjiang): Use constants for cache entity name and operation name.
 	inline static const vector<const char *> CACHE_ENTITY_NAMES = []() {
 		vector<const char *> cache_entity_names;
-		cache_entity_names.reserve(kIoOperationCount);
+		cache_entity_names.reserve(kCacheEntityCount);
 		cache_entity_names.emplace_back("metadata");
 		cache_entity_names.emplace_back("data");
 		cache_entity_names.emplace_back("file handle");
 		cache_entity_names.emplace_back("glob");
+		D_ASSERT(cache_entity_names.size() == kCacheEntityCount);
 		return cache_entity_names;
 	}();
 	// Operation names, indexed by operation enums.
@@ -101,6 +104,8 @@ public:
 		oper_names.emplace_back("open");
 		oper_names.emplace_back("read");
 		oper_names.emplace_back("glob");
+		oper_names.emplace_back("disk_cache_read");
+		D_ASSERT(oper_names.size() == kIoOperationCount);
 		return oper_names;
 	}();
 


### PR DESCRIPTION
This PR adds latency histogram into profile system, so people can tell whether disk cache is suffering perf issue.

There're two followup items:
- Use config file to initialize histogram data member, instead of manual construction, which is easy to get wrong
- Add and update quantile calculation for latency stats