### PR TITLE
Fix cache removal

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -52,6 +52,16 @@ void CacheFileSystem::SetMetadataCache() {
 	}
 }
 
+bool CacheFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	ClearCache(filename);
+	return internal_filesystem->TryRemoveFile(filename, opener);
+}
+
+void CacheFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
+	ClearCache(filename);
+	internal_filesystem->RemoveFile(filename, opener);
+}
+
 void CacheFileSystem::SetGlobCache() {
 	if (!g_enable_glob_cache) {
 		glob_cache = nullptr;
@@ -133,6 +143,7 @@ void CacheFileSystem::ClearCache(const std::string &filepath) {
 		glob_cache->Clear([&filepath](const std::string &key) { return key == filepath; });
 	}
 	ClearFileHandleCache(filepath);
+	cache_reader_manager.ClearCache(filepath);
 }
 
 bool CacheFileSystem::CanHandleFile(const string &fpath) {

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -84,8 +84,8 @@ string Sha256ToHexString(const duckdb::hash_bytes &sha256) {
 
 // Get local cache filename for the given [remote_file].
 //
-// Cache filename is formatted as `<cache-directory>/<filename-sha256>.<filename>`. So we could get all cache files
-// under one directory, and get all cache files with commands like `ls`.
+// Cache filename is formatted as `<cache-directory>/<filename-sha256>-<filename>-<start-offset>-<size>`. So we could
+// get all cache files under one directory, and get all cache files with commands like `ls`.
 //
 // Considering the naming format, it's worth noting it might _NOT_ work for local files, including mounted filesystems.
 CacheFileDestination GetLocalCacheFile(const vector<string> &cache_directories, const string &remote_file,
@@ -145,7 +145,7 @@ string GetLocalCacheFilePrefix(const string &remote_file) {
 	const string remote_file_sha256_str = Sha256ToHexString(remote_file_sha256_val);
 
 	const string fname = StringUtil::GetFileName(remote_file);
-	return StringUtil::Format("%s.%s", remote_file_sha256_str, fname);
+	return StringUtil::Format("%s-%s", remote_file_sha256_str, fname);
 }
 
 // Attempt to evict cache files, if file size threshold reached.

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -101,6 +101,10 @@ public:
 	// It's worth noting data block cache won't get deleted.
 	void ClearCache(const std::string &filepath);
 
+	// Remove file from both internal filesystem and cache.
+	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
+
 	// For other API calls, delegate to [internal_filesystem] to handle.
 	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
 	                                          bool write) override {
@@ -149,9 +153,6 @@ public:
 	}
 	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
 		return internal_filesystem->IsPipe(filename, opener);
-	}
-	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
-		internal_filesystem->RemoveFile(filename, opener);
 	}
 	void FileSync(FileHandle &handle) override {
 		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();

--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -35,6 +35,17 @@ const auto TEST_FILE_CONTENT = []() {
 }();
 const auto TEST_FILENAME = StringUtil::Format("/tmp/%s", UUID::ToString(UUID::GenerateRandomUUID()));
 const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache";
+
+void CreateSourceTestFile() {
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
+	                                                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
+	                        TEST_FILE_SIZE, /*location=*/0);
+	file_handle->Sync();
+	file_handle->Close();
+}
+
 } // namespace
 
 // Test default directory works for uncached read.
@@ -446,6 +457,40 @@ TEST_CASE("Test on insufficient disk space", "[on-disk cache filesystem test]") 
 	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 1);
 }
 
+// Testing scenario: remove file should clear corresponding items in the cache.
+TEST_CASE("Test on file removal", "[on-disk cache filesystem test]") {
+	constexpr uint64_t test_block_size = 5;
+	*g_on_disk_cache_directories = {TEST_ON_DISK_CACHE_DIRECTORY};
+	g_cache_block_size = test_block_size;
+	SCOPE_EXIT {
+		ResetGlobalConfig();
+	};
+	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
+	auto disk_cache_fs = make_uniq<CacheFileSystem>(LocalFileSystem::CreateLocal());
+
+	// First uncached read.
+	{
+		auto handle = disk_cache_fs->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+		const uint64_t start_offset = 0;
+		const uint64_t bytes_to_read = TEST_FILE_SIZE;
+		string content(bytes_to_read, '\0');
+		disk_cache_fs->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
+		                    start_offset);
+		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
+	}
+
+	// Now remove the file and on-disk cache file.
+	disk_cache_fs->RemoveFile(TEST_FILENAME);
+	REQUIRE(GetFileCountUnder(TEST_ON_DISK_CACHE_DIRECTORY) == 0);
+
+	// Check source file existence.
+	const bool exists = disk_cache_fs->FileExists(TEST_FILENAME);
+	REQUIRE(!exists);
+
+	// Re-create the immutable test file, otherwise other test cases will break.
+	CreateSourceTestFile();
+}
+
 // Testing scenario: check lru-based eviction policy.
 TEST_CASE("Test on lru eviction", "[on-disk cache filesystem test]") {
 	SCOPE_EXIT {
@@ -520,16 +565,9 @@ TEST_CASE("Test on lru eviction", "[on-disk cache filesystem test]") {
 int main(int argc, char **argv) {
 	// Set global cache type for testing.
 	*g_test_cache_type = *ON_DISK_CACHE_TYPE;
-
-	auto local_filesystem = LocalFileSystem::CreateLocal();
-	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
-	                                                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
-	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
-	                        TEST_FILE_SIZE, /*location=*/0);
-	file_handle->Sync();
-	file_handle->Close();
+	CreateSourceTestFile();
 
 	int result = Catch::Session().run(argc, argv);
-	local_filesystem->RemoveFile(TEST_FILENAME);
+	LocalFileSystem::CreateLocal()->RemoveFile(TEST_FILENAME);
 	return result;
 }


### PR DESCRIPTION
This PR fixes two issues:
- A bug for cache block file prefix calculation: the separator between hash and source file name should be `-` instead of `.`; corresponding test case added to avoid regression
- When a file is requested to remove, all of its cache entries (including metadata cache and data cache) should be cleared as well