### PR TITLE
Provide option to clear cache on write

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,17 @@ set(TARGET_NAME cache_httpfs)
 
 # Suppress warnings.
 if(UNIX OR APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings -Wno-c++17-extensions -Wno-c++20-extensions")
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -Wno-write-strings -Wno-c++17-extensions -Wno-c++20-extensions"
+  )
 endif()
 
 # Check if compiler is Clang (case-insensitive check)
 string(TOLOWER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_ID_LOWER)
 string(TOLOWER "${CMAKE_CXX_COMPILER}" CMAKE_CXX_COMPILER_LOWER)
-if(CMAKE_CXX_COMPILER_ID_LOWER MATCHES "clang" OR CMAKE_CXX_COMPILER_LOWER MATCHES "clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety")
+if(CMAKE_CXX_COMPILER_ID_LOWER MATCHES "clang" OR CMAKE_CXX_COMPILER_LOWER
+                                                  MATCHES "clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wthread-safety")
 endif()
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
@@ -212,16 +215,13 @@ add_executable(test_cache_exclusion_manager
                unit/test_cache_exclusion_manager.cpp)
 target_link_libraries(test_cache_exclusion_manager ${EXTENSION_NAME})
 
-add_executable(test_multi_duckdb_instance
-               unit/test_multi_duckdb_instance.cpp)
+add_executable(test_multi_duckdb_instance unit/test_multi_duckdb_instance.cpp)
 target_link_libraries(test_multi_duckdb_instance ${EXTENSION_NAME})
 
-add_executable(test_scoped_directory
-               unit/test_scoped_directory.cpp)
+add_executable(test_scoped_directory unit/test_scoped_directory.cpp)
 target_link_libraries(test_scoped_directory ${EXTENSION_NAME})
 
-add_executable(test_optional
-               unit/test_optional.cpp)
+add_executable(test_optional unit/test_optional.cpp)
 target_link_libraries(test_optional ${EXTENSION_NAME})
 
 # Benchmark

--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -110,6 +110,9 @@ bool DEFAULT_ENABLE_GLOB_CACHE = true;
 // Default enable cache validation via version tag and last modification timestamp.
 bool DEFAULT_ENABLE_CACHE_VALIDATION = false;
 
+// Default enable clearing cache on write operations.
+bool DEFAULT_CLEAR_CACHE_ON_WRITE = false;
+
 // Default not ignore SIGPIPE in the extension.
 bool DEFAULT_IGNORE_SIGPIPE = false;
 

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -276,6 +276,11 @@ void UpdateEnableCacheValidation(ClientContext &context, SetScope scope, Value &
 	inst_state.config.enable_cache_validation = parameter.GetValue<bool>();
 }
 
+void UpdateClearCacheOnWrite(ClientContext &context, SetScope scope, Value &parameter) {
+	auto &inst_state = GetInstanceStateOrThrow(context);
+	inst_state.config.clear_cache_on_write = parameter.GetValue<bool>();
+}
+
 // Implementation for check cache directories and create directories if necessary.
 void UpdateCacheDirectoriesImpl(CacheHttpfsInstanceState &inst_state, vector<string> directories) {
 	std::sort(directories.begin(), directories.end());
@@ -579,6 +584,15 @@ void LoadInternal(ExtensionLoader &loader) {
 	                          "When enabled, cache entries are validated against the current file version tag and "
 	                          "modification timestamp to ensure cache consistency. By default disabled.",
 	                          LogicalTypeId::BOOLEAN, DEFAULT_ENABLE_CACHE_VALIDATION, UpdateEnableCacheValidation);
+
+	// Cache invalidation on write config.
+	config.AddExtensionOption(
+	    "cache_httpfs_clear_cache_on_write",
+	    "Whether to clear cache entries on write operations. When enabled, write operations will invalidate cached "
+	    "metadata, file handles, and glob entries for the modified file, which could be expensive."
+	    "Disabling this can improve write performance when many cache entries exist, but may lead to stale cache "
+	    "reads. By default disabled.",
+	    LogicalTypeId::BOOLEAN, DEFAULT_CLEAR_CACHE_ON_WRITE, UpdateClearCacheOnWrite);
 
 	// On disk cache config.
 	// TODO(hjiang): Add a new configurable for on-disk cache staleness.

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -112,6 +112,9 @@ extern bool DEFAULT_ENABLE_GLOB_CACHE;
 // Default enable cache validation via version tag and last modification timestamp.
 extern bool DEFAULT_ENABLE_CACHE_VALIDATION;
 
+// Default enable clearing cache on write operations.
+extern bool DEFAULT_CLEAR_CACHE_ON_WRITE;
+
 // Default not ignore SIGPIPE in the extension.
 extern bool DEFAULT_IGNORE_SIGPIPE;
 

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -116,6 +116,9 @@ struct InstanceConfig {
 
 	// Cache validation config
 	bool enable_cache_validation = DEFAULT_ENABLE_CACHE_VALIDATION;
+
+	// Cache invalidation on write config
+	bool clear_cache_on_write = DEFAULT_CLEAR_CACHE_ON_WRITE;
 };
 
 //===--------------------------------------------------------------------===//

--- a/unit/test_clear_cache_on_write.cpp
+++ b/unit/test_clear_cache_on_write.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Test cache cleared on Write with location", "[cache filesystem write 
 	// Create test file
 	auto local_filesystem = LocalFileSystem::CreateLocal();
 	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
-	                                                                  FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	                                                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
 	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
 	                        TEST_FILE_SIZE, /*location=*/0);
 	file_handle->Sync();
@@ -63,7 +63,6 @@ TEST_CASE("Test cache cleared on Write with location", "[cache filesystem write 
 	const int64_t new_size = cache_filesystem->GetFileSize(*verify_handle);
 	REQUIRE(new_size == static_cast<int64_t>(new_content.length()));
 	verify_handle->Close();
-
 }
 
 TEST_CASE("Test cache cleared on Write without location", "[cache filesystem write test]") {
@@ -80,7 +79,7 @@ TEST_CASE("Test cache cleared on Write without location", "[cache filesystem wri
 	// Create test file
 	auto local_filesystem = LocalFileSystem::CreateLocal();
 	auto file_handle = local_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE |
-	                                                                  FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+	                                                                 FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
 	local_filesystem->Write(*file_handle, const_cast<void *>(static_cast<const void *>(TEST_FILE_CONTENT.data())),
 	                        TEST_FILE_SIZE, /*location=*/0);
 	file_handle->Sync();
@@ -94,9 +93,8 @@ TEST_CASE("Test cache cleared on Write without location", "[cache filesystem wri
 	// Write to the file using Write without location parameter, this should clear cache
 	const string new_content = "different content";
 	auto write_handle = cache_filesystem->OpenFile(TEST_FILENAME, FileOpenFlags::FILE_FLAGS_WRITE);
-	const int64_t bytes_written =
-	    cache_filesystem->Write(*write_handle, const_cast<void *>(static_cast<const void *>(new_content.data())),
-	                            new_content.length());
+	const int64_t bytes_written = cache_filesystem->Write(
+	    *write_handle, const_cast<void *>(static_cast<const void *>(new_content.data())), new_content.length());
 	REQUIRE(bytes_written == static_cast<int64_t>(new_content.length()));
 	write_handle->Close();
 

--- a/unit/test_multi_duckdb_instance.cpp
+++ b/unit/test_multi_duckdb_instance.cpp
@@ -1,6 +1,7 @@
 // Unit test for multiple DuckDB instances in a single process.
 //
-// This test validates that the extension properly supports multiple DuckDB instances in a single process, each with its own independent configuration and state.
+// This test validates that the extension properly supports multiple DuckDB instances in a single process, each with its
+// own independent configuration and state.
 
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
@@ -102,7 +103,7 @@ TEST_CASE("Test multiple instances with different cache types", "[multi-instance
 		const uint64_t bytes_to_read = 10;
 		string content(bytes_to_read, '\0');
 		cache_fs1->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
-		               start_offset);
+		                start_offset);
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
 	}
 
@@ -112,7 +113,7 @@ TEST_CASE("Test multiple instances with different cache types", "[multi-instance
 		const uint64_t bytes_to_read = 8;
 		string content(bytes_to_read, '\0');
 		cache_fs2->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
-		               start_offset);
+		                start_offset);
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
 	}
 
@@ -122,7 +123,7 @@ TEST_CASE("Test multiple instances with different cache types", "[multi-instance
 		const uint64_t bytes_to_read = 10;
 		string content(bytes_to_read, '\0');
 		cache_fs3->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())), bytes_to_read,
-		               start_offset);
+		                start_offset);
 		REQUIRE(content == TEST_FILE_CONTENT.substr(start_offset, bytes_to_read));
 	}
 

--- a/unit/test_optional.cpp
+++ b/unit/test_optional.cpp
@@ -29,34 +29,44 @@
 namespace duckdb {
 
 struct Tracker {
-  Tracker() : value(0) { ++ctor; }
-  explicit Tracker(int v) : value(v) { ++ctor; }
-  Tracker(const Tracker& other) : value(other.value) { ++copy; }
-  Tracker(Tracker&& other) noexcept : value(other.value) { ++move; }
-  Tracker& operator=(const Tracker& other) {
-    value = other.value;
-    ++copy_assign;
-    return *this;
-  }
-  Tracker& operator=(Tracker&& other) noexcept {
-    value = other.value;
-    ++move_assign;
-    return *this;
-  }
-  ~Tracker() { ++dtor; }
+	Tracker() : value(0) {
+		++ctor;
+	}
+	explicit Tracker(int v) : value(v) {
+		++ctor;
+	}
+	Tracker(const Tracker &other) : value(other.value) {
+		++copy;
+	}
+	Tracker(Tracker &&other) noexcept : value(other.value) {
+		++move;
+	}
+	Tracker &operator=(const Tracker &other) {
+		value = other.value;
+		++copy_assign;
+		return *this;
+	}
+	Tracker &operator=(Tracker &&other) noexcept {
+		value = other.value;
+		++move_assign;
+		return *this;
+	}
+	~Tracker() {
+		++dtor;
+	}
 
-  static void Reset() {
-    ctor = copy = move = copy_assign = move_assign = dtor = 0;
-  }
+	static void Reset() {
+		ctor = copy = move = copy_assign = move_assign = dtor = 0;
+	}
 
-  int value;
+	int value;
 
-  static int ctor;
-  static int copy;
-  static int move;
-  static int copy_assign;
-  static int move_assign;
-  static int dtor;
+	static int ctor;
+	static int copy;
+	static int move;
+	static int copy_assign;
+	static int move_assign;
+	static int dtor;
 };
 
 int Tracker::ctor = 0;
@@ -67,171 +77,172 @@ int Tracker::move_assign = 0;
 int Tracker::dtor = 0;
 
 struct Comparable {
-  explicit Comparable(int v = 0) : v(v) {}
-  int v;
+	explicit Comparable(int v = 0) : v(v) {
+	}
+	int v;
 };
 
-inline bool operator==(const Comparable& a, const Comparable& b) {
-  return a.v == b.v;
+inline bool operator==(const Comparable &a, const Comparable &b) {
+	return a.v == b.v;
 }
-inline bool operator<(const Comparable& a, const Comparable& b) {
-  return a.v < b.v;
+inline bool operator<(const Comparable &a, const Comparable &b) {
+	return a.v < b.v;
 }
 
-}  // namespace duckdb
+} // namespace duckdb
 
 using namespace duckdb; // NOLINT
 
 TEST_CASE("Default and nullopt", "[optional]") {
-  optional<int> empty;
-  REQUIRE(!empty);
+	optional<int> empty;
+	REQUIRE(!empty);
 
-  optional<int> also_empty(nullopt);
-  REQUIRE(!also_empty);
+	optional<int> also_empty(nullopt);
+	REQUIRE(!also_empty);
 
-  optional<int> with_value(5);
-  REQUIRE(with_value);
-  REQUIRE(*with_value == 5);
+	optional<int> with_value(5);
+	REQUIRE(with_value);
+	REQUIRE(*with_value == 5);
 }
 
 TEST_CASE("In-place and initializer-list construction", "[optional]") {
-  optional<string> name(in_place, "duckdb");
-  REQUIRE(name);
-  REQUIRE(name->size() == 6u);
+	optional<string> name(in_place, "duckdb");
+	REQUIRE(name);
+	REQUIRE(name->size() == 6u);
 
-  optional<vector<int> > numbers(in_place, {1, 2, 3});
-  REQUIRE(numbers);
-  REQUIRE(numbers->size() == 3u);
-  REQUIRE(numbers->at(1) == 2);
+	optional<vector<int>> numbers(in_place, {1, 2, 3});
+	REQUIRE(numbers);
+	REQUIRE(numbers->size() == 3u);
+	REQUIRE(numbers->at(1) == 2);
 }
 
 TEST_CASE("Copy and move semantics", "[optional]") {
-  Tracker::Reset();
-  optional<Tracker> src(in_place, 10);
-  optional<Tracker> copy(src);
-  optional<Tracker> moved(std::move(src));
+	Tracker::Reset();
+	optional<Tracker> src(in_place, 10);
+	optional<Tracker> copy(src);
+	optional<Tracker> moved(std::move(src));
 
-  REQUIRE(copy);
-  REQUIRE(moved);
-  REQUIRE(copy->value == 10);
-  REQUIRE(moved->value == 10);
+	REQUIRE(copy);
+	REQUIRE(moved);
+	REQUIRE(copy->value == 10);
+	REQUIRE(moved->value == 10);
 
-  REQUIRE(Tracker::ctor == 1);
-  REQUIRE(Tracker::copy == 1);
-  REQUIRE(Tracker::move == 1);
+	REQUIRE(Tracker::ctor == 1);
+	REQUIRE(Tracker::copy == 1);
+	REQUIRE(Tracker::move == 1);
 }
 
 TEST_CASE("Assignment and reset", "[optional]") {
-  Tracker::Reset();
-  optional<Tracker> opt;
-  opt = Tracker(3);
-  REQUIRE(opt);
-  REQUIRE(opt->value == 3);
+	Tracker::Reset();
+	optional<Tracker> opt;
+	opt = Tracker(3);
+	REQUIRE(opt);
+	REQUIRE(opt->value == 3);
 
-  opt = nullopt;
-  REQUIRE(!opt);
+	opt = nullopt;
+	REQUIRE(!opt);
 
-  optional<Tracker> lhs(in_place, 7);
-  optional<Tracker> rhs(in_place, 9);
-  lhs = rhs;
-  REQUIRE(lhs);
-  REQUIRE(lhs->value == 9);
+	optional<Tracker> lhs(in_place, 7);
+	optional<Tracker> rhs(in_place, 9);
+	lhs = rhs;
+	REQUIRE(lhs);
+	REQUIRE(lhs->value == 9);
 
-  lhs = std::move(rhs);
-  REQUIRE(lhs);
-  REQUIRE(lhs->value == 9);
+	lhs = std::move(rhs);
+	REQUIRE(lhs);
+	REQUIRE(lhs->value == 9);
 }
 
 TEST_CASE("Emplace", "[optional]") {
-  optional<string> text;
-  string& ref1 = text.emplace("abc");
-  REQUIRE(&ref1 == &*text);
-  REQUIRE(text);
-  REQUIRE(text->size() == 3u);
+	optional<string> text;
+	string &ref1 = text.emplace("abc");
+	REQUIRE(&ref1 == &*text);
+	REQUIRE(text);
+	REQUIRE(text->size() == 3u);
 
-  string& ref2 = text.emplace(5, 'z');
-  REQUIRE(&ref2 == &*text);
-  REQUIRE(text->size() == 5u);
+	string &ref2 = text.emplace(5, 'z');
+	REQUIRE(&ref2 == &*text);
+	REQUIRE(text->size() == 5u);
 }
 
 TEST_CASE("Accessors and exceptions", "[optional]") {
-  optional<string> text("hello");
-  REQUIRE(text->size() == 5u);
-  REQUIRE((*text)[1] == 'e');
+	optional<string> text("hello");
+	REQUIRE(text->size() == 5u);
+	REQUIRE((*text)[1] == 'e');
 
-  const optional<string> ctext(text);
-  REQUIRE(ctext->size() == 5u);
-  REQUIRE((*ctext)[4] == 'o');
+	const optional<string> ctext(text);
+	REQUIRE(ctext->size() == 5u);
+	REQUIRE((*ctext)[4] == 'o');
 
-  optional<int> empty;
-  REQUIRE_THROWS_AS(empty.value(), bad_optional_access);
+	optional<int> empty;
+	REQUIRE_THROWS_AS(empty.value(), bad_optional_access);
 }
 
 TEST_CASE("value_or", "[optional]") {
-  optional<int> empty;
-  optional<int> filled(8);
-  REQUIRE(empty.value_or(42) == 42);
-  REQUIRE(filled.value_or(42) == 8);
-  REQUIRE(optional<string>().value_or("fallback") == "fallback");
+	optional<int> empty;
+	optional<int> filled(8);
+	REQUIRE(empty.value_or(42) == 42);
+	REQUIRE(filled.value_or(42) == 8);
+	REQUIRE(optional<string>().value_or("fallback") == "fallback");
 }
 
 TEST_CASE("swap", "[optional]") {
-  optional<int> a;
-  optional<int> b(1);
-  swap(a, b);
-  REQUIRE(a);
-  REQUIRE(*a == 1);
-  REQUIRE(!b);
+	optional<int> a;
+	optional<int> b(1);
+	swap(a, b);
+	REQUIRE(a);
+	REQUIRE(*a == 1);
+	REQUIRE(!b);
 
-  optional<int> c(2);
-  optional<int> d(3);
-  c.swap(d);
-  REQUIRE(*c == 3);
-  REQUIRE(*d == 2);
+	optional<int> c(2);
+	optional<int> d(3);
+	c.swap(d);
+	REQUIRE(*c == 3);
+	REQUIRE(*d == 2);
 }
 
 TEST_CASE("Comparisons", "[optional]") {
-  optional<int> e1;
-  optional<int> e2;
-  optional<int> one(1);
-  optional<int> two(2);
+	optional<int> e1;
+	optional<int> e2;
+	optional<int> one(1);
+	optional<int> two(2);
 
-  REQUIRE(e1 == e2);
-  REQUIRE(e1 == nullopt);
-  REQUIRE(one != e1);
-  REQUIRE(one < two);
-  REQUIRE(two > one);
-  REQUIRE(one == 1);
-  REQUIRE(1 == one);
-  REQUIRE(two > 1);
+	REQUIRE(e1 == e2);
+	REQUIRE(e1 == nullopt);
+	REQUIRE(one != e1);
+	REQUIRE(one < two);
+	REQUIRE(two > one);
+	REQUIRE(one == 1);
+	REQUIRE(1 == one);
+	REQUIRE(two > 1);
 
-  optional<Comparable> ca(Comparable(5));
-  optional<Comparable> cb(Comparable(6));
-  REQUIRE(ca < cb);
-  REQUIRE(cb > ca);
+	optional<Comparable> ca(Comparable(5));
+	optional<Comparable> cb(Comparable(6));
+	REQUIRE(ca < cb);
+	REQUIRE(cb > ca);
 }
 
 TEST_CASE("make_optional helpers", "[optional]") {
-  auto opt_int = make_optional(7);
-  REQUIRE(static_cast<bool>(opt_int));
-  REQUIRE(*opt_int == 7);
+	auto opt_int = make_optional(7);
+	REQUIRE(static_cast<bool>(opt_int));
+	REQUIRE(*opt_int == 7);
 
-  auto opt_str = make_optional<string>(3, 'a');
-  REQUIRE(opt_str);
-  REQUIRE(*opt_str == "aaa");
+	auto opt_str = make_optional<string>(3, 'a');
+	REQUIRE(opt_str);
+	REQUIRE(*opt_str == "aaa");
 
-  auto opt_vec = make_optional<vector<int> >({1, 2, 3});
-  REQUIRE(opt_vec);
-  REQUIRE(opt_vec->size() == 3u);
+	auto opt_vec = make_optional<vector<int>>({1, 2, 3});
+	REQUIRE(opt_vec);
+	REQUIRE(opt_vec->size() == 3u);
 }
 
 TEST_CASE("hash", "[optional]") {
-  std::hash<optional<int> > h;
-  size_t a = h(nullopt);
-  size_t b = h(optional<int>(5));
-  size_t c = h(optional<int>(6));
-  REQUIRE(a != b);
-  REQUIRE(b != c);
+	std::hash<optional<int>> h;
+	size_t a = h(nullopt);
+	size_t b = h(optional<int>(5));
+	size_t c = h(optional<int>(6));
+	REQUIRE(a != b);
+	REQUIRE(b != c);
 }
 
 int main(int argc, char **argv) {

--- a/unit/test_read_exception_propagation.cpp
+++ b/unit/test_read_exception_propagation.cpp
@@ -28,8 +28,10 @@ const auto TEST_ON_DISK_CACHE_DIRECTORY = "/tmp/duckdb_test_cache_httpfs_cache_e
 TEST_CASE("Test exception propagation on file read - disk cache", "[read exception test]") {
 	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
 
-	auto close_callback = []() {};
-	auto dtor_callback = []() {};
+	auto close_callback = []() {
+	};
+	auto dtor_callback = []() {
+	};
 	auto mock_filesystem = make_uniq<MockFileSystem>(std::move(close_callback), std::move(dtor_callback));
 	mock_filesystem->SetFileSize(TEST_FILE_SIZE);
 	// Enable exception throwing on read operations
@@ -63,18 +65,19 @@ TEST_CASE("Test exception propagation on file read - disk cache", "[read excepti
 	string content(bytes_to_read, '\0');
 
 	// The read should throw an IOException because the mock filesystem is configured to throw
-	REQUIRE_THROWS_AS(
-		cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
-								bytes_to_read, start_offset),
-		IOException);
+	REQUIRE_THROWS_AS(cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
+	                                         bytes_to_read, start_offset),
+	                  IOException);
 }
 
 // Test that exceptions are correctly propagated in parallel read operations for disk cache.
 TEST_CASE("Test exception propagation in parallel reads - disk cache", "[read exception test]") {
 	LocalFileSystem::CreateLocal()->RemoveDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
 
-	auto close_callback = []() {};
-	auto dtor_callback = []() {};
+	auto close_callback = []() {
+	};
+	auto dtor_callback = []() {
+	};
 	auto mock_filesystem = make_uniq<MockFileSystem>(std::move(close_callback), std::move(dtor_callback));
 	mock_filesystem->SetFileSize(TEST_FILE_SIZE * 2); // Larger file to trigger multiple chunks
 	// Enable exception throwing on read operations
@@ -108,17 +111,18 @@ TEST_CASE("Test exception propagation in parallel reads - disk cache", "[read ex
 
 		// The read should throw an IOException because the mock filesystem is configured to throw
 		// This tests exception propagation through the parallel read mechanism
-		REQUIRE_THROWS_AS(
-		    cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
-		                           bytes_to_read, start_offset),
-		    IOException);
+		REQUIRE_THROWS_AS(cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
+		                                         bytes_to_read, start_offset),
+		                  IOException);
 	}
 }
 
 // Test that exceptions thrown during file read are correctly propagated for in-memory cache.
 TEST_CASE("Test exception propagation on file read - in-memory cache", "[read exception test]") {
-	auto close_callback = []() {};
-	auto dtor_callback = []() {};
+	auto close_callback = []() {
+	};
+	auto dtor_callback = []() {
+	};
 	auto mock_filesystem = make_uniq<MockFileSystem>(std::move(close_callback), std::move(dtor_callback));
 	mock_filesystem->SetFileSize(TEST_FILE_SIZE);
 	// Enable exception throwing on read operations
@@ -148,16 +152,17 @@ TEST_CASE("Test exception propagation on file read - in-memory cache", "[read ex
 	string content(bytes_to_read, '\0');
 
 	// The read should throw an IOException because the mock filesystem is configured to throw
-	REQUIRE_THROWS_AS(
-		cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
-								bytes_to_read, start_offset),
-		IOException);
+	REQUIRE_THROWS_AS(cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
+	                                         bytes_to_read, start_offset),
+	                  IOException);
 }
 
 // Test that exceptions are correctly propagated in parallel read operations for in-memory cache.
 TEST_CASE("Test exception propagation in parallel reads - in-memory cache", "[read exception test]") {
-	auto close_callback = []() {};
-	auto dtor_callback = []() {};
+	auto close_callback = []() {
+	};
+	auto dtor_callback = []() {
+	};
 	auto mock_filesystem = make_uniq<MockFileSystem>(std::move(close_callback), std::move(dtor_callback));
 	mock_filesystem->SetFileSize(TEST_FILE_SIZE * 2); // Larger file to trigger multiple chunks
 	// Enable exception throwing on read operations
@@ -189,10 +194,9 @@ TEST_CASE("Test exception propagation in parallel reads - in-memory cache", "[re
 
 	// The read should throw an IOException because the mock filesystem is configured to throw
 	// This tests exception propagation through the parallel read mechanism
-	REQUIRE_THROWS_AS(
-		cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
-								bytes_to_read, start_offset),
-		IOException);
+	REQUIRE_THROWS_AS(cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
+	                                         bytes_to_read, start_offset),
+	                  IOException);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This PR provides an additional option to disable/enable cache disable-ment on write operation, which could be slow based on iterating through all in-memory, on-disk cache entries and IO operations.

Notice, I used another laptop this weekend, so clang-format setting seems to change a lot.. will fix.