### PR TITLE
[3/N] Fix cache infor access for oversized filepath

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -81,9 +81,10 @@ vector<DataCacheEntryInfo> DiskCacheReader::GetCacheEntriesInfo() const {
 	for (const auto &cur_cache_dir : cache_directories) {
 		local_filesystem->ListFiles(cur_cache_dir,
 		                            [&cache_entries_info, cur_cache_dir](const string &fname, bool /*unused*/) {
-			                            auto remote_file_info = DiskCacheUtil::GetRemoteFileInfo(fname);
+			                            auto cache_filepath = StringUtil::Format("%s/%s", cur_cache_dir, fname);
+			                            auto remote_file_info = DiskCacheUtil::GetRemoteFileInfo(cache_filepath);
 			                            cache_entries_info.emplace_back(DataCacheEntryInfo {
-			                                .cache_filepath = StringUtil::Format("%s/%s", cur_cache_dir, fname),
+			                                .cache_filepath = std::move(cache_filepath),
 			                                .remote_filename = std::move(remote_file_info.remote_filename),
 			                                .start_offset = remote_file_info.start_offset,
 			                                .end_offset = remote_file_info.end_offset,

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -44,8 +44,8 @@ public:
 		uint64_t end_offset = 0;
 	};
 
-	// Get remote file information from the given local cache [fname].
-	static RemoteFileInfo GetRemoteFileInfo(const string &fname);
+	// Get remote file information from the given local cache [cache_filepath].
+	static RemoteFileInfo GetRemoteFileInfo(const string &cache_filepath);
 
 	// Used to delete on-disk cache files, which returns the file prefix for the given [remote_file].
 	static string GetLocalCacheFilePrefix(const string &remote_file);

--- a/src/utils/include/filesystem_utils.hpp
+++ b/src/utils/include/filesystem_utils.hpp
@@ -41,7 +41,7 @@ map<timestamp_t, string> GetOnDiskFilesUnder(const vector<string> &folders);
 // Return whether the update operation succeeds.
 bool UpdateFileTimestamps(const string &filepath);
 
-// Store the version string in the file's extended attributes
+// Store the version string in the file's extended attributes.
 // Returns whether the operation succeeds.
 bool SetCacheVersion(const string &filepath, const string &version);
 
@@ -49,7 +49,7 @@ bool SetCacheVersion(const string &filepath, const string &version);
 // Returns empty string if missing or error.
 string GetCacheVersion(const string &filepath);
 
-// Set extended attributes on a file.
+// Set extended attributes on a file; if the attribute key already exists, it will be overwritten.
 // Return whether the operation succeeds.
 // Notice, this function doesn't provide transaction guarantee.
 bool SetFileAttributes(const string &filepath, const unordered_map<string, string> &attrs);
@@ -77,6 +77,10 @@ struct MaxFileNameLength {
 
 // Get the platform maximum for full file path length and single filename component length.
 MaxFileNameLength GetMaxFileNameLength();
+
+// Read a single extended attribute value from a file.
+// Returns the value as a string, or empty string if missing or on error.
+string GetFileAttribute(const string &filepath, const string &key);
 
 // Get the maximum size in bytes for a single extended attribute value.
 idx_t GetMaxXattrValueSize();

--- a/src/utils/include/test_utils.hpp
+++ b/src/utils/include/test_utils.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "base_cache_reader.hpp"
 #include "cache_filesystem.hpp"
 #include "cache_httpfs_instance_state.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -59,6 +60,9 @@ public:
 
 	// Get the instance state
 	CacheHttpfsInstanceState &GetInstanceStateOrThrow();
+
+	// Get the cache reader
+	BaseCacheReader &GetCacheReader();
 
 	// Get the config for inspection/modification
 	InstanceConfig &GetConfig();

--- a/src/utils/test_utils.cpp
+++ b/src/utils/test_utils.cpp
@@ -59,6 +59,12 @@ CacheHttpfsInstanceState &TestCacheFileSystemHelper::GetInstanceStateOrThrow() {
 	return *instance_state;
 }
 
+BaseCacheReader &TestCacheFileSystemHelper::GetCacheReader() {
+	auto *reader = instance_state->cache_reader_manager.GetCacheReader();
+	D_ASSERT(reader);
+	return *reader;
+}
+
 InstanceConfig &TestCacheFileSystemHelper::GetConfig() {
 	return instance_state->config;
 }

--- a/test/unittest/test_oversized_cache_filepath.cpp
+++ b/test/unittest/test_oversized_cache_filepath.cpp
@@ -17,10 +17,17 @@ constexpr int64_t TEST_CHUNK_SIZE = 26;
 const auto TEST_DIRECTORY = "/tmp/duckdb_test_oversized_cache_filepath";
 
 // Build a filename that exceeds the platform's max filename length.
-string MakeOversizedFilename() {
+struct OversizedFile {
+	string filepath;
+	string filename;
+};
+OversizedFile MakeOversizedFilepath() {
 	const auto limits = GetMaxFileNameLength();
 	const string long_component(limits.max_filename_len + 100, 'x');
-	return StringUtil::Format("s3://bucket/%s.parquet", long_component);
+	return OversizedFile {
+	    .filepath = StringUtil::Format("s3://bucket/%s.parquet", long_component),
+	    .filename = StringUtil::Format("%s.parquet", long_component),
+	};
 }
 
 } // namespace
@@ -32,7 +39,7 @@ TEST_CASE("Oversized filename caching roundtrip", "[disk_cache_util]") {
 	ScopedDirectory scoped_dir(TEST_DIRECTORY);
 	LocalFileSystem local_fs {};
 
-	const string test_filename = MakeOversizedFilename();
+	const auto oversized_file = MakeOversizedFilepath();
 	auto mock_filesystem = make_uniq<MockFileSystem>([]() {}, []() {});
 	mock_filesystem->SetFileSize(TEST_FILESIZE);
 	auto *mock_fs_ptr = mock_filesystem.get();
@@ -48,7 +55,7 @@ TEST_CASE("Oversized filename caching roundtrip", "[disk_cache_util]") {
 
 	// First read: cache miss, should fall through to mock filesystem.
 	{
-		auto handle = cache_filesystem->OpenFile(test_filename, FileOpenFlags::FILE_FLAGS_READ);
+		auto handle = cache_filesystem->OpenFile(oversized_file.filepath, FileOpenFlags::FILE_FLAGS_READ);
 		string buffer(TEST_FILESIZE, '\0');
 		cache_filesystem->Read(*handle, const_cast<char *>(buffer.data()), TEST_FILESIZE, /*location=*/0);
 		REQUIRE(buffer == string(TEST_FILESIZE, 'a'));
@@ -73,7 +80,7 @@ TEST_CASE("Oversized filename caching roundtrip", "[disk_cache_util]") {
 
 	// Second read: should be a cache hit (in-memory or on-disk), no mock reads.
 	{
-		auto handle = cache_filesystem->OpenFile(test_filename, FileOpenFlags::FILE_FLAGS_READ);
+		auto handle = cache_filesystem->OpenFile(oversized_file.filepath, FileOpenFlags::FILE_FLAGS_READ);
 		string buffer(TEST_FILESIZE, '\0');
 		cache_filesystem->Read(*handle, const_cast<char *>(buffer.data()), TEST_FILESIZE, /*location=*/0);
 		REQUIRE(buffer == string(TEST_FILESIZE, 'a'));
@@ -81,4 +88,21 @@ TEST_CASE("Oversized filename caching roundtrip", "[disk_cache_util]") {
 		auto read_ops = mock_fs_ptr->GetSortedReadOperations();
 		REQUIRE(read_ops.empty());
 	}
+
+	// Check cache entries info.
+	auto &cache_reader = helper.GetCacheReader();
+	auto cache_entries_info = cache_reader.GetCacheEntriesInfo();
+	REQUIRE(cache_entries_info.size() == 2);
+
+	// In-memory disk cache cache is returned first.
+	REQUIRE(cache_entries_info[0].cache_type == "in-mem-disk-cache");
+	REQUIRE(cache_entries_info[0].remote_filename == oversized_file.filename);
+	REQUIRE(cache_entries_info[0].start_offset == 0);
+	REQUIRE(cache_entries_info[0].end_offset == TEST_FILESIZE);
+
+	// Then comes on-disk cache.
+	REQUIRE(cache_entries_info[1].cache_type == "on-disk");
+	REQUIRE(cache_entries_info[1].remote_filename == oversized_file.filename);
+	REQUIRE(cache_entries_info[1].start_offset == 0);
+	REQUIRE(cache_entries_info[1].end_offset == TEST_FILESIZE);
 }


### PR DESCRIPTION
Closes https://github.com/dentiny/duck-read-cache-fs/issues/421

The last part for fixing on-disk cache for remote files with too long filepath, so we could get the correct cache info by first assembling the original local cache filepath.
TODO item: the feature is platform-dependent (since it relies on file attributes), so should be tested on macos also.