### PR TITLE
Add test for cache status after clear

### DIFF
--- a/test/sql/cache_access_info.test
+++ b/test/sql/cache_access_info.test
@@ -22,10 +22,9 @@ SET cache_httpfs_profile_type='temp';
 statement ok
 SELECT cache_httpfs_clear_cache();
 
-query I
-SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
 ----
-0
 
 statement ok
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');

--- a/test/sql/clear_cache.test
+++ b/test/sql/clear_cache.test
@@ -7,10 +7,9 @@ require cache_httpfs
 statement ok
 SELECT cache_httpfs_clear_cache();
 
-query I
-SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
 ----
-0
 
 # Cannot use on-disk cache, because it doesn't support clear cache by filepath.
 statement ok

--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -20,10 +20,9 @@ SET cache_httpfs_cache_directory='/tmp/duckdb_cache_httpfs_cache';
 statement ok
 SELECT cache_httpfs_clear_cache();
 
-query I
-SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
 ----
-0
 
 # Test uncached query.
 query IIIIII
@@ -294,10 +293,9 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 statement ok
 SELECT cache_httpfs_clear_cache();
 
-query I
-SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
 ----
-0
 
 query I
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');

--- a/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
+++ b/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
@@ -20,10 +20,9 @@ statement ok
 SELECT cache_httpfs_clear_cache();
 
 # Check no cache entry after clearing cache.
-query I
-SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
 ----
-0
 
 query I
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');

--- a/test/sql/wrap_cache_filesystem.test
+++ b/test/sql/wrap_cache_filesystem.test
@@ -15,10 +15,9 @@ SELECT cache_httpfs_wrap_cache_filesystem('cache_httpfs_fake_filesystem');
 statement ok
 SELECT cache_httpfs_clear_cache();
 
-query I
-SELECT COUNT(*) FROM cache_httpfs_cache_status_query();
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query();
 ----
-0
 
 # Check read through fake filesystem works fine.
 statement ok


### PR DESCRIPTION
I'm not sure why CI pipeline shows different results with local reproduction (example: https://github.com/duckdb/community-extensions/actions/runs/18615222411/job/53078820335?pr=745), so simply add cache status check after clear.