### PR TITLE
Fix compilation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ add_executable(test_cache_exclusion_manager
                unit/test_cache_exclusion_manager.cpp)
 target_link_libraries(test_cache_exclusion_manager ${EXTENSION_NAME})
 
-# Benchmark 
+# Benchmark
 add_executable(read_s3_object benchmark/read_s3_object.cpp)
 target_link_libraries(read_s3_object ${EXTENSION_NAME})
 

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -25,7 +25,7 @@ public:
 	LatencyGuard(const LatencyGuard &) = delete;
 	LatencyGuard &operator=(const LatencyGuard &) = delete;
 	LatencyGuard(LatencyGuard &&) = default;
-	LatencyGuard &operator=(LatencyGuard &&) = default;
+	LatencyGuard &operator=(LatencyGuard &&) = delete;
 
 private:
 	BaseProfileCollector &profile_collector;

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -84,13 +84,14 @@ public:
 	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	// Does update file offset (which acts as `Read` semantics).
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
-	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+	                                optional_ptr<FileOpener> opener = nullptr) override;
 	std::string GetName() const override;
 	BaseProfileCollector *GetProfileCollector() const {
 		return profile_collector.get();
 	}
 	// Get file size, which attempts to get metadata cache if possible.
-	int64_t GetFileSize(FileHandle &handle);
+	int64_t GetFileSize(FileHandle &handle) override;
 	// Get last modification timestamp, which attempts to get metadata cache if possible.
 	timestamp_t GetLastModifiedTime(FileHandle &handle) override;
 	// Get cache reader manager.

--- a/src/include/noop_cache_reader.hpp
+++ b/src/include/noop_cache_reader.hpp
@@ -26,7 +26,7 @@ public:
 		return {};
 	}
 
-	virtual std::string GetName() const {
+	std::string GetName() const override {
 		return "noop_cache_reader";
 	}
 };


### PR DESCRIPTION
Fix warnings:
```sh
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_filesystem.cpp:1:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:5:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/base_profile_collector.cpp:1:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_filesystem_ref_registry.cpp:3:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:5:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/in_memory_cache_reader.cpp:1:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/in_memory_cache_reader.hpp:5:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/disk_cache_reader.cpp:10:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/disk_cache_reader.hpp:7:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/temp_profile_collector.cpp:1:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/temp_profile_collector.hpp:5:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/noop_cache_reader.cpp:1:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/noop_cache_reader.hpp:7:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/noop_cache_reader.cpp:1:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/noop_cache_reader.hpp:29:22: warning: 'GetName' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   29 |         virtual std::string GetName() const {
      |                             ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:40:22: note: overridden virtual function is here
   40 |         virtual std::string GetName() const {
      |                             ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/utils/test_utils.cpp:4:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_reader_manager.hpp:7:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_status_query_function.cpp:7:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:5:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
1 warning generated.
1 warning generated.
1 warning generated.
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_filesystem.cpp:1:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_filesystem.cpp:1:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_filesystem.cpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/noop_cache_reader.hpp:29:22: warning: 'GetName' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   29 |         virtual std::string GetName() const {
      |                             ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:40:22: note: overridden virtual function is here
   40 |         virtual std::string GetName() const {
      |                             ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/in_memory_cache_reader.cpp:1:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/in_memory_cache_reader.hpp:6:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/in_memory_cache_reader.cpp:1:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/in_memory_cache_reader.hpp:6:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_reader_manager.cpp:4:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/disk_cache_reader.hpp:16:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_reader_manager.cpp:4:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/disk_cache_reader.hpp:16:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/disk_cache_reader.cpp:10:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/disk_cache_reader.hpp:16:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/disk_cache_reader.cpp:10:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/disk_cache_reader.hpp:16:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_filesystem_ref_registry.cpp:3:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_filesystem_ref_registry.cpp:3:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/noop_cache_reader.cpp:3:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/noop_cache_reader.cpp:3:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_status_query_function.cpp:7:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_status_query_function.cpp:7:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_reader_manager.cpp:7:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/noop_cache_reader.hpp:29:22: warning: 'GetName' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   29 |         virtual std::string GetName() const {
      |                             ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:40:22: note: overridden virtual function is here
   40 |         virtual std::string GetName() const {
      |                             ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_httpfs_extension.cpp:9:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:5:
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_cache_reader.hpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:16: warning: explicitly defaulted move assignment operator is implicitly deleted [-Wdefaulted-function-deleted]
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                       ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:31:24: note: move assignment operator of 'LatencyGuard' is implicitly deleted because field 'profile_collector' is of reference type 'BaseProfileCollector &'
   31 |         BaseProfileCollector &profile_collector;
      |                               ^
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/base_profile_collector.hpp:28:45: note: replace 'default' with 'delete'
   28 |         LatencyGuard &operator=(LatencyGuard &&) = default;
      |                                                    ^~~~~~~
      |                                                    delete
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_httpfs_extension.cpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:87:25: warning: 'OpenFile' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   87 |         unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener = nullptr);
      |                                ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:132:44: note: overridden virtual function is here
  132 |         DUCKDB_API virtual unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
      |                                                   ^
In file included from /Users/hjiang/Desktop/duck-read-cache-fs/src/cache_httpfs_extension.cpp:9:
/Users/hjiang/Desktop/duck-read-cache-fs/src/include/cache_filesystem.hpp:93:10: warning: 'GetFileSize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   93 |         int64_t GetFileSize(FileHandle &handle);
      |                 ^
/Users/hjiang/Desktop/duck-read-cache-fs/duckdb/src/include/duckdb/common/file_system.hpp:153:29: note: overridden virtual function is here
  153 |         DUCKDB_API virtual int64_t GetFileSize(FileHandle &handle);
      |                                    ^
```