### PR TITLE
Fix duplicate macro on windows

### DIFF
--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -234,11 +234,11 @@ private:
 	friend class CacheFileSystemHandle;
 
 	struct FileMetadata {
-		inline constexpr static int64_t INVALID_FILE_SIZE = -1;
-		inline constexpr static timestamp_t INVALID_MODIFICATION_TIME = static_cast<timestamp_t>(-1);
+		inline constexpr static int64_t CACHE_HTTPFS_INVALID_FILE_SIZE = -1;
+		inline constexpr static timestamp_t CACHE_HTTPFS_INVALID_MODIFICATION_TIME = static_cast<timestamp_t>(-1);
 
-		int64_t file_size = INVALID_FILE_SIZE;
-		timestamp_t last_modification_time = INVALID_MODIFICATION_TIME;
+		int64_t file_size = CACHE_HTTPFS_INVALID_FILE_SIZE;
+		timestamp_t last_modification_time = CACHE_HTTPFS_INVALID_MODIFICATION_TIME;
 	};
 
 	struct FileHandleCacheKey {


### PR DESCRIPTION
Closes https://github.com/dentiny/duck-read-cache-fs/issues/348

The issue is, `INVALID_FILE_SIZE` is an existing macro defined at [windows platform](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfilesize).
Prefix a few constants with `CACHE_HTTPFS_`