### PR TITLE
[minor] Rename SharedLruCache class

### DIFF
--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -13,7 +13,7 @@
 #include "duckdb/main/client_context.hpp"
 #include "exclusive_multi_lru_cache.hpp"
 #include "mutex.hpp"
-#include "shared_lru_cache.hpp"
+#include "shared_value_lru_cache.hpp"
 #include "thread_annotation.hpp"
 
 #include <functional>
@@ -308,7 +308,7 @@ private:
 	// Refer to [CacheHttpfsInstanceState] for thread-safety guarentee.
 	std::reference_wrapper<BaseProfileCollector> profile_collector;
 	// Metadata cache, which maps from file path to metadata.
-	using MetadataCache = ThreadSafeSharedLruConstCache<string, FileMetadata>;
+	using MetadataCache = ThreadSafeSharedValueLruConstCache<string, FileMetadata>;
 	unique_ptr<MetadataCache> metadata_cache;
 	// File handle cache, which maps from file path to uncached file handle.
 	// Cache is used here to avoid HEAD HTTP request on read operations.
@@ -321,7 +321,7 @@ private:
 	    ThreadSafeCounter<FileHandleCacheKey, FileHandleCacheKeyHash, FileHandleCacheKeyEqual>;
 	shared_ptr<InUseFileHandleCounter> in_use_file_handle_counter;
 	// Glob cache, which maps from path to filenames.
-	using GlobCache = ThreadSafeSharedLruConstCache<string, vector<OpenFileInfo>>;
+	using GlobCache = ThreadSafeSharedValueLruConstCache<string, vector<OpenFileInfo>>;
 	unique_ptr<GlobCache> glob_cache;
 	// Per-instance state (shared ownership keeps state alive until all CacheFileSystems are destroyed)
 	weak_ptr<CacheHttpfsInstanceState> instance_state;

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -13,7 +13,7 @@
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "in_mem_cache_block.hpp"
-#include "shared_lru_cache.hpp"
+#include "shared_value_lru_cache.hpp"
 #include "thread_annotation.hpp"
 
 namespace duckdb {
@@ -51,7 +51,7 @@ private:
 	};
 
 	using InMemCache =
-	    ThreadSafeSharedLruCache<InMemCacheBlock, InMemCacheEntry, InMemCacheBlockHash, InMemCacheBlockEqual>;
+	    ThreadSafeSharedValueLruCache<InMemCacheBlock, InMemCacheEntry, InMemCacheBlockHash, InMemCacheBlockEqual>;
 
 	// Return whether the given cache entry is still valid and usable.
 	bool ValidateCacheEntry(InMemCacheEntry *cache_entry, const string &version_tag);

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -8,7 +8,7 @@
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "in_mem_cache_block.hpp"
-#include "shared_lru_cache.hpp"
+#include "shared_value_lru_cache.hpp"
 
 namespace duckdb {
 
@@ -41,7 +41,7 @@ private:
 	};
 
 	using InMemCache =
-	    ThreadSafeSharedLruCache<InMemCacheBlock, InMemCacheEntry, InMemCacheBlockHash, InMemCacheBlockEqual>;
+	    ThreadSafeSharedValueLruCache<InMemCacheBlock, InMemCacheEntry, InMemCacheBlockHash, InMemCacheBlockEqual>;
 
 	// Return whether the given cache entry is still valid and usable.
 	bool ValidateCacheEntry(InMemCacheEntry *cache_entry, const string &version_tag);

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CATCHFS_UNITTEST_OBJECTS
     test_read_exception_propagation.cpp
     test_scoped_directory.cpp
     test_set_extension_config_from_unit.cpp
-    test_shared_lru_cache.cpp
+    test_shared_value_lru_cache.cpp
     test_size_literals.cpp
     test_thread_pool.cpp
     test_url_utils.cpp

--- a/test/unittest/test_shared_value_lru_cache.cpp
+++ b/test/unittest/test_shared_value_lru_cache.cpp
@@ -7,7 +7,7 @@
 #include <tuple>
 
 #include "duckdb/common/string.hpp"
-#include "shared_lru_cache.hpp"
+#include "shared_value_lru_cache.hpp"
 
 using namespace duckdb; // NOLINT
 
@@ -28,8 +28,8 @@ struct MapKeyHash {
 };
 } // namespace
 
-TEST_CASE("SharedLru PutAndGetSameKey", "[shared lru test]") {
-	ThreadSafeSharedLruCache<std::string, std::string> cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/0};
+TEST_CASE("SharedValueLru PutAndGetSameKey", "[shared value lru test]") {
+	ThreadSafeSharedValueLruCache<std::string, std::string> cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/0};
 
 	// No value initially.
 	auto val = cache.Get("1");
@@ -56,9 +56,9 @@ TEST_CASE("SharedLru PutAndGetSameKey", "[shared lru test]") {
 	REQUIRE(val == nullptr);
 }
 
-TEST_CASE("SharedLru CustomizedStruct", "[shared lru test]") {
-	ThreadSafeSharedLruCache<MapKey, std::string, MapKeyHash, MapKeyEqual> cache {/*max_entries_p=*/1,
-	                                                                              /*timeout_millisec_p=*/0};
+TEST_CASE("SharedValueLru CustomizedStruct", "[shared value lru test]") {
+	ThreadSafeSharedValueLruCache<MapKey, std::string, MapKeyHash, MapKeyEqual> cache {/*max_entries_p=*/1,
+	                                                                                   /*timeout_millisec_p=*/0};
 	MapKey key;
 	key.fname = "hello";
 	key.off = 10;
@@ -72,8 +72,8 @@ TEST_CASE("SharedLru CustomizedStruct", "[shared lru test]") {
 	REQUIRE(*val == "world");
 }
 
-TEST_CASE("SharedLru Clear with filter", "[shared lru test]") {
-	ThreadSafeSharedLruCache<std::string, std::string> cache {/*max_entries_p=*/3, /*timeout_millisec_p=*/0};
+TEST_CASE("SharedValueLru Clear with filter", "[shared value lru test]") {
+	ThreadSafeSharedValueLruCache<std::string, std::string> cache {/*max_entries_p=*/3, /*timeout_millisec_p=*/0};
 	cache.Put("key1", make_shared_ptr<std::string>("val1"));
 	cache.Put("key2", make_shared_ptr<std::string>("val2"));
 	cache.Put("key3", make_shared_ptr<std::string>("val3"));
@@ -91,8 +91,8 @@ TEST_CASE("SharedLru Clear with filter", "[shared lru test]") {
 	REQUIRE(val == nullptr);
 }
 
-TEST_CASE("SharedLru GetOrCreate", "[shared lru test]") {
-	using CacheType = ThreadSafeSharedLruCache<std::string, std::string>;
+TEST_CASE("SharedValueLru GetOrCreate", "[shared value lru test]") {
+	using CacheType = ThreadSafeSharedValueLruCache<std::string, std::string>;
 
 	std::atomic<bool> invoked = {false}; // Used to check only invoke once.
 	auto factory = [&invoked](const std::string &key) -> shared_ptr<std::string> {
@@ -125,8 +125,8 @@ TEST_CASE("SharedLru GetOrCreate", "[shared lru test]") {
 	REQUIRE(*cached_val == key);
 }
 
-TEST_CASE("SharedLru Put and get with timeout", "[shared lru test]") {
-	using CacheType = ThreadSafeSharedLruCache<std::string, std::string>;
+TEST_CASE("SharedValueLru Put and get with timeout", "[shared value lru test]") {
+	using CacheType = ThreadSafeSharedValueLruCache<std::string, std::string>;
 
 	CacheType cache {/*max_entries_p=*/1, /*timeout_millisec_p=*/500};
 	cache.Put("key", make_shared_ptr<std::string>("val"));


### PR DESCRIPTION
DuckDB v1.5 introduces a LRU cache called `SharedLruCache`, which conflicts with our extensions.