### PR TITLE
Clear cache write

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -206,6 +206,18 @@ std::string CacheFileSystem::GetName() const {
 	return StringUtil::Format("cache_httpfs_%s", internal_filesystem->GetName());
 }
 
+void CacheFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+	internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes, location);
+	ClearCache(handle.GetPath());
+}
+int64_t CacheFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
+	auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+	auto result = internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes);
+	ClearCache(handle.GetPath());
+	return result;
+}
+
 unique_ptr<FileHandle> CacheFileSystem::CreateCacheFileHandleForRead(unique_ptr<FileHandle> internal_file_handle) {
 	if (internal_file_handle == nullptr) {
 		return nullptr;

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -111,6 +111,13 @@ public:
 	bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
 	               FileOpener *opener = nullptr) override;
 
+	// Write operations, which clear corresponding cache entries.
+	//
+	// TODO(hjiang): Current cache entries cleanup is expensive, it's always a O(N) linear search, if it proves to be
+	// bottleneck we should add a bloom filter.
+	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
+	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+
 	// Clear all cache inside of cache filesystem (i.e. glob cache, file handle cache, metadata cache).
 	// It's worth noting data block cache won't get deleted.
 	void ClearCache();
@@ -129,17 +136,6 @@ public:
 		auto file_handle = internal_filesystem->OpenCompressedFile(context, std::move(handle), write);
 		return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this,
 		                                        /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {});
-	}
-	void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
-		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-		internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes, location);
-		ClearCache(handle.GetPath());
-	}
-	int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
-		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-		auto result = internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes);
-		ClearCache(handle.GetPath());
-		return result;
 	}
 	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override {
 		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();

--- a/unit/test_clear_cache_on_write.cpp
+++ b/unit/test_clear_cache_on_write.cpp
@@ -1,0 +1,113 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "cache_filesystem_config.hpp"
+#include "disk_cache_reader.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "filesystem_utils.hpp"
+#include "scoped_directory.hpp"
+#include "test_utils.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+constexpr uint64_t TEST_FILE_SIZE = 26;
+const auto TEST_FILE_CONTENT = []() {
+	string content(TEST_FILE_SIZE, '\0');
+	for (uint64_t idx = 0; idx < TEST_FILE_SIZE; ++idx) {
+		content[idx] = 'a' + idx;
+	}
+	return content;
+}();
+const auto TEST_DIRECTORY = "/tmp/duckdb_test_cache_write";
+const auto TEST_FILENAME =
+    StringUtil::Format("/tmp/duckdb_test_cache_write/%s", UUID::ToString(UUID::GenerateRandomUUID()));
+} // namespace
+
+TEST_CASE("Test cache cleared on Write with location", "[cache filesystem write test]") {
+	ScopedDirectory scoped_dir(TEST_DIRECTORY);
+
+	TestCacheConfig config;
+	config.cache_type = *ON_DISK_CACHE_TYPE;
+	config.enable_glob_cache = true;
+	config.enable_file_handle_cache = true;
+	config.enable_metadata_cache = true;
+	TestCacheFileSystemHelper helper(config);
+	auto *cache_filesystem = helper.GetCacheFileSystem();
+
+	// Create test file
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
+	                                                                  FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
+	                        TEST_FILE_SIZE, /*location=*/0);
+	file_handle->Sync();
+	file_handle->Close();
+
+	// Perform read operations to populate cache (metadata, file handle, glob)
+	auto read_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+	[[maybe_unused]] const int64_t original_size = cache_filesystem->GetFileSize(*read_handle);
+	read_handle->Close();
+
+	// Write to the file, this should clear all cache entries for this file
+	const string new_content = "new content after write";
+	auto write_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE);
+	cache_filesystem->Write(*write_handle, const_cast<void *>(static_cast<const void *>(new_content.data())),
+	                        new_content.length(), /*location=*/0);
+	write_handle->Close();
+
+	// Verify cache was cleared by reading metadata again, it should reflect the new file size
+	auto verify_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+	const int64_t new_size = cache_filesystem->GetFileSize(*verify_handle);
+	REQUIRE(new_size == static_cast<int64_t>(new_content.length()));
+	verify_handle->Close();
+
+}
+
+TEST_CASE("Test cache cleared on Write without location", "[cache filesystem write test]") {
+	ScopedDirectory scoped_dir(TEST_DIRECTORY);
+
+	TestCacheConfig config;
+	config.cache_type = *ON_DISK_CACHE_TYPE;
+	config.enable_glob_cache = true;
+	config.enable_file_handle_cache = true;
+	config.enable_metadata_cache = true;
+	TestCacheFileSystemHelper helper(config);
+	auto *cache_filesystem = helper.GetCacheFileSystem();
+
+	// Create test file
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
+	                                                                  FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
+	                        TEST_FILE_SIZE, /*location=*/0);
+	file_handle->Sync();
+	file_handle->Close();
+
+	// Perform read operations to populate cache
+	auto read_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+	[[maybe_unused]] const int64_t original_size = cache_filesystem->GetFileSize(*read_handle);
+	read_handle->Close();
+
+	// Write to the file using Write without location parameter, this should clear cache
+	const string new_content = "different content";
+	auto write_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE);
+	const int64_t bytes_written =
+	    cache_filesystem->Write(*write_handle, const_cast<void *>(static_cast<const void *>(new_content.data())),
+	                            new_content.length());
+	REQUIRE(bytes_written == static_cast<int64_t>(new_content.length()));
+	write_handle->Close();
+
+	// Verify cache was cleared by reading metadata, should reflect new file size
+	auto verify_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_READ);
+	const int64_t new_size = cache_filesystem->GetFileSize(*verify_handle);
+	REQUIRE(new_size == static_cast<int64_t>(new_content.length()));
+	verify_handle->Close();
+}
+
+int main(int argc, char **argv) {
+	int result = Catch::Session().run(argc, argv);
+	return result;
+}


### PR DESCRIPTION
Current cache file handle will be created on not only read, but also write operations.
But on write, cache entries are not deleted which means even read-after-write consistency is not guaranteed.
This PR clears certain entries on write, similar to how we handle deletion operations.
I don't think it's good for performance, but we could add bloom filter if it's an issue.

Closes https://github.com/dentiny/duck-read-cache-fs/issues/344
