### PR TITLE
Fix disk cache directories regression

### DIFF
--- a/src/cache_httpfs_instance_state.cpp
+++ b/src/cache_httpfs_instance_state.cpp
@@ -45,7 +45,7 @@ void InstanceCacheReaderManager::SetCacheReader(const InstanceConfig &config,
 	if (config.cache_type == *ON_DISK_CACHE_TYPE) {
 		if (on_disk_cache_reader == nullptr) {
 			on_disk_cache_reader =
-			    make_uniq<DiskCacheReader>(std::move(instance_state_p), config.on_disk_cache_directories);
+			    make_uniq<DiskCacheReader>(std::move(instance_state_p));
 		}
 		internal_cache_reader = on_disk_cache_reader.get();
 		return;
@@ -88,7 +88,7 @@ void InstanceCacheReaderManager::InitializeDiskCacheReader(const vector<string> 
                                                            weak_ptr<CacheHttpfsInstanceState> instance_state_p) {
 	std::lock_guard<std::mutex> lock(mutex);
 	if (on_disk_cache_reader == nullptr) {
-		on_disk_cache_reader = make_uniq<DiskCacheReader>(std::move(instance_state_p), cache_directories);
+		on_disk_cache_reader = make_uniq<DiskCacheReader>(std::move(instance_state_p));
 	}
 }
 
@@ -331,6 +331,14 @@ CacheHttpfsInstanceState &GetInstanceStateOrThrow(DatabaseInstance &instance) {
 		throw InternalException("cache_httpfs instance state not found - extension not properly loaded");
 	}
 	return *state;
+}
+
+InstanceConfig& GetInstanceConfig(weak_ptr<CacheHttpfsInstanceState> instance_state) {
+	auto instance_state_locked = instance_state.lock();
+	if (instance_state_locked == nullptr) {
+		throw InternalException("cache_httpfs instance state is no longer valid");
+	}
+	return instance_state_locked->config;
 }
 
 } // namespace duckdb

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -162,4 +162,7 @@ shared_ptr<CacheHttpfsInstanceState> GetInstanceStateShared(DatabaseInstance &in
 // Get instance state, throwing if not found
 CacheHttpfsInstanceState &GetInstanceStateOrThrow(DatabaseInstance &instance);
 
+// Get instance config from the instance state.
+InstanceConfig& GetInstanceConfig(weak_ptr<CacheHttpfsInstanceState> instance_state);
+
 } // namespace duckdb

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -23,8 +23,7 @@ struct CacheHttpfsInstanceState;
 class DiskCacheReader final : public BaseCacheReader {
 public:
 	// Constructor: cache_directories defines where cache files are stored.
-	explicit DiskCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p,
-	                         vector<string> cache_directories = {*DEFAULT_ON_DISK_CACHE_DIRECTORY});
+	explicit DiskCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p);
 	~DiskCacheReader() override = default;
 
 	std::string GetName() const override {
@@ -66,8 +65,6 @@ private:
 
 	// Used to access local cache files.
 	unique_ptr<FileSystem> local_filesystem;
-	// Cache directories (where cache files are stored).
-	vector<string> cache_directories;
 	// Used for on-disk cache block LRU-based eviction.
 	std::mutex cache_file_creation_timestamp_map_mutex;
 	// Maps from last access timestamp to filepath.


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/dentiny/duck-read-cache-fs/pull/329; the bug is, disk cache directories are directly passed into disk cache reader, instead of reading at runtime, so duckdb config setting doesn't apply.
Closes https://github.com/dentiny/duck-read-cache-fs/issues/332