### PR TITLE
Use STL regex to replace re2

### DIFF
--- a/src/cache_exclusion_manager.cpp
+++ b/src/cache_exclusion_manager.cpp
@@ -1,28 +1,23 @@
 #include "cache_exclusion_manager.hpp"
 
-#include <utility>
-
-#include "duckdb/common/helper.hpp"
-
 namespace duckdb {
 
 void CacheExclusionManager::AddExclusionRegex(const string &regex) {
-	auto pattern = make_uniq<::duckdb_re2::RE2>(regex);
 	const concurrency::lock_guard<concurrency::mutex> lck(mu);
-	exclusion_regexes.emplace_back(std::move(pattern));
+	exclusion_regexes.emplace_back(regex);
+	exclusion_patterns.emplace_back(regex);
 }
 
 void CacheExclusionManager::ResetExclusionRegex() {
 	const concurrency::lock_guard<concurrency::mutex> lck(mu);
 	exclusion_regexes.clear();
+	exclusion_patterns.clear();
 }
 
 bool CacheExclusionManager::MatchAnyExclusion(const string &filepath) const {
-	// TODO(hjiang): Could be accessed by multiple threads and potentially be a bottleneck, could use shared pointer to
-	// improve.
 	const concurrency::lock_guard<concurrency::mutex> lck(mu);
 	for (const auto &cur_pattern : exclusion_regexes) {
-		if (RE2::PartialMatch(filepath, *cur_pattern)) {
+		if (std::regex_search(filepath, cur_pattern)) {
 			return true;
 		}
 	}
@@ -30,13 +25,8 @@ bool CacheExclusionManager::MatchAnyExclusion(const string &filepath) const {
 }
 
 vector<string> CacheExclusionManager::GetExclusionRegex() const {
-	vector<string> results;
 	const concurrency::lock_guard<concurrency::mutex> lck(mu);
-	results.reserve(exclusion_regexes.size());
-	for (const auto &cur_pattern : exclusion_regexes) {
-		results.emplace_back(cur_pattern->pattern());
-	}
-	return results;
+	return exclusion_patterns;
 }
 
 } // namespace duckdb

--- a/src/include/cache_exclusion_manager.hpp
+++ b/src/include/cache_exclusion_manager.hpp
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include <regex>
+
 #include "duckdb/common/string.hpp"
-#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "mutex.hpp"
-#include "re2/re2.h"
 #include "thread_annotation.hpp"
 
 namespace duckdb {
@@ -27,7 +27,8 @@ public:
 
 private:
 	mutable concurrency::mutex mu;
-	vector<unique_ptr<::duckdb_re2::RE2>> exclusion_regexes DUCKDB_GUARDED_BY(mu);
+	vector<std::regex> exclusion_regexes DUCKDB_GUARDED_BY(mu);
+	vector<string> exclusion_patterns DUCKDB_GUARDED_BY(mu);
 };
 
 } // namespace duckdb


### PR DESCRIPTION
When running unit tests, I non-deterministically met invalid memory access on cache manager destructor;
`gdb` backtraces shows
```sh
Program received signal SIGABRT, Aborted.
0x0000fffff48c7dc0 in ?? () from /lib/aarch64-linux-gnu/libc.so.6
#0  0x0000fffff48c7dc0 in ?? () from /lib/aarch64-linux-gnu/libc.so.6
#1  0x0000fffff4876980 [PAC] in raise () from /lib/aarch64-linux-gnu/libc.so.6
#2  0x0000fffff4861ac4 [PAC] in abort () from /lib/aarch64-linux-gnu/libc.so.6
#3  0x0000fffff48bb368 [PAC] in ?? () from /lib/aarch64-linux-gnu/libc.so.6
#4  0x0000fffff48d2e9c [PAC] in ?? () from /lib/aarch64-linux-gnu/libc.so.6
#5  0x0000fffff48d3128 [PAC] in ?? () from /lib/aarch64-linux-gnu/libc.so.6
#6  0x0000fffff48d7ed8 [PAC] in free () from /lib/aarch64-linux-gnu/libc.so.6
#7  0x0000aaaaaabfd898 [PAC] in duckdb_re2::RE2::~RE2 (this=0xaaaaaaca3930, __in_chrg=<optimized out>) at /usr/include/c++/14/bits/new_allocator.h:104
#8  0x0000aaaaaab77680 in std::default_delete<duckdb_re2::RE2>::operator() (this=<optimized out>, __ptr=0xaaaaaaca3930) at /usr/include/c++/14/bits/unique_ptr.h:87
#9  std::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2> >::~unique_ptr (this=0xaaaaaac88050, __in_chrg=<optimized out>) at /usr/include/c++/14/bits/unique_ptr.h:399
#10 duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true>::~unique_ptr (this=0xaaaaaac88050, __in_chrg=<optimized out>) at /home/vscode/duck-read-cache-fs/duckdb/src/include/duckdb/common/unique_ptr.hpp:13
#11 std::_Destroy<duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true> > (__pointer=0xaaaaaac88050) at /usr/include/c++/14/bits/stl_construct.h:151
#12 std::_Destroy_aux<false>::__destroy<duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true>*> (__first=0xaaaaaac88050, __last=0xaaaaaac88060) at /usr/include/c++/14/bits/stl_construct.h:163
#13 std::_Destroy<duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true>*> (__first=<optimized out>, __last=0xaaaaaac88060) at /usr/include/c++/14/bits/stl_construct.h:196
#14 std::_Destroy<duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true>*, duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true> > (__first=<optimized out>, __last=0xaaaaaac88060) at /usr/include/c++/14/bits/alloc_traits.h:993
#15 std::vector<duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true>, std::allocator<duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true> > >::~vector (this=0xffffffffe760, __in_chrg=<optimized out>) at /usr/include/c++/14/bits/stl_vector.h:735
#16 duckdb::vector<duckdb::unique_ptr<duckdb_re2::RE2, std::default_delete<duckdb_re2::RE2>, true>, true>::~vector (this=0xffffffffe760, __in_chrg=<optimized out>) at /home/vscode/duck-read-cache-fs/duckdb/src/include/duckdb/common/vector.hpp:21
#17 duckdb::CacheExclusionManager::~CacheExclusionManager (this=0xffffffffe730, __in_chrg=<optimized out>) at /home/vscode/duck-read-cache-fs/src/include/cache_exclusion_manager.hpp:14
```
The suspicion is duckdb internal jemalloc overrides global ptmalloc on `re2` library.
Current implementation is already simple enough, and I don't find any illegal usage; to simplify code change, this PR directly uses STL ones instead of duckdb ones.