### PR TITLE
Fix clear cache

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -134,6 +134,7 @@ void CacheFileSystem::ClearCache() {
 		glob_cache->Clear();
 	}
 	ClearFileHandleCache();
+	cache_reader_manager.ClearCache();
 }
 
 void CacheFileSystem::ClearCache(const std::string &filepath) {


### PR DESCRIPTION
Fix for https://github.com/dentiny/duck-read-cache-fs/pull/280.

After introducing write-through/read-through cache for disk cache reader, all cache clear function also needs to consider it.