### PR TITLE
Fix clear cache on write test

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -407,15 +407,15 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 // Same strategy applies for duckdb internal "external file cache".
 unique_ptr<FileHandle> CacheFileSystem::OpenFileExtended(const OpenFileInfo &file, FileOpenFlags flags,
                                                          optional_ptr<FileOpener> opener) {
-	// Now we handle uncompressed files, which should be cached.
 	InitializeGlobalConfig(opener);
-	if (flags.OpenForReading()) {
-		return GetOrCreateFileHandleForRead(file, flags, opener);
-	}
 
 	// If setting has already been specified to clear cache, we clear it only once at file open.
 	if (instance_state.lock()->config.clear_cache_on_write) {
 		ClearCache(file.path);
+	}
+
+	if (flags.OpenForReading()) {
+		return GetOrCreateFileHandleForRead(file, flags, opener);
 	}
 
 	// Otherwise, we do nothing (i.e. profiling) but wrapping it with cache file handle wrapper.

--- a/src/utils/include/test_utils.hpp
+++ b/src/utils/include/test_utils.hpp
@@ -31,6 +31,9 @@ struct TestCacheConfig {
 	idx_t max_in_mem_cache_block_count = 8192;
 	idx_t max_disk_reader_mem_cache_block_count = 8192;
 	idx_t min_disk_bytes_for_cache = 0; // 0 means use default behavior
+
+	// Cache behavior
+	bool clear_cache_on_write = false;
 };
 
 // Helper class to create a properly configured CacheFileSystem for testing.

--- a/src/utils/test_utils.cpp
+++ b/src/utils/test_utils.cpp
@@ -31,6 +31,9 @@ TestCacheFileSystemHelper::TestCacheFileSystemHelper(const TestCacheConfig &conf
 	inst_config.disk_reader_max_mem_cache_block_count = config.max_disk_reader_mem_cache_block_count;
 	inst_config.min_disk_bytes_for_cache = config.min_disk_bytes_for_cache;
 
+	// Cache behavior
+	inst_config.clear_cache_on_write = config.clear_cache_on_write;
+
 	// Initialize profile collector
 	instance_state->SetProfileCollector(inst_config.profile_type);
 


### PR DESCRIPTION
This PR does two things:
- Fix a unit test, in which we should specify clear cache on write option (previous test build setup has some issues so it's not triggered)
- Fix a bug that, if a file handle is opened with read/write mode, current implementation won't clear cache