### PR TITLE
[minor] Cleanup unused function

### DIFF
--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -120,22 +120,6 @@ bool DEFAULT_IGNORE_SIGPIPE = false;
 // value will be considered.
 idx_t DEFAULT_MIN_DISK_BYTES_FOR_CACHE = 0;
 
-namespace {
-
-// Cache directories configs split token.s
-constexpr char CACHE_DIRECTORIES_CONFIG_SPLITTER = ';';
-
-// Parse directory configuration string into directories.
-vector<string> ParseCacheDirectoryConfig(const string &directory_config_str) {
-	auto directories = StringUtil::Split(directory_config_str, /*delimiter=*/CACHE_DIRECTORIES_CONFIG_SPLITTER);
-	// Sort the cache directories, so for different directories config value with same directory sets, ordering doesn't
-	// affect cache status.
-	std::sort(directories.begin(), directories.end());
-	return directories;
-}
-
-} // namespace
-
 uint64_t GetThreadCountForSubrequests(uint64_t io_request_count, uint64_t max_subrequest_count) {
 	if (max_subrequest_count == 0) {
 		// Different platforms have different limits on the number of threads, use 1000 as the hard cap, above which
@@ -144,26 +128,6 @@ uint64_t GetThreadCountForSubrequests(uint64_t io_request_count, uint64_t max_su
 		return MinValue<uint64_t>(io_request_count, MAX_THREAD_COUNT);
 	}
 	return MinValue<uint64_t>(io_request_count, max_subrequest_count);
-}
-
-std::vector<string> GetCacheDirectoryConfig(optional_ptr<FileOpener> opener) {
-	Value val;
-
-	// Attempt to get cache directories config first.
-	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_directories_config", val);
-	auto new_cache_directories_config = val.ToString();
-	if (!new_cache_directories_config.empty()) {
-		// Cache directory parameter will be ignored, if directory config specified.
-		auto directories = ParseCacheDirectoryConfig(new_cache_directories_config);
-		return directories;
-	}
-
-	// Then fallback to parse cache directory.
-	FileOpener::TryGetCurrentSetting(opener, "cache_httpfs_cache_directory", val);
-	auto new_on_disk_cache_directory = val.ToString();
-	vector<string> directories;
-	directories.emplace_back(std::move(new_on_disk_cache_directory));
-	return directories;
 }
 
 } // namespace duckdb

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -126,9 +126,6 @@ extern idx_t DEFAULT_MIN_DISK_BYTES_FOR_CACHE;
 // Util function for filesystem configurations.
 //===--------------------------------------------------------------------===//
 
-// Get on-disk directories config.
-std::vector<string> GetCacheDirectoryConfig(optional_ptr<FileOpener> opener);
-
 // Get concurrent IO sub-request count.
 // If max_subrequest_count is 0, uses a default cap of 1024.
 uint64_t GetThreadCountForSubrequests(uint64_t io_request_count, uint64_t max_subrequest_count);


### PR DESCRIPTION
I'm not sure how it slips through `-Wunused-function` compilation option though.