### PR TITLE
Fix extended info access segfault

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -300,9 +300,12 @@ vector<OpenFileInfo> CacheFileSystem::GlobImpl(const string &path, FileOpener *o
 	// Attempt to fill in metadata cache.
 	for (const auto &cur_file_info : open_file_info) {
 		const auto &filepath = cur_file_info.path;
-		const auto &cur_extended_file_info = *cur_file_info.extended_info;
+		if (cur_file_info.extended_info == nullptr) {
+			continue;
+		}
 
 		// Attempt to get file size from extended file info.
+		const auto &cur_extended_file_info = *cur_file_info.extended_info;
 		auto iter = cur_extended_file_info.options.find(FILE_SIZE_INFO_KEY);
 		if (iter == cur_extended_file_info.options.end()) {
 			continue;

--- a/test/sql/issue_393.test
+++ b/test/sql/issue_393.test
@@ -1,0 +1,18 @@
+# name: test/sql/issue_393.test
+# description: regression test for issue 393
+# group: [sql]
+
+require notwindows
+
+require cache_httpfs
+
+# The test file to read is ~16KiB.
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+# Test uncached query.
+query IIIIII
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?dummyParam=val');
+----
+251


### PR DESCRIPTION
Closes https://github.com/dentiny/duck-read-cache-fs/issues/393