### PR TITLE
Add unit test for empty files

### DIFF
--- a/unit/test_disk_cache_filesystem.cpp
+++ b/unit/test_disk_cache_filesystem.cpp
@@ -415,8 +415,8 @@ TEST_CASE("Test on zero-byte cache file", "[on-disk cache filesystem test]") {
 		                    start_offset);
 		// Check all bytes remain null, since buffer should be unchanged for zero-byte file.
 		REQUIRE(content.size() == bytes_to_read);
-		for (size_t i = 0; i < content.size(); ++i) {
-			REQUIRE(content[i] == '\0');
+		for (size_t idx = 0; idx < content.size(); ++idx) {
+			REQUIRE(content[idx] == '\0');
 		}
 	}
 


### PR DESCRIPTION
This PR adds a missing unit test, which uses disk cache reader to read and access an empty file and validates no on-disk cache file created.