### PR TITLE
[minor] Cleanup cache file store function

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -167,8 +167,8 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 	// We're tolerate of local cache file write failure, which doesn't affect returned content correctness.
 	try {
 		const auto &cache_directory = config.on_disk_cache_directories[cache_destination.cache_directory_idx];
-		DiskCacheUtil::StoreLocalCacheFile(handle.GetPath(), cache_directory, cache_destination.cache_filepath, content,
-		                                   version_tag, config, [this]() { return EvictCacheBlockLru(); });
+		DiskCacheUtil::StoreLocalCacheFile(cache_directory, cache_destination.cache_filepath, content, version_tag,
+		                                   config, [this]() { return EvictCacheBlockLru(); });
 
 		// Update in-memory cache if applicable.
 		if (in_mem_cache_blocks != nullptr) {

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -49,6 +49,9 @@ DiskCacheUtil::CacheFileDestination DiskCacheUtil::GetLocalCacheFile(const vecto
 	}
 	const idx_t cache_directory_idx = hash_value % cache_directories.size();
 	const auto &cur_cache_dir = cache_directories[cache_directory_idx];
+	if (StringUtil::EndsWith(cur_cache_dir, "/")) {
+		throw InternalException("Cache directory %s cannot ends with '/'", cur_cache_dir);
+	}
 
 	auto cache_filepath = StringUtil::Format("%s/%s-%s-%llu-%llu", cur_cache_dir, remote_file_sha256_str, fname,
 	                                         start_offset, bytes_to_read);
@@ -112,9 +115,8 @@ void DiskCacheUtil::EvictCacheFiles(FileSystem &local_filesystem, const string &
 	local_filesystem.TryRemoveFile(filepath_to_evict);
 }
 
-void DiskCacheUtil::StoreLocalCacheFile(const string &remote_filepath, const string &cache_directory,
-                                        const string &local_cache_file, const string &content,
-                                        const string &version_tag, const InstanceConfig &config,
+void DiskCacheUtil::StoreLocalCacheFile(const string &cache_directory, const string &local_cache_file,
+                                        const string &content, const string &version_tag, const InstanceConfig &config,
                                         const std::function<string()> &lru_eviction_decider) {
 	LocalFileSystem local_filesystem {};
 
@@ -127,10 +129,10 @@ void DiskCacheUtil::StoreLocalCacheFile(const string &remote_filepath, const str
 		return;
 	}
 
-	// Dump to a temporary location at local filesystem.
-	const auto fname = StringUtil::GetFileName(remote_filepath);
-	const auto local_temp_file = StringUtil::Format("%s/%s.%s.httpfs_local_cache", cache_directory, fname,
-	                                                UUID::ToString(UUID::GenerateRandomUUID()));
+	// Dump to a unique temporary location at local filesystem, since there could be multiple processes writing cache
+	// file for the same remote file.
+	const auto local_temp_file =
+	    StringUtil::Format("%s.%s.httpfs_local_cache", local_cache_file, UUID::ToString(UUID::GenerateRandomUUID()));
 	{
 		auto file_open_flags = FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW;
 		// When we enable write-through/read-through cache for disk cache reader, use direct IO to avoid double caching.

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -52,9 +52,9 @@ public:
 	// Store content to a local cache file.
 	// Disk space availability is validated, and eviction is triggered if needed.
 	// [lru_eviction_decider] is used to obtain the filepath to remove under LRU eviction policy.
-	static void StoreLocalCacheFile(const string &remote_filepath, const string &cache_directory,
-	                                const string &local_cache_file, const string &content, const string &version_tag,
-	                                const InstanceConfig &config, const std::function<string()> &lru_eviction_decider);
+	static void StoreLocalCacheFile(const string &cache_directory, const string &local_cache_file,
+	                                const string &content, const string &version_tag, const InstanceConfig &config,
+	                                const std::function<string()> &lru_eviction_decider);
 
 	// Result of a local cache file read attempt.
 	struct LocalCacheReadResult {


### PR DESCRIPTION
A minor no-op cleanup: `StoreLocalCacheFile` is already taking too many arguments, this PR removes an unnecessary one.