### PR TITLE
Make CacheFileSystem support OpenFileExtended

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -367,7 +367,6 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 	return CreateCacheFileHandleForRead(std::move(file_handle));
 }
 
-// LCOV_EXCL_START
 unique_ptr<FileHandle> CacheFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
                                                          optional_ptr<FileOpener> opener) {
 	InitializeGlobalConfig(opener);
@@ -384,15 +383,7 @@ unique_ptr<FileHandle> CacheFileSystem::OpenFileExtended(const OpenFileInfo &fil
 
 unique_ptr<FileHandle> CacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                                                  optional_ptr<FileOpener> opener) {
-	InitializeGlobalConfig(opener);
-	if (flags.OpenForReading()) {
-		return GetOrCreateFileHandleForRead(OpenFileInfo(path), flags, opener);
-	}
-
-	// Otherwise, we do nothing (i.e. profiling) but wrapping it with cache file handle wrapper.
-	auto file_handle = internal_filesystem->OpenFile(path, flags, opener);
-	return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this,
-	                                        /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {});
+	return OpenFileExtended(OpenFileInfo(path), flags, opener);
 }
 
 void CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -220,10 +220,10 @@ public:
 	}
 
 protected:
-	// Because extended version of open and list are all "protected" visibility, which cannot access with the
-	// [`internal_filesystem`] variable, so we explicitly disable the extended version and fallback to normal one.
+	unique_ptr<FileHandle> OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
+	                                        optional_ptr<FileOpener> opener) override;
 	bool SupportsOpenFileExtended() const override {
-		return false;
+		return true;
 	}
 	bool SupportsListFilesExtended() const override {
 		return false;
@@ -308,7 +308,7 @@ private:
 
 	// Get file handle from cache, or open if it doesn't exist.
 	// Return cached file handle.
-	unique_ptr<FileHandle> GetOrCreateFileHandleForRead(const string &path, FileOpenFlags flags,
+	unique_ptr<FileHandle> GetOrCreateFileHandleForRead(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                    optional_ptr<FileOpener> opener);
 
 	// Mutex to protect concurrent access.


### PR DESCRIPTION
## Overview

Adds support for the `OpenFileExtended` API in `CacheFileSystem`, enabling file opening with extended metadata through `OpenFileInfo`. This change refactors `GetOrCreateFileHandleForRead` to accept `OpenFileInfo` instead of a raw path string, maintaining backward compatibility through the existing `OpenFile` method.

This change enables LakeHouse to populate metadata information (`etag`, `last_modified`, and `file_size`) when it's already available, preventing the underlying `HTTPFileSystem` from making unnecessary HEAD requests. This has a strong impact on fresh DuckDB process starts where the in-memory metadata cache is still empty, reducing latency and network overhead during initial file operations.

## Details

**API Changes:**
- `GetOrCreateFileHandleForRead` now accepts `OpenFileInfo &file` instead of `const string &path`
- Added `OpenFileExtended` override implementation that handles both read and write operations
- Changed `SupportsOpenFileExtended()` to return `true` (was previously `false`)

**Implementation:**
- For read operations, `OpenFileExtended` delegates to `GetOrCreateFileHandleForRead` with the `OpenFileInfo` parameter
- For write operations, it wraps the file handle with `CacheFileSystemHandle` for consistency
- The existing `OpenFile` method now wraps the path string in `OpenFileInfo` when calling `GetOrCreateFileHandleForRead`, ensuring backward compatibility

**Impact:**
- Enables callers to use the extended file opening API with additional metadata
- Maintains full backward compatibility with existing `OpenFile` calls
- File handle caching behavior remains unchanged for read operations
- Reduces unnecessary HTTP HEAD requests when metadata is already available