### PR TITLE
Fix max fanout subrequest handling and add regression test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ set(TARGET_NAME cache_httpfs)
 
 # Suppress warnings.
 set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -Wno-write-strings -Wno-c++17-extensions -Wno-c++20-extensions")
+    "${CMAKE_CXX_FLAGS} -Wno-write-strings -Wno-c++17-extensions -Wno-c++20-extensions"
+)
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
@@ -133,6 +134,9 @@ add_executable(test_large_file_inmem_reader
                unit/test_large_file_inmem_reader.cpp)
 target_link_libraries(test_large_file_inmem_reader ${EXTENSION_NAME})
 
+add_executable(test_max_fanout_subrequest unit/test_max_fanout_subrequest.cpp)
+target_link_libraries(test_max_fanout_subrequest ${EXTENSION_NAME})
+
 add_executable(test_chunk_utils unit/test_chunk_utils.cpp)
 target_link_libraries(test_chunk_utils ${EXTENSION_NAME})
 
@@ -191,12 +195,10 @@ add_executable(test_cache_exclusion_manager
                unit/test_cache_exclusion_manager.cpp)
 target_link_libraries(test_cache_exclusion_manager ${EXTENSION_NAME})
 
-add_executable(test_multi_duckdb_instance
-               unit/test_multi_duckdb_instance.cpp)
+add_executable(test_multi_duckdb_instance unit/test_multi_duckdb_instance.cpp)
 target_link_libraries(test_multi_duckdb_instance ${EXTENSION_NAME})
 
-add_executable(test_scoped_directory
-               unit/test_scoped_directory.cpp)
+add_executable(test_scoped_directory unit/test_scoped_directory.cpp)
 target_link_libraries(test_scoped_directory ${EXTENSION_NAME})
 
 # Benchmark

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -281,7 +281,7 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 	idx_t already_read_bytes = 0;
 	// Threads to parallelly perform IO.
 
-	ThreadPool io_threads(GetThreadCountForSubrequests(alignment_info.subrequest_count));
+	ThreadPool io_threads(GetThreadCountForSubrequests(alignment_info.subrequest_count, config.max_subrequest_count));
 	// Get file-level metadata once before processing chunks.
 	string version_tag = config.enable_cache_validation ? handle.Cast<CacheFileSystemHandle>().GetVersionTag() : "";
 

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -77,7 +77,7 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 	idx_t already_read_bytes = 0;
 
 	// Threads to parallelly perform IO.
-	ThreadPool io_threads(GetThreadCountForSubrequests(alignment_info.subrequest_count));
+	ThreadPool io_threads(GetThreadCountForSubrequests(alignment_info.subrequest_count, config.max_subrequest_count));
 	// Get file-level metadata once before processing chunks.
 	string version_tag = config.enable_cache_validation ? handle.Cast<CacheFileSystemHandle>().GetVersionTag() : "";
 

--- a/test/sql/max_subrequest_fanout.test
+++ b/test/sql/max_subrequest_fanout.test
@@ -28,7 +28,7 @@ SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/du
 # // Subrequest number 10, which means little parallelism
 # //===--------------------------------------------------------------------===//
 statement ok
-SET cache_httpfs_max_fanout_subrequest=1
+SET cache_httpfs_max_fanout_subrequest=10
 
 query I
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');

--- a/unit/test_max_fanout_subrequest.cpp
+++ b/unit/test_max_fanout_subrequest.cpp
@@ -1,0 +1,177 @@
+// Unit test for cache_httpfs_max_fanout_subrequest.
+//
+// This verifies that a single read request does not fan out more concurrent
+// subrequests than the configured limit.
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+#include "cache_filesystem.hpp"
+#include "cache_httpfs_instance_state.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/main/database.hpp"
+#include "scope_guard.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace duckdb; // NOLINT
+
+namespace {
+
+constexpr idx_t kTestFileSize = 16 * 1024;
+constexpr idx_t kBlockSize = 64;
+constexpr idx_t kMaxFanout = 1;
+constexpr std::chrono::milliseconds kPerReadDelay {10};
+
+class SlowTrackingFileSystem : public LocalFileSystem {
+public:
+	explicit SlowTrackingFileSystem(std::chrono::milliseconds per_read_delay_p)
+	    : local_filesystem(LocalFileSystem::CreateLocal()), per_read_delay(per_read_delay_p) {
+	}
+
+	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags, optional_ptr<FileOpener> opener) override {
+		return local_filesystem->OpenFile(path, flags, opener);
+	}
+
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+		const int current_count = current_read_count.fetch_add(1) + 1;
+		UpdateMaxConcurrentReadCount(current_count);
+
+		std::this_thread::sleep_for(per_read_delay);
+		local_filesystem->Read(handle, buffer, nr_bytes, location);
+
+		current_read_count.fetch_sub(1);
+	}
+
+	int64_t GetFileSize(FileHandle &handle) override {
+		return local_filesystem->GetFileSize(handle);
+	}
+
+	timestamp_t GetLastModifiedTime(FileHandle &handle) override {
+		return local_filesystem->GetLastModifiedTime(handle);
+	}
+
+	void Seek(FileHandle &handle, idx_t location) override {
+		local_filesystem->Seek(handle, location);
+	}
+
+	idx_t SeekPosition(FileHandle &handle) override {
+		return local_filesystem->SeekPosition(handle);
+	}
+
+	std::string GetName() const override {
+		return "slow_tracking_filesystem";
+	}
+
+	int GetMaxConcurrentReadCount() const {
+		return max_concurrent_read_count.load();
+	}
+
+private:
+	void UpdateMaxConcurrentReadCount(int current_count) {
+		int max_count = max_concurrent_read_count.load();
+		while (current_count > max_count &&
+		       !max_concurrent_read_count.compare_exchange_weak(max_count, current_count)) {
+		}
+	}
+
+private:
+	unique_ptr<FileSystem> local_filesystem;
+	std::chrono::milliseconds per_read_delay;
+	std::atomic<int> current_read_count {0};
+	std::atomic<int> max_concurrent_read_count {0};
+};
+
+struct TestFsHelper {
+	DuckDB db;
+	shared_ptr<CacheHttpfsInstanceState> instance_state;
+	unique_ptr<CacheFileSystem> cache_fs;
+	SlowTrackingFileSystem *slow_fs = nullptr;
+
+	TestFsHelper(unique_ptr<SlowTrackingFileSystem> slow_fs_p, const string &cache_type,
+	             const string &cache_directory) {
+		instance_state = make_shared_ptr<CacheHttpfsInstanceState>();
+
+		auto &config = instance_state->config;
+		config.cache_type = cache_type;
+		config.cache_block_size = kBlockSize;
+		config.max_subrequest_count = kMaxFanout;
+		config.enable_cache_validation = false;
+		config.enable_disk_reader_mem_cache = false;
+		config.on_disk_cache_directories = {cache_directory};
+
+		auto local_filesystem = LocalFileSystem::CreateLocal();
+		local_filesystem->CreateDirectory(cache_directory);
+
+		SetInstanceState(*db.instance.get(), instance_state);
+		slow_fs = slow_fs_p.get();
+		cache_fs = make_uniq<CacheFileSystem>(std::move(slow_fs_p), instance_state);
+	}
+};
+
+string BuildTestFileContent() {
+	string content(kTestFileSize, '\0');
+	for (idx_t idx = 0; idx < content.size(); ++idx) {
+		content[idx] = static_cast<char>('a' + (idx % 26));
+	}
+	return content;
+}
+
+int RunReadAndGetMaxConcurrency(const string &cache_type) {
+	const auto test_id = UUID::ToString(UUID::GenerateRandomUUID());
+	const string source_path = StringUtil::Format("/tmp/cache_httpfs_fanout_source_%s.data", test_id);
+	const string cache_dir = StringUtil::Format("/tmp/cache_httpfs_fanout_cache_%s", test_id);
+
+	auto local_filesystem = LocalFileSystem::CreateLocal();
+	ScopeGuard cleanup;
+	cleanup += [&]() {
+		if (local_filesystem->DirectoryExists(cache_dir)) {
+			local_filesystem->RemoveDirectory(cache_dir);
+		}
+	};
+	cleanup += [&]() {
+		if (local_filesystem->FileExists(source_path)) {
+			local_filesystem->RemoveFile(source_path);
+		}
+	};
+
+	const string source_content = BuildTestFileContent();
+	{
+		auto file_handle = local_filesystem->OpenFile(source_path, FileOpenFlags::FILE_FLAGS_WRITE |
+		                                                               FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW);
+		local_filesystem->Write(*file_handle, const_cast<char *>(source_content.data()), source_content.size(), 0);
+		file_handle->Sync();
+		file_handle->Close();
+	}
+
+	auto slow_fs = make_uniq<SlowTrackingFileSystem>(kPerReadDelay);
+	TestFsHelper helper(std::move(slow_fs), cache_type, cache_dir);
+	auto *cache_fs = helper.cache_fs.get();
+
+	auto file_handle = cache_fs->OpenFile(source_path, FileOpenFlags::FILE_FLAGS_READ);
+	string read_output(source_content.size(), '\0');
+	cache_fs->Read(*file_handle, const_cast<char *>(read_output.data()), read_output.size(), 0);
+	REQUIRE(read_output == source_content);
+
+	return helper.slow_fs->GetMaxConcurrentReadCount();
+}
+
+} // namespace
+
+TEST_CASE("Test max fanout subrequest on in-memory cache reader", "[max fanout subrequest]") {
+	const int max_concurrency = RunReadAndGetMaxConcurrency("in_mem");
+	REQUIRE(max_concurrency == kMaxFanout);
+}
+
+TEST_CASE("Test max fanout subrequest on on-disk cache reader", "[max fanout subrequest]") {
+	const int max_concurrency = RunReadAndGetMaxConcurrency("on_disk");
+	REQUIRE(max_concurrency == kMaxFanout);
+}
+
+int main(int argc, char **argv) {
+	return Catch::Session().run(argc, argv);
+}


### PR DESCRIPTION
## Summary
- fix `cache_httpfs_max_fanout_subrequest` not being applied in large file readers
- pass `config.max_subrequest_count` into subrequest thread pool sizing for both in-memory and disk cache readers
- add regression unit test `test_max_fanout_subrequest` to verify fanout cap is respected
- correct SQL test case in `max_subrequest_fanout.test` second scenario

## Testing
- build/release/test/unittest "test/*"
- build/release/extension/cache_httpfs/test_* (all pass)
- build/release/tools/sqlite3_api_wrapper/test_sqlite3_api_wrapper
