### PR TITLE
Fix database attachment

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -182,6 +182,10 @@ std::string CacheFileSystem::GetName() const {
 }
 
 unique_ptr<FileHandle> CacheFileSystem::CreateCacheFileHandleForRead(unique_ptr<FileHandle> internal_file_handle) {
+	if (internal_file_handle == nullptr) {
+		return nullptr;
+	}
+
 	const auto flags = internal_file_handle->GetFlags();
 	D_ASSERT(flags.OpenForReading());
 
@@ -345,7 +349,7 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const strin
 		const auto latency_guard = profile_collector->RecordOperationStart(IoOperation::kOpen);
 		file_handle = internal_filesystem->OpenFile(path, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
 	}
-	DUCKDB_LOG_OPEN_CACHE_MISS((*file_handle));
+	DUCKDB_LOG_OPEN_CACHE_MISS_PTR((file_handle));
 	return CreateCacheFileHandleForRead(std::move(file_handle));
 }
 

--- a/src/include/cache_filesystem_logger.hpp
+++ b/src/include/cache_filesystem_logger.hpp
@@ -2,10 +2,44 @@
 
 namespace duckdb {
 
+// Reference-version macros.
 #define DUCKDB_LOG_OPEN_CACHE_HIT(HANDLE)  DUCKDB_LOG_FILE_SYSTEM(HANDLE, "FILE OPEN CACHE HIT");
 #define DUCKDB_LOG_OPEN_CACHE_MISS(HANDLE) DUCKDB_LOG_FILE_SYSTEM(HANDLE, "FILE OPEN CACHE MISS");
 
 #define DUCKDB_LOG_READ_CACHE_HIT(HANDLE)  DUCKDB_LOG_FILE_SYSTEM(HANDLE, "FILE READ CACHE HIT");
 #define DUCKDB_LOG_READ_CACHE_MISS(HANDLE) DUCKDB_LOG_FILE_SYSTEM(HANDLE, "FILE READ CACHE MISS");
+
+// Pointer-version macros.
+#define DUCKDB_LOG_OPEN_CACHE_HIT_PTR(HANDLE)                                                                          \
+	do {                                                                                                               \
+		if ((HANDLE) != nullptr) {                                                                                     \
+			auto &__handle = *HANDLE;                                                                                  \
+			DUCKDB_LOG_FILE_SYSTEM(__handle, "FILE OPEN CACHE HIT");                                                   \
+		}                                                                                                              \
+	} while (0)
+
+#define DUCKDB_LOG_OPEN_CACHE_MISS_PTR(HANDLE)                                                                         \
+	do {                                                                                                               \
+		if ((HANDLE) != nullptr) {                                                                                     \
+			auto &__handle = *HANDLE;                                                                                  \
+			DUCKDB_LOG_FILE_SYSTEM(__handle, "FILE OPEN CACHE MISS");                                                  \
+		}                                                                                                              \
+	} while (0)
+
+#define DUCKDB_LOG_READ_CACHE_HIT_PTR(HANDLE)                                                                          \
+	do {                                                                                                               \
+		if ((HANDLE) != nullptr) {                                                                                     \
+			auto &__handle = *HANDLE;                                                                                  \
+			DUCKDB_LOG_FILE_SYSTEM(__handle, "FILE READ CACHE HIT");                                                   \
+		}                                                                                                              \
+	} while (0)
+
+#define DUCKDB_LOG_READ_CACHE_MISS_PTR(HANDLE)                                                                         \
+	do {                                                                                                               \
+		if ((HANDLE) != nullptr) {                                                                                     \
+			auto &__handle = *HANDLE;                                                                                  \
+			DUCKDB_LOG_FILE_SYSTEM(__handle, "FILE READ CACHE MISS");                                                  \
+		}                                                                                                              \
+	} while (0)
 
 } // namespace duckdb

--- a/test/sql/attach_db.test
+++ b/test/sql/attach_db.test
@@ -1,0 +1,13 @@
+# name: test/sql/attach_db.test
+# description: test database file attachment
+# group: [sql]
+
+require cache_httpfs
+
+statement ok
+ATTACH 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/sample.duckdb' as db;
+
+query III
+SELECT database_name, schema_name, table_name FROM duckdb_tables() WHERE database_name = 'db';
+----
+db	main	users


### PR DESCRIPTION
This PR fixes https://github.com/dentiny/duck-read-cache-fs/issues/187, https://github.com/dentiny/duck-read-cache-fs/issues/186

TLDR:
- In duckdb internal, it requires to attach remote duckdb database file with httpfs extension loaded
- I tried to fix the constraint with duckdb, but the team has some concerns: https://github.com/duckdb/duckdb/pull/17178
- In this PR I workaround by: manually load the `httpfs` into database extension manager, which achieves the same effect as `LOAD httpfs`, also achieve the 100% compatibility as the extension declares

This PR also fixes a segfault in cache filesystem.