### PR TITLE
Provide table functions to query cache config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(EXTENSION_SOURCES
     src/cache_status_query_function.cpp
     src/cache_reader_manager.cpp
     src/disk_cache_reader.cpp
+    src/extension_config_query_function.cpp
     src/in_memory_cache_reader.cpp
     src/histogram.cpp
     src/filesystem_status_query_function.cpp

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/opener_file_system.hpp"
 #include "duckdb/storage/external_file_cache.hpp"
+#include "extension_config_query_function.hpp"
 #include "fake_filesystem.hpp"
 #include "filesystem_status_query_function.hpp"
 #include "hffs.hpp"
@@ -405,6 +406,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ScalarFunction clear_profile_stats_function("cache_httpfs_clear_profile", /*arguments=*/ {},
 	                                            /*return_type=*/LogicalType::BOOLEAN, ResetProfileStats);
 	loader.RegisterFunction(clear_profile_stats_function);
+
+	// Register table function to get current cache config.
+	loader.RegisterFunction(GetDataCacheConfigQueryFunc());
+	loader.RegisterFunction(GetMetadataCacheConfigQueryFunc());
+	loader.RegisterFunction(GetFileHandleCacheConfigQueryFunc());
+	loader.RegisterFunction(GetGlobCacheConfigQueryFunc());
+	loader.RegisterFunction(GetCacheTypeQueryFunc());
+	loader.RegisterFunction(GetCacheConfigQueryFunc());
 
 	// Register filesystem registration query function.
 	loader.RegisterFunction(ListRegisteredFileSystemsQueryFunc());

--- a/src/extension_config_query_function.cpp
+++ b/src/extension_config_query_function.cpp
@@ -1,0 +1,442 @@
+#include "extension_config_query_function.hpp"
+
+#include "cache_exclusion_manager.hpp"
+#include "cache_filesystem_config.hpp"
+#include "duckdb/common/extra_type_info.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+namespace {
+
+struct CacheConfigData : public GlobalTableFunctionState {
+	// Cache config should be emitted only once.
+	bool emitted = false;
+};
+
+// Get disk cache directories in duckdb [`Value`].
+Value GetDiskCacheDirectories() {
+	vector<Value> directories;
+	directories.reserve(g_on_disk_cache_directories->size());
+	for (const auto &cur_dir : *g_on_disk_cache_directories) {
+		directories.emplace_back(Value {cur_dir});
+	}
+	return Value::LIST(LogicalType::VARCHAR, std::move(directories));
+}
+
+// Get cache exclusion regexes in duckdb [`Value`].
+Value GetCacheExclusionRegexes() {
+	auto exclusion_regexes = CacheExclusionManager::GetInstance().GetExclusionRegex();
+	vector<Value> exclusion_regex_values;
+	exclusion_regex_values.reserve(exclusion_regexes.size());
+	for (auto &cur_regex : exclusion_regex_values) {
+		exclusion_regex_values.emplace_back(Value {std::move(cur_regex)});
+	}
+	return Value::LIST(LogicalType::VARCHAR, std::move(exclusion_regex_values));
+}
+
+void DataCacheConfigQueryFuncBindImpl(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("data cache type");
+	if (*g_cache_type == *ON_DISK_CACHE_TYPE) {
+		return_types.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
+		names.emplace_back("disk cache directories");
+
+		return_types.emplace_back(LogicalType::UBIGINT);
+		names.emplace_back("disk cache block size");
+
+		return_types.emplace_back(LogicalType::VARCHAR);
+		names.emplace_back("disk cache eviction policy");
+	} else if (*g_cache_type == *IN_MEM_CACHE_TYPE) {
+		return_types.emplace_back(LogicalType::UBIGINT);
+		names.emplace_back("in-memory cache block size");
+
+		return_types.emplace_back(LogicalType::VARCHAR);
+		names.emplace_back("in-memory cache eviction policy");
+	}
+}
+
+void FillDataCacheConfig(DataChunk &output, idx_t &col) {
+	output.SetValue(col++, /*index=*/0, *g_cache_type);
+	if (*g_cache_type == *ON_DISK_CACHE_TYPE) {
+		output.SetValue(col++, /*index=*/0, GetDiskCacheDirectories());
+		output.SetValue(col++, /*index=*/0, Value::UBIGINT(g_cache_block_size));
+		output.SetValue(col++, /*index=*/0, *g_on_disk_eviction_policy);
+	} else if (*g_cache_type == *IN_MEM_CACHE_TYPE) {
+		output.SetValue(col++, /*index=*/0, Value::UBIGINT(g_cache_block_size));
+		output.SetValue(col++, /*index=*/0, "lru"); // currently only LRU supported
+	}
+}
+
+void MetadataCacheConfigQueryFuncBindImpl(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("metadata cache type");
+	if (g_enable_metadata_cache) {
+		return_types.emplace_back(LogicalType::UBIGINT);
+		names.emplace_back("metadata cache entry size");
+	}
+}
+
+void FillMetadataCacheConfig(DataChunk &output, idx_t &col) {
+	if (g_enable_metadata_cache) {
+		output.SetValue(col++, /*index=*/0, "enabled");
+		output.SetValue(col++, /*index=*/0, Value::UBIGINT(g_max_metadata_cache_entry));
+	} else {
+		output.SetValue(col++, /*index=*/0, "disabled");
+	}
+}
+
+void FileHandleCacheConfigQueryFuncBindImpl(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("file handle cache type");
+	if (g_enable_file_handle_cache) {
+		return_types.emplace_back(LogicalType::UBIGINT);
+		names.emplace_back("file handle cache entry size");
+	}
+}
+
+void FillFileHandleCacheConfig(DataChunk &output, idx_t &col) {
+	if (g_enable_file_handle_cache) {
+		output.SetValue(col++, /*index=*/0, "enabled");
+		output.SetValue(col++, /*index=*/0, Value::UBIGINT(g_max_file_handle_cache_entry));
+	} else {
+		output.SetValue(col++, /*index=*/0, "disabled");
+	}
+}
+
+void GlobCacheConfigQueryFuncBindImpl(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("glob cache type");
+	if (g_enable_glob_cache) {
+		return_types.emplace_back(LogicalType::UBIGINT);
+		names.emplace_back("glob cache entry size");
+	}
+}
+
+void FillGlobCacheConfig(DataChunk &output, idx_t &col) {
+	if (g_enable_glob_cache) {
+		output.SetValue(col++, /*index=*/0, "enabled");
+		output.SetValue(col++, /*index=*/0, Value::UBIGINT(g_max_glob_cache_entry));
+	} else {
+		output.SetValue(col++, /*index=*/0, "disabled");
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Data cache config query function
+//===--------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> DataCacheConfigQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+	DataCacheConfigQueryFuncBindImpl(return_types, names);
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> DataCacheConfigQueryFuncInit(ClientContext &context,
+                                                                  TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheConfigData>();
+	return std::move(result);
+}
+
+void DataCacheConfigQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheConfigData>();
+
+	// Config has already been emitted.
+	if (data.emitted) {
+		return;
+	}
+	data.emitted = true;
+
+	idx_t col = 0;
+	FillDataCacheConfig(output, col);
+	output.SetCardinality(/*count=*/1);
+}
+
+//===--------------------------------------------------------------------===//
+// Metadata cache config query function
+//===--------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> MetadataCacheConfigQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                          vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+	MetadataCacheConfigQueryFuncBindImpl(return_types, names);
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> MetadataCacheConfigQueryFuncInit(ClientContext &context,
+                                                                      TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheConfigData>();
+	return std::move(result);
+}
+
+void MetadataCacheConfigQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheConfigData>();
+
+	// Config has already been emitted.
+	if (data.emitted) {
+		return;
+	}
+	data.emitted = true;
+
+	idx_t col = 0;
+	FillMetadataCacheConfig(output, col);
+	output.SetCardinality(/*count=*/1);
+}
+
+//===--------------------------------------------------------------------===//
+// File handle cache config query function
+//===--------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> FileHandleCacheConfigQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                            vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+	FileHandleCacheConfigQueryFuncBindImpl(return_types, names);
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> FileHandleCacheConfigQueryFuncInit(ClientContext &context,
+                                                                        TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheConfigData>();
+	return std::move(result);
+}
+
+void FileHandleCacheConfigQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheConfigData>();
+
+	// Config has already been emitted.
+	if (data.emitted) {
+		return;
+	}
+	data.emitted = true;
+
+	idx_t col = 0;
+	FillFileHandleCacheConfig(output, col);
+	output.SetCardinality(/*count=*/1);
+}
+
+//===--------------------------------------------------------------------===//
+// Glob cache config query function
+//===--------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> GlobCacheConfigQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+	GlobCacheConfigQueryFuncBindImpl(return_types, names);
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> GlobCacheConfigQueryFuncInit(ClientContext &context,
+                                                                  TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheConfigData>();
+	return std::move(result);
+}
+
+void GlobCacheConfigQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheConfigData>();
+
+	// Config has already been emitted.
+	if (data.emitted) {
+		return;
+	}
+	data.emitted = true;
+
+	idx_t col = 0;
+	FillGlobCacheConfig(output, col);
+	output.SetCardinality(/*count=*/1);
+}
+
+//===--------------------------------------------------------------------===//
+// Cache type and enablement query function
+//===--------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> CacheTypeQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+
+	return_types.reserve(4);
+	names.reserve(4);
+
+	// Intentionally use string instead of boolean to indicate cache enabled or not, for better display.
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("data cache");
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("metadata cache");
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("file handle cache");
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("glob cache");
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> CacheTypeQueryFuncInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheConfigData>();
+	return std::move(result);
+}
+
+void CacheTypeQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheConfigData>();
+
+	// Config has already been emitted.
+	if (data.emitted) {
+		return;
+	}
+	data.emitted = true;
+
+	idx_t col = 0;
+
+	// Data cache.
+	output.SetValue(col++, /*index=*/0, *g_cache_type);
+
+	// Metadata cache.
+	if (g_enable_metadata_cache) {
+		output.SetValue(col++, /*index=*/0, "enabled");
+	} else {
+		output.SetValue(col++, /*index=*/0, "disabled");
+	}
+
+	// File handle cache.
+	if (g_enable_file_handle_cache) {
+		output.SetValue(col++, /*index=*/0, "enabled");
+	} else {
+		output.SetValue(col++, /*index=*/0, "disabled");
+	}
+
+	// Glob cache.
+	if (g_enable_glob_cache) {
+		output.SetValue(col++, /*index=*/0, "enabled");
+	} else {
+		output.SetValue(col++, /*index=*/0, "disabled");
+	}
+
+	output.SetCardinality(/*count=*/1);
+}
+
+//===--------------------------------------------------------------------===//
+// Cache config query function
+//===--------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> CacheConfigQueryFuncBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	D_ASSERT(return_types.empty());
+	D_ASSERT(names.empty());
+
+	// Data cache config.
+	DataCacheConfigQueryFuncBindImpl(return_types, names);
+
+	// Metadata cache config.
+	MetadataCacheConfigQueryFuncBindImpl(return_types, names);
+
+	// File handle cache config.
+	FileHandleCacheConfigQueryFuncBindImpl(return_types, names);
+
+	// Glob cache config.
+	GlobCacheConfigQueryFuncBindImpl(return_types, names);
+
+	// Cache exclusion regex.
+	return_types.emplace_back(LogicalType::LIST(LogicalType::VARCHAR));
+	names.emplace_back("cache exclusion regexes");
+
+	return nullptr;
+}
+
+unique_ptr<GlobalTableFunctionState> CacheConfigQueryFuncInit(ClientContext &context, TableFunctionInitInput &input) {
+	auto result = make_uniq<CacheConfigData>();
+	return std::move(result);
+}
+
+void CacheConfigQueryTableFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.global_state->Cast<CacheConfigData>();
+
+	// Config has already been emitted.
+	if (data.emitted) {
+		return;
+	}
+	data.emitted = true;
+
+	idx_t col = 0;
+
+	// Data cache config.
+	FillDataCacheConfig(output, col);
+
+	// Metadata cache config.
+	FillMetadataCacheConfig(output, col);
+
+	// File handle cache config.
+	FillFileHandleCacheConfig(output, col);
+
+	// Glob cache config.
+	FillGlobCacheConfig(output, col);
+
+	// Cache exclusion regex.
+	output.SetValue(col++, /*index=*/0, GetCacheExclusionRegexes());
+
+	output.SetCardinality(/*count=*/1);
+}
+} // namespace
+
+TableFunction GetDataCacheConfigQueryFunc() {
+	TableFunction get_data_cache_config_query_func {/*name=*/"cache_httpfs_get_data_cache_config",
+	                                                /*arguments=*/ {},
+	                                                /*function=*/DataCacheConfigQueryTableFunc,
+	                                                /*bind=*/DataCacheConfigQueryFuncBind,
+	                                                /*init_global=*/DataCacheConfigQueryFuncInit};
+	return get_data_cache_config_query_func;
+}
+
+TableFunction GetMetadataCacheConfigQueryFunc() {
+	TableFunction get_metadata_cache_config_query_func {/*name=*/"cache_httpfs_get_metadata_cache_config",
+	                                                    /*arguments=*/ {},
+	                                                    /*function=*/MetadataCacheConfigQueryTableFunc,
+	                                                    /*bind=*/MetadataCacheConfigQueryFuncBind,
+	                                                    /*init_global=*/MetadataCacheConfigQueryFuncInit};
+	return get_metadata_cache_config_query_func;
+}
+
+TableFunction GetFileHandleCacheConfigQueryFunc() {
+	TableFunction get_file_handle_cache_config_query_func {/*name=*/"cache_httpfs_get_file_handle_cache_config",
+	                                                       /*arguments=*/ {},
+	                                                       /*function=*/FileHandleCacheConfigQueryTableFunc,
+	                                                       /*bind=*/FileHandleCacheConfigQueryFuncBind,
+	                                                       /*init_global=*/FileHandleCacheConfigQueryFuncInit};
+	return get_file_handle_cache_config_query_func;
+}
+
+TableFunction GetGlobCacheConfigQueryFunc() {
+	TableFunction get_glob_cache_config_query_func {/*name=*/"cache_httpfs_get_glob_cache_config",
+	                                                /*arguments=*/ {},
+	                                                /*function=*/GlobCacheConfigQueryTableFunc,
+	                                                /*bind=*/GlobCacheConfigQueryFuncBind,
+	                                                /*init_global=*/GlobCacheConfigQueryFuncInit};
+	return get_glob_cache_config_query_func;
+}
+
+TableFunction GetCacheTypeQueryFunc() {
+	TableFunction get_cache_type_query_func {/*name=*/"cache_httpfs_get_cache_type",
+	                                         /*arguments=*/ {},
+	                                         /*function=*/CacheTypeQueryTableFunc,
+	                                         /*bind=*/CacheTypeQueryFuncBind,
+	                                         /*init_global=*/CacheTypeQueryFuncInit};
+	return get_cache_type_query_func;
+}
+
+TableFunction GetCacheConfigQueryFunc() {
+	TableFunction get_cache_config_query_func {/*name=*/"cache_httpfs_get_cache_config",
+	                                           /*arguments=*/ {},
+	                                           /*function=*/CacheConfigQueryTableFunc,
+	                                           /*bind=*/CacheConfigQueryFuncBind,
+	                                           /*init_global=*/CacheConfigQueryFuncInit};
+	return get_cache_config_query_func;
+}
+
+} // namespace duckdb

--- a/src/include/extension_config_query_function.hpp
+++ b/src/include/extension_config_query_function.hpp
@@ -1,0 +1,27 @@
+// This file contains query function to get current cache config.
+
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+
+namespace duckdb {
+
+// Get table function to query data cache config.
+TableFunction GetDataCacheConfigQueryFunc();
+
+// Get table function to query metadata cache config.
+TableFunction GetMetadataCacheConfigQueryFunc();
+
+// Get table function to query file handle cache config.
+TableFunction GetFileHandleCacheConfigQueryFunc();
+
+// Get table function to query glob cache config.
+TableFunction GetGlobCacheConfigQueryFunc();
+
+// Get table function to query cache type and enablement.
+TableFunction GetCacheTypeQueryFunc();
+
+// Get table function to query cache extension config.
+TableFunction GetCacheConfigQueryFunc();
+
+} // namespace duckdb

--- a/test/sql/extension_config.test
+++ b/test/sql/extension_config.test
@@ -1,0 +1,47 @@
+# name: test/sql/extension_config.test
+# description: test extension config fetching
+# group: [sql]
+
+require cache_httpfs
+
+# Query cache type.
+query IIII
+SELECT * FROM cache_httpfs_get_cache_type();
+----
+on_disk	enabled	enabled	enabled
+
+# Query data cache config.
+query IIII
+SELECT * FROM cache_httpfs_get_data_cache_config();
+----
+on_disk	[/tmp/duckdb_cache_httpfs_cache]	524288	creation_timestamp
+
+# Currently implementation late updates cache type on IO access, to check data cache config after update, have to perform an IO operation first.
+statement ok
+SET cache_httpfs_type='in_mem';
+
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 1;
+
+query III
+SELECT * FROM cache_httpfs_get_data_cache_config();
+----
+in_mem		524288	lru
+
+# Query metadata cache config.
+query II
+SELECT * FROM cache_httpfs_get_metadata_cache_config();
+----
+enabled		250
+
+# Query file handle cache config.
+query II
+SELECT * FROM cache_httpfs_get_file_handle_cache_config();
+----
+enabled		250
+
+# Query glob cache config.
+query II
+SELECT * FROM cache_httpfs_get_glob_cache_config();
+----
+enabled		64


### PR DESCRIPTION
Currently the extension contains 4 types of caches: data, metadata, file handle, glob, and each of them have their own configs. Users could query current config setting of course, but the added table functions group related configs together, based on cache types, for better usability.

One downside of the current approach is:
- Current extension late applies config change on the first IO operation
- So right after a user updates a config, query config won't reflect it directly
- Issue to track: https://github.com/dentiny/duck-read-cache-fs/issues/259

Example usage:
```sql
D SELECT * FROM cache_httpfs_get_data_cache_config();
┌─────────────────┬──────────────────────────────────┬───────────────────────┬────────────────────────────┐
│ data cache type │      disk cache directories      │ disk cache block size │ disk cache eviction policy │
│     varchar     │            varchar[]             │        uint64         │          varchar           │
├─────────────────┼──────────────────────────────────┼───────────────────────┼────────────────────────────┤
│ on_disk         │ [/tmp/duckdb_cache_httpfs_cache] │        524288         │ creation_timestamp         │
└─────────────────┴──────────────────────────────────┴───────────────────────┴────────────────────────────┘

D SET cache_httpfs_type='in_mem';
-- Force an IO operation due to the limitation mentioned above.
D SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 1;
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│     251      │
└──────────────┘

D SELECT * FROM cache_httpfs_get_data_cache_config();
┌─────────────────┬────────────────────────────┬─────────────────────────────────┐
│ data cache type │ in-memory cache block size │ in-memory cache eviction policy │
│     varchar     │           uint64           │             varchar             │
├─────────────────┼────────────────────────────┼─────────────────────────────────┤
│ in_mem          │           524288           │ lru                             │
└─────────────────┴────────────────────────────┴─────────────────────────────────┘

D SELECT * FROM cache_httpfs_get_metadata_cache_config();
┌─────────────────────┬───────────────────────────┐
│ metadata cache type │ metadata cache entry size │
│       varchar       │          uint64           │
├─────────────────────┼───────────────────────────┤
│ enabled             │            250            │
└─────────────────────┴───────────────────────────┘

D SELECT * FROM cache_httpfs_get_file_handle_cache_config();
┌────────────────────────┬──────────────────────────────┐
│ file handle cache type │ file handle cache entry size │
│        varchar         │            uint64            │
├────────────────────────┼──────────────────────────────┤
│ enabled                │             250              │
└────────────────────────┴──────────────────────────────┘

D SELECT * FROM cache_httpfs_get_glob_cache_config();
┌─────────────────┬───────────────────────┐
│ glob cache type │ glob cache entry size │
│     varchar     │        uint64         │
├─────────────────┼───────────────────────┤
│ enabled         │          64           │
└─────────────────┴───────────────────────┘
```