### PR TITLE
Add memory cache for disk cache reader into cache status

### DIFF
--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -309,6 +309,7 @@ SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query();
 ----
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem-disk-cache
 /tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	stock/exchanges.csv	0	16222	on-disk
 
 # Query parquet file.

--- a/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
+++ b/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
@@ -39,5 +39,7 @@ SELECT COUNT(*) FROM read_parquet('https://blobs.duckdb.org/data/taxi_2019_04.pa
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query();
 ----
+(no disk cache)	https://blobs.duckdb.org/data/taxi_2019_04.parquet	126877696	127056503	in-mem-disk-cache
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem-disk-cache
 /tmp/duckdb_cache_httpfs_cache_1/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	stock/exchanges.csv	0	16222	on-disk
 /tmp/duckdb_cache_httpfs_cache_2/9a30b02c260f8209e5648653bcedd2e125f0a796061b24a0b996c4bc867d38c7-taxi_2019_04.parquet-126877696-178807	taxi_2019_04.parquet	126877696	127056503	on-disk

--- a/test/sql/glob_read.test
+++ b/test/sql/glob_read.test
@@ -30,6 +30,8 @@ test	88	NULL	2020-12-30 00:25:58.745232+00
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query() ORDER BY remote_filename;
 ----
+(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv	0	23	in-mem-disk-cache
+(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv	0	171	in-mem-disk-cache
 /tmp/duckdb_cache_httpfs_cache/790e86440e87f3fe45cbfab00131ea59fbe90728a8277d2bc0610e9c43dae4cf-ubn1.csv-0-23	ubn1.csv	0	23	on-disk
 /tmp/duckdb_cache_httpfs_cache/716e708a8a767ba362ce86783df2a9bdf9f1e867fa38091e09865a3d3bf96a7a-ubn2.csv-0-171	ubn2.csv	0	171	on-disk
 


### PR DESCRIPTION
This PR is a followup PR for https://github.com/dentiny/duck-read-cache-fs/pull/280, adds disk cache reader's in-memory cache to cache status report.
