### PR TITLE
No use direct IO in misaligned

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -134,8 +134,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 	{
 		const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kDiskCacheRead);
 		auto read_result =
-		    DiskCacheUtil::ReadLocalCacheFile(cache_dest.dest_local_filepath, cache_read_chunk.chunk_size,
-		                                      config.enable_disk_reader_mem_cache, version_tag);
+		    DiskCacheUtil::ReadLocalCacheFile(cache_dest.dest_local_filepath, cache_read_chunk.chunk_size, version_tag);
 		if (read_result.cache_hit) {
 			GetProfileCollector().RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit);
 			DUCKDB_LOG_READ_CACHE_HIT((handle));

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -195,14 +195,9 @@ string TryGetOriginalCacheFilepath(const string &filepath) {
 	}
 }
 
-/*static*/ DiskCacheUtil::LocalCacheReadResult DiskCacheUtil::ReadLocalCacheFile(const string &cache_filepath,
-                                                                                 idx_t chunk_size, bool use_direct_io,
-                                                                                 const string &version_tag) {
-	auto file_open_flags = FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
-	if (use_direct_io) {
-		file_open_flags |= FileOpenFlags::FILE_FLAGS_DIRECT_IO;
-	}
-
+/*static*/ DiskCacheUtil::LocalCacheReadResult
+DiskCacheUtil::ReadLocalCacheFile(const string &cache_filepath, idx_t chunk_size, const string &version_tag) {
+	constexpr auto file_open_flags = FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
 	LocalFileSystem local_filesystem {};
 	// On all platform, DuckDB opens option guarantee reference counting, which means even if the file is requested to
 	// delete, already-opened file handle could still be accessed with no problem.

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -78,7 +78,7 @@ public:
 
 	// Attempt to open, validate, and read a local cache file at the already-resolved [cache_filepath].
 	// If the local cache file doesn't match requested [version_tag], it will be deleted.
-	static LocalCacheReadResult ReadLocalCacheFile(const string &cache_filepath, idx_t chunk_size, bool use_direct_io,
+	static LocalCacheReadResult ReadLocalCacheFile(const string &cache_filepath, idx_t chunk_size,
 	                                               const string &version_tag);
 
 	// Remove dead temporary cache files (write-to-temp-then-swap leftovers) under [cache_directories].


### PR DESCRIPTION
Direct IO actually has more strict requirement
> The O_DIRECT flag may impose alignment restrictions on the length
       and address of user-space buffers and the file offset of I/Os.  In
       Linux alignment restrictions vary by filesystem and kernel version
       and might be absent entirely.  The handling of misaligned O_DIRECT
       I/Os also varies; they can either fail with EINVAL or fall back to
       buffered I/O.

Ref: https://man7.org/linux/man-pages/man2/open.2.html