### PR TITLE
[minor] Use duckdb containers instead of STL

### DIFF
--- a/src/histogram.cpp
+++ b/src/histogram.cpp
@@ -16,7 +16,7 @@ Histogram::Histogram(double min_val, double max_val, int num_bkt)
 	Reset();
 }
 
-void Histogram::SetStatsDistribution(std::string name, std::string unit) {
+void Histogram::SetStatsDistribution(string name, string unit) {
 	distribution_name_ = std::move(name);
 	distribution_unit_ = std::move(unit);
 }
@@ -60,8 +60,8 @@ double Histogram::mean() const {
 	return sum_ / total_counts_;
 }
 
-std::string Histogram::FormatString() const {
-	std::string res;
+string Histogram::FormatString() const {
+	string res;
 
 	// Format outliers.
 	if (!outliers_.empty()) {

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
 #include <utility>
 
 #include "cache_entry_info.hpp"
 #include "cache_filesystem_config.hpp"
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
 #include "io_operations.hpp"
 
@@ -51,18 +51,18 @@ public:
 	// Record cache access condition.
 	virtual void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) = 0;
 	// Get profiler type.
-	virtual std::string GetProfilerType() = 0;
+	virtual string GetProfilerType() = 0;
 	// Get cache access information.
 	// It's guaranteed that access info are returned in the order of and are size of [CacheEntity].
 	virtual vector<CacheAccessInfo> GetCacheAccessInfo() const = 0;
 	// Set cache reader type.
-	void SetCacheReaderType(std::string cache_reader_type_p) {
+	void SetCacheReaderType(string cache_reader_type_p) {
 		cache_reader_type = std::move(cache_reader_type_p);
 	}
 	// Reset profile stats.
 	virtual void Reset() = 0;
 	// Get human-readable aggregated profile collection, and its latest completed IO operation timestamp.
-	virtual std::pair<std::string /*stats*/, uint64_t /*timestamp*/> GetHumanReadableStats() = 0;
+	virtual std::pair<string /*stats*/, uint64_t /*timestamp*/> GetHumanReadableStats() = 0;
 
 	template <class TARGET>
 	TARGET &Cast() {
@@ -76,7 +76,7 @@ public:
 	}
 
 protected:
-	std::string cache_reader_type = "";
+	string cache_reader_type = "";
 };
 
 class NoopProfileCollector final : public BaseProfileCollector {
@@ -91,7 +91,7 @@ public:
 	}
 	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) override {
 	}
-	std::string GetProfilerType() override {
+	string GetProfilerType() override {
 		return *NOOP_PROFILE_TYPE;
 	}
 	vector<CacheAccessInfo> GetCacheAccessInfo() const override {
@@ -103,7 +103,7 @@ public:
 		return cache_access_info;
 	}
 	void Reset() override {};
-	std::pair<std::string, uint64_t> GetHumanReadableStats() override {
+	std::pair<string, uint64_t> GetHumanReadableStats() override {
 		return std::make_pair("(noop profile collector)", /*timestamp=*/0);
 	}
 };

--- a/src/include/cache_entry_info.hpp
+++ b/src/include/cache_entry_info.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
+
+#include "duckdb/common/string.hpp"
 
 namespace duckdb {
 
 // Entry information for data cache, which applies to both in-memory cache and on-disk cache.
 struct DataCacheEntryInfo {
-	std::string cache_filepath;
-	std::string remote_filename;
+	string cache_filepath;
+	string remote_filename;
 	uint64_t start_offset = 0; // Inclusive.
 	uint64_t end_offset = 0;   // Exclusive.
-	std::string cache_type;    // Either in-memory or on-disk.
+	string cache_type;         // Either in-memory or on-disk.
 };
 
 bool operator<(const DataCacheEntryInfo &lhs, const DataCacheEntryInfo &rhs);
@@ -19,7 +20,7 @@ bool operator<(const DataCacheEntryInfo &lhs, const DataCacheEntryInfo &rhs);
 // Cache access information, which applies to metadata and file handle cache.
 struct CacheAccessInfo {
 	// Cache entity name.
-	std::string cache_type;
+	string cache_type;
 	// Number of cache hit.
 	uint64_t cache_hit_count = 0;
 	// Number of cache miss.

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -2,12 +2,11 @@
 
 #include <cstdint>
 #include <optional>
-#include <string>
-#include <unordered_set>
 
 #include "duckdb/common/file_opener.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/vector.hpp"
 #include "no_destructor.hpp"
 #include "size_literals.hpp"

--- a/src/include/cache_httpfs_extension.hpp
+++ b/src/include/cache_httpfs_extension.hpp
@@ -1,16 +1,15 @@
 #pragma once
 
 #include "duckdb.hpp"
-
-#include <string>
+#include "duckdb/common/string.hpp"
 
 namespace duckdb {
 
 class CacheHttpfsExtension : public Extension {
 public:
 	void Load(ExtensionLoader &loader) override;
-	std::string Name() override;
-	std::string Version() const override;
+	string Name() override;
+	string Version() const override;
 
 private:
 	// Cache httpfs automatically loads httpfs.

--- a/src/include/histogram.hpp
+++ b/src/include/histogram.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <cstddef>
-#include <string>
-#include <vector>
+
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 
@@ -70,12 +71,12 @@ private:
 	// Accumulated sum.
 	double sum_ = 0.0;
 	// List of bucket counts.
-	std::vector<size_t> hist_;
+	vector<size_t> hist_;
 	// List of outliers.
-	std::vector<double> outliers_;
+	vector<double> outliers_;
 	// Item name and unit for stats distribution.
-	std::string distribution_name_;
-	std::string distribution_unit_;
+	string distribution_name_;
+	string distribution_unit_;
 };
 
 } // namespace duckdb

--- a/src/include/in_mem_cache_block.hpp
+++ b/src/include/in_mem_cache_block.hpp
@@ -5,15 +5,15 @@
 #include <cstdint>
 #include <functional>
 #include <mutex>
-#include <string>
 #include <tuple>
 
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 
 struct InMemCacheBlock {
-	std::string fname;
+	string fname;
 	idx_t start_off = 0;
 	idx_t blk_size = 0;
 };
@@ -25,8 +25,7 @@ struct InMemCacheBlockEqual {
 };
 struct InMemCacheBlockHash {
 	std::size_t operator()(const InMemCacheBlock &key) const {
-		return std::hash<std::string> {}(key.fname) ^ std::hash<idx_t> {}(key.start_off) ^
-		       std::hash<idx_t> {}(key.blk_size);
+		return std::hash<string> {}(key.fname) ^ std::hash<idx_t> {}(key.start_off) ^ std::hash<idx_t> {}(key.blk_size);
 	}
 };
 

--- a/src/utils/include/copiable_value_lru_cache.hpp
+++ b/src/utils/include/copiable_value_lru_cache.hpp
@@ -13,13 +13,13 @@
 #include <functional>
 #include <list>
 #include <memory>
-#include <unordered_map>
-#include <string>
 #include <utility>
 #include <type_traits>
 #include <mutex>
 
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "map_utils.hpp"
 #include "time_utils.hpp"

--- a/src/utils/include/counter.hpp
+++ b/src/utils/include/counter.hpp
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <mutex>
-#include <unordered_map>
 #include <utility>
 
 #include "duckdb/common/assert.hpp"
+#include "duckdb/common/unordered_map.hpp"
 
 namespace duckdb {
 

--- a/src/utils/include/exclusive_lru_cache.hpp
+++ b/src/utils/include/exclusive_lru_cache.hpp
@@ -15,12 +15,12 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <unordered_map>
-#include <string>
 #include <utility>
 #include <type_traits>
 
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "map_utils.hpp"
 #include "time_utils.hpp"

--- a/src/utils/include/exclusive_multi_lru_cache.hpp
+++ b/src/utils/include/exclusive_multi_lru_cache.hpp
@@ -13,17 +13,17 @@
 
 #include <condition_variable>
 #include <cstdint>
-#include <deque>
 #include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
-#include <unordered_map>
-#include <string>
 #include <utility>
 #include <type_traits>
 
+#include "duckdb/common/deque.hpp"
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "time_utils.hpp"
 

--- a/src/utils/include/resize_uninitialized.hpp
+++ b/src/utils/include/resize_uninitialized.hpp
@@ -18,8 +18,8 @@
 
 #include <type_traits>
 #include <cstddef>
-#include <string>
 
+#include "duckdb/common/string.hpp"
 #include "type_traits.hpp"
 
 namespace duckdb {

--- a/src/utils/include/shared_lru_cache.hpp
+++ b/src/utils/include/shared_lru_cache.hpp
@@ -11,13 +11,13 @@
 #include <list>
 #include <memory>
 #include <optional>
-#include <unordered_map>
-#include <string>
 #include <utility>
 #include <type_traits>
 #include <mutex>
 
 #include "duckdb/common/helper.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/vector.hpp"
 #include "map_utils.hpp"
 #include "time_utils.hpp"

--- a/src/utils/include/thread_pool.hpp
+++ b/src/utils/include/thread_pool.hpp
@@ -4,11 +4,12 @@
 #include <future>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <thread>
 #include <type_traits>
 #include <utility>
-#include <vector>
+
+#include "duckdb/common/queue.hpp"
+#include "duckdb/common/vector.hpp"
 
 namespace duckdb {
 
@@ -37,8 +38,8 @@ private:
 	std::mutex mutex_;
 	std::condition_variable new_job_cv_;
 	std::condition_variable job_completion_cv_;
-	std::queue<Job> jobs_;
-	std::vector<std::thread> workers_;
+	queue<Job> jobs_;
+	vector<std::thread> workers_;
 };
 
 template <typename Fn, typename... Args>

--- a/src/utils/include/thread_utils.hpp
+++ b/src/utils/include/thread_utils.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
+#include "duckdb/common/string.hpp"
 
 namespace duckdb {
 
 // Set thread name to current thread; fail silently if an error happens.
-void SetThreadName(const std::string &thread_name);
+void SetThreadName(const string &thread_name);
 
 // Get the number of cores available to the system.
 // On linux platform, this function not only gets physical core number for CPU, but also considers available core number

--- a/src/utils/thread_utils.cpp
+++ b/src/utils/thread_utils.cpp
@@ -9,7 +9,7 @@
 
 namespace duckdb {
 
-void SetThreadName(const std::string &thread_name) {
+void SetThreadName(const string &thread_name) {
 #if defined(__APPLE__)
 	pthread_setname_np(thread_name.c_str());
 #elif defined(__linux__)

--- a/unit/test_base_cache_filesystem.cpp
+++ b/unit/test_base_cache_filesystem.cpp
@@ -1,9 +1,8 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-#include <string>
-
 #include "disk_cache_reader.hpp"
+#include "duckdb/common/string.hpp"
 #include "duckdb/common/virtual_file_system.hpp"
 #include "hffs.hpp"
 

--- a/unit/test_cache_filesystem_with_mock.cpp
+++ b/unit/test_cache_filesystem_with_mock.cpp
@@ -1,11 +1,10 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-#include <string>
-
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string.hpp"
 #include "mock_filesystem.hpp"
 
 using namespace duckdb; // NOLINT

--- a/unit/test_cache_stats_collection.cpp
+++ b/unit/test_cache_stats_collection.cpp
@@ -3,10 +3,9 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-#include <string>
-
 #include "cache_filesystem_config.hpp"
 #include "disk_cache_reader.hpp"
+#include "duckdb/common/string.hpp"
 #include "scope_guard.hpp"
 #include "test_utils.hpp"
 
@@ -14,8 +13,8 @@ using namespace duckdb; // NOLINT
 
 namespace {
 
-const std::string TEST_CONTENT = "helloworld";
-const std::string TEST_FILEPATH = "/tmp/testfile";
+const string TEST_CONTENT = "helloworld";
+const string TEST_FILEPATH = "/tmp/testfile";
 void CreateTestFile() {
 	auto local_filesystem = LocalFileSystem::CreateLocal();
 	auto file_handle = local_filesystem->OpenFile(TEST_FILEPATH, FileOpenFlags::FILE_FLAGS_WRITE |

--- a/unit/test_copiable_value_lru_cache.cpp
+++ b/unit/test_copiable_value_lru_cache.cpp
@@ -4,11 +4,11 @@
 #include <atomic>
 #include <chrono>
 #include <future>
-#include <string>
 #include <thread>
 #include <tuple>
 
 #include "copiable_value_lru_cache.hpp"
+#include "duckdb/common/string.hpp"
 
 using namespace duckdb; // NOLINT
 

--- a/unit/test_exclusive_lru_cache.cpp
+++ b/unit/test_exclusive_lru_cache.cpp
@@ -4,10 +4,10 @@
 #include <atomic>
 #include <chrono>
 #include <future>
-#include <string>
 #include <thread>
 #include <tuple>
 
+#include "duckdb/common/string.hpp"
 #include "exclusive_lru_cache.hpp"
 
 using namespace duckdb; // NOLINT

--- a/unit/test_exclusive_multi_lru_cache.cpp
+++ b/unit/test_exclusive_multi_lru_cache.cpp
@@ -4,10 +4,10 @@
 #include <atomic>
 #include <chrono>
 #include <future>
-#include <string>
 #include <thread>
 #include <tuple>
 
+#include "duckdb/common/string.hpp"
 #include "exclusive_multi_lru_cache.hpp"
 
 using namespace duckdb; // NOLINT

--- a/unit/test_no_destructor.cpp
+++ b/unit/test_no_destructor.cpp
@@ -1,43 +1,42 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
+#include "duckdb/common/string.hpp"
 #include "no_destructor.hpp"
-
-#include <string>
 
 using namespace duckdb; // NOLINT
 
 TEST_CASE("NoDestructor test", "[no destructor test]") {
-	const std::string s = "helloworld";
+	const string s = "helloworld";
 
 	// Default constructor.
 	{
-		NoDestructor<std::string> content {};
+		NoDestructor<string> content {};
 		REQUIRE(*content == "");
 	}
 
 	// Construct by const reference.
 	{
-		NoDestructor<std::string> content {s};
+		NoDestructor<string> content {s};
 		REQUIRE(*content == s);
 	}
 
 	// Construct by rvalue reference.
 	{
-		std::string another_str = "helloworld";
-		NoDestructor<std::string> content {std::move(another_str)};
+		string another_str = "helloworld";
+		NoDestructor<string> content {std::move(another_str)};
 		REQUIRE(*content == s);
 	}
 
 	// Construct by ctor with multiple arguments.
 	{
-		NoDestructor<std::string> content {s.begin(), s.end()};
+		NoDestructor<string> content {s.begin(), s.end()};
 		REQUIRE(*content == "helloworld");
 	}
 
 	// Access internal object.
 	{
-		NoDestructor<std::string> content {s.begin(), s.end()};
+		NoDestructor<string> content {s.begin(), s.end()};
 		(*content)[0] = 'b';
 		(*content)[1] = 'c';
 		REQUIRE(*content == "bclloworld");
@@ -45,7 +44,7 @@ TEST_CASE("NoDestructor test", "[no destructor test]") {
 
 	// Reassign.
 	{
-		NoDestructor<std::string> content {s.begin(), s.end()};
+		NoDestructor<string> content {s.begin(), s.end()};
 		*content = "worldhello";
 		REQUIRE(*content == "worldhello");
 	}

--- a/unit/test_shared_lru_cache.cpp
+++ b/unit/test_shared_lru_cache.cpp
@@ -4,10 +4,10 @@
 #include <atomic>
 #include <chrono>
 #include <future>
-#include <string>
 #include <thread>
 #include <tuple>
 
+#include "duckdb/common/string.hpp"
 #include "shared_lru_cache.hpp"
 
 using namespace duckdb; // NOLINT


### PR DESCRIPTION
I added a few safe containers in duckdb, which provides assertion on invalid access.