### PR TITLE
[2/N] Optimize test build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,83 +129,56 @@ install(
   EXPORT "${DUCKDB_EXPORT_SET}"
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}")
 
-# Test cases.
-if(${BUILD_UNITTESTS})
-  # Unit tests.
-  add_subdirectory(test/unittest)
+# Unit tests.
+add_subdirectory(test/unittest)
 
-  # Integration tests.
-  include_directories(duckdb/third_party/catch)
+# Integration tests.
+include_directories(duckdb/third_party/catch)
 
-  add_executable(test_noop_cache_reader unit/test_noop_cache_reader.cpp)
-  target_link_libraries(test_noop_cache_reader ${EXTENSION_NAME})
+add_executable(test_noop_cache_reader unit/test_noop_cache_reader.cpp)
+target_link_libraries(test_noop_cache_reader ${EXTENSION_NAME})
 
-  add_executable(test_disk_cache_filesystem unit/test_disk_cache_filesystem.cpp)
-  target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})
+add_executable(test_disk_cache_filesystem unit/test_disk_cache_filesystem.cpp)
+target_link_libraries(test_disk_cache_filesystem ${EXTENSION_NAME})
 
-  add_executable(test_disk_cache_validation unit/test_disk_cache_validation.cpp)
-  target_link_libraries(test_disk_cache_validation ${EXTENSION_NAME})
+add_executable(test_disk_cache_validation unit/test_disk_cache_validation.cpp)
+target_link_libraries(test_disk_cache_validation ${EXTENSION_NAME})
 
-  add_executable(test_read_exception_propagation
-                 unit/test_read_exception_propagation.cpp)
-  target_link_libraries(test_read_exception_propagation ${EXTENSION_NAME})
+add_executable(test_large_file_disk_reader unit/test_large_file_disk_reader.cpp)
+target_link_libraries(test_large_file_disk_reader ${EXTENSION_NAME})
 
-  add_executable(test_large_file_disk_reader
-                 unit/test_large_file_disk_reader.cpp)
-  target_link_libraries(test_large_file_disk_reader ${EXTENSION_NAME})
+add_executable(test_disk_cache_with_multi_directories
+               unit/test_disk_cache_with_multi_directories.cpp)
+target_link_libraries(test_disk_cache_with_multi_directories ${EXTENSION_NAME})
 
-  add_executable(test_disk_cache_with_multi_directories
-                 unit/test_disk_cache_with_multi_directories.cpp)
-  target_link_libraries(test_disk_cache_with_multi_directories
-                        ${EXTENSION_NAME})
+add_executable(test_in_memory_cache_filesystem
+               unit/test_in_memory_cache_filesystem.cpp)
+target_link_libraries(test_in_memory_cache_filesystem ${EXTENSION_NAME})
 
-  add_executable(test_in_memory_cache_filesystem
-                 unit/test_in_memory_cache_filesystem.cpp)
-  target_link_libraries(test_in_memory_cache_filesystem ${EXTENSION_NAME})
+add_executable(test_large_file_inmem_reader
+               unit/test_large_file_inmem_reader.cpp)
+target_link_libraries(test_large_file_inmem_reader ${EXTENSION_NAME})
 
-  add_executable(test_large_file_inmem_reader
-                 unit/test_large_file_inmem_reader.cpp)
-  target_link_libraries(test_large_file_inmem_reader ${EXTENSION_NAME})
+add_executable(test_filesystem_utils unit/test_filesystem_utils.cpp)
+target_link_libraries(test_filesystem_utils ${EXTENSION_NAME})
 
-  add_executable(test_max_fanout_subrequest unit/test_max_fanout_subrequest.cpp)
-  target_link_libraries(test_max_fanout_subrequest ${EXTENSION_NAME})
+add_executable(test_cache_filesystem unit/test_cache_filesystem.cpp)
+target_link_libraries(test_cache_filesystem ${EXTENSION_NAME})
 
-  add_executable(test_chunk_utils unit/test_chunk_utils.cpp)
-  target_link_libraries(test_chunk_utils ${EXTENSION_NAME})
+add_executable(test_cache_stats_collection unit/test_cache_stats_collection.cpp)
+target_link_libraries(test_cache_stats_collection ${EXTENSION_NAME})
 
-  add_executable(test_filesystem_utils unit/test_filesystem_utils.cpp)
-  target_link_libraries(test_filesystem_utils ${EXTENSION_NAME})
+add_executable(test_filesystem_config unit/test_filesystem_config.cpp)
+target_link_libraries(test_filesystem_config ${EXTENSION_NAME})
 
-  add_executable(test_cache_filesystem unit/test_cache_filesystem.cpp)
-  target_link_libraries(test_cache_filesystem ${EXTENSION_NAME})
+add_executable(test_set_extension_config unit/test_set_extension_config.cpp)
+target_link_libraries(test_set_extension_config ${EXTENSION_NAME})
 
-  add_executable(test_cache_stats_collection
-                 unit/test_cache_stats_collection.cpp)
-  target_link_libraries(test_cache_stats_collection ${EXTENSION_NAME})
+add_executable(test_base_cache_filesystem unit/test_base_cache_filesystem.cpp)
+target_link_libraries(test_base_cache_filesystem ${EXTENSION_NAME})
 
-  add_executable(test_io_operation_latency unit/test_io_operation_latency.cpp)
-  target_link_libraries(test_io_operation_latency ${EXTENSION_NAME})
-
-  add_executable(test_filesystem_config unit/test_filesystem_config.cpp)
-  target_link_libraries(test_filesystem_config ${EXTENSION_NAME})
-
-  add_executable(test_set_extension_config unit/test_set_extension_config.cpp)
-  target_link_libraries(test_set_extension_config ${EXTENSION_NAME})
-
-  add_executable(test_base_cache_filesystem unit/test_base_cache_filesystem.cpp)
-  target_link_libraries(test_base_cache_filesystem ${EXTENSION_NAME})
-
-  add_executable(test_cache_filesystem_with_mock
-                 unit/test_cache_filesystem_with_mock.cpp)
-  target_link_libraries(test_cache_filesystem_with_mock ${EXTENSION_NAME})
-
-  add_executable(test_cache_exclusion_manager
-                 unit/test_cache_exclusion_manager.cpp)
-  target_link_libraries(test_cache_exclusion_manager ${EXTENSION_NAME})
-
-  add_executable(test_multi_duckdb_instance unit/test_multi_duckdb_instance.cpp)
-  target_link_libraries(test_multi_duckdb_instance ${EXTENSION_NAME})
-endif()
+add_executable(test_multi_duckdb_instance unit/test_multi_duckdb_instance.cpp)
+target_link_libraries(test_multi_duckdb_instance ${EXTENSION_NAME})
 
 # Benchmark
 if(${BUILD_BENCHMARK})

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -2,12 +2,34 @@ include_directories(include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_SOURCE_DIR}/third_party)
 include_directories(${CMAKE_SOURCE_DIR}/src/include)
+include_directories(${CMAKE_SOURCE_DIR}/src/utils/include)
 include_directories(${DuckDB_SOURCE_DIR}/third_party)
 include_directories(${DuckDB_SOURCE_DIR}/test/include)
 
-file(GLOB_RECURSE CATCHFS_UNITTEST_OBJECTS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+set(CATCHFS_UNITTEST_OBJECTS
+    main.cpp
+    test_cache_exclusion_manager.cpp
+    test_cache_filesystem_with_mock.cpp
+    test_chunk_utils.cpp
+    test_clear_cache_on_write.cpp
+    test_copiable_value_lru_cache.cpp
+    test_counter.cpp
+    test_disk_cache_util.cpp
+    test_exclusive_lru_cache.cpp
+    test_exclusive_multi_lru_cache.cpp
+    test_histogram.cpp
+    test_io_operation_latency.cpp
+    test_max_fanout_subrequest.cpp
+    test_no_destructor.cpp
+    test_optional.cpp
+    test_read_exception_propagation.cpp
+    test_scoped_directory.cpp
+    test_shared_lru_cache.cpp
+    test_size_literals.cpp
+    test_thread_pool.cpp
+    test_url_utils.cpp)
 
-add_executable(unittest_cache_httpfs main.cpp ${CATCHFS_UNITTEST_OBJECTS})
+add_executable(unittest_cache_httpfs ${CATCHFS_UNITTEST_OBJECTS})
 
 if(NOT WIN32
    AND NOT SUN

--- a/test/unittest/test_cache_exclusion_manager.cpp
+++ b/test/unittest/test_cache_exclusion_manager.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch/catch.hpp"
 
 #include "cache_exclusion_manager.hpp"
 
@@ -16,9 +15,4 @@ TEST_CASE("Exclusion test", "[cache exclusion manager test]") {
 	// A match-all regex.
 	exclusion_manager.AddExclusionRegex(".*");
 	REQUIRE(exclusion_manager.MatchAnyExclusion("match-file"));
-}
-
-int main(int argc, char **argv) {
-	int result = Catch::Session().run(argc, argv);
-	return result;
 }

--- a/test/unittest/test_cache_filesystem_with_mock.cpp
+++ b/test/unittest/test_cache_filesystem_with_mock.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch/catch.hpp"
 
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
@@ -279,9 +278,4 @@ TEST_CASE("Test clear cache", "[mock filesystem test]") {
 	perform_io_operation();
 	REQUIRE(mock_filesystem_ptr->GetGlobInvocation() == 3);
 	REQUIRE(mock_filesystem_ptr->GetFileOpenInvocation() == 3);
-}
-
-int main(int argc, char **argv) {
-	int result = Catch::Session().run(argc, argv);
-	return result;
 }

--- a/test/unittest/test_chunk_utils.cpp
+++ b/test/unittest/test_chunk_utils.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch/catch.hpp"
 
 #include "chunk_utils.hpp"
 
@@ -117,8 +116,4 @@ TEST_CASE("Test request ending at block boundary", "[chunk utils test]") {
 	REQUIRE(alignment.aligned_start_offset == 0);
 	REQUIRE(alignment.aligned_last_chunk_offset == 0);
 	REQUIRE(alignment.subrequest_count == 1);
-}
-
-int main(int argc, char **argv) {
-	return Catch::Session().run(argc, argv);
 }

--- a/test/unittest/test_clear_cache_on_write.cpp
+++ b/test/unittest/test_clear_cache_on_write.cpp
@@ -1,5 +1,4 @@
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch/catch.hpp"
 
 #include "cache_filesystem_config.hpp"
 #include "disk_cache_reader.hpp"
@@ -96,9 +95,4 @@ TEST_CASE("Test cache cleared on Write without location", "[cache filesystem wri
 	const int64_t new_size = cache_filesystem->GetFileSize(*verify_handle);
 	REQUIRE(new_size == static_cast<int64_t>(new_content.length()));
 	verify_handle->Close();
-}
-
-int main(int argc, char **argv) {
-	int result = Catch::Session().run(argc, argv);
-	return result;
 }

--- a/test/unittest/test_io_operation_latency.cpp
+++ b/test/unittest/test_io_operation_latency.cpp
@@ -1,7 +1,6 @@
 // Unit test to verify IO operation latency recording does reflect in the profile output.
 
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch/catch.hpp"
 
 #include "cache_filesystem.hpp"
 #include "duckdb/common/local_file_system.hpp"
@@ -104,8 +103,4 @@ TEST_CASE("Test IO operation latency recording", "[io operation latency]") {
 	REQUIRE(ProfileContainsOperation(profile, OPER_NAMES[static_cast<idx_t>(IoOperation::kFileRemove)]));
 	REQUIRE(ProfileContainsOperation(profile, OPER_NAMES[static_cast<idx_t>(IoOperation::kGlob)]));
 	REQUIRE(ProfileContainsOperation(profile, OPER_NAMES[static_cast<idx_t>(IoOperation::kFilePathCacheClear)]));
-}
-
-int main(int argc, char **argv) {
-	return Catch::Session().run(argc, argv);
 }

--- a/test/unittest/test_max_fanout_subrequest.cpp
+++ b/test/unittest/test_max_fanout_subrequest.cpp
@@ -1,10 +1,8 @@
 // Unit test for cache_httpfs_max_fanout_subrequest.
 //
-// This verifies that a single read request does not fan out more concurrent
-// subrequests than the configured limit.
+// This verifies that a single read request does not fan out more concurrent subrequests than the configured limit.
 
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch/catch.hpp"
 
 #include "cache_filesystem.hpp"
 #include "cache_httpfs_instance_state.hpp"
@@ -164,8 +162,4 @@ TEST_CASE("Test max fanout subrequest on in-memory cache reader", "[max fanout s
 TEST_CASE("Test max fanout subrequest on on-disk cache reader", "[max fanout subrequest]") {
 	const int max_concurrency = RunReadAndGetMaxConcurrency("on_disk");
 	REQUIRE(max_concurrency <= MAX_FANOUT);
-}
-
-int main(int argc, char **argv) {
-	return Catch::Session().run(argc, argv);
 }

--- a/test/unittest/test_read_exception_propagation.cpp
+++ b/test/unittest/test_read_exception_propagation.cpp
@@ -1,7 +1,6 @@
 // Unit test for exception propagation in cache filesystem.
 
-#define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "catch/catch.hpp"
 
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
@@ -197,8 +196,4 @@ TEST_CASE("Test exception propagation in parallel reads - in-memory cache", "[re
 	REQUIRE_THROWS_AS(cache_filesystem->Read(*handle, const_cast<void *>(static_cast<const void *>(content.data())),
 	                                         bytes_to_read, start_offset),
 	                  IOException);
-}
-
-int main(int argc, char **argv) {
-	return Catch::Session().run(argc, argv);
 }


### PR DESCRIPTION
Followup PR for https://github.com/dentiny/duck-read-cache-fs/pull/411, which moves more unit test build from separate executables to a unified one.