### PR TITLE
Profiler per-connection instead of CacheReader

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -45,10 +45,10 @@ CacheFileSystem::FileHandleCacheKey::FileHandleCacheKey(const string &path_arg, 
 
 CacheFileSystemHandle::CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs,
                                              std::function<void(CacheFileSystemHandle &)> dtor_callback_p,
-                                             connection_t connection_id)
+                                             connection_t connection_id_p)
     : FileHandle(fs, internal_file_handle_p->GetPath(), internal_file_handle_p->GetFlags()),
       logger(internal_file_handle_p->logger), internal_file_handle(std::move(internal_file_handle_p)),
-      dtor_callback(std::move(dtor_callback_p)), connection_id(connection_id) {
+      dtor_callback(std::move(dtor_callback_p)), connection_id(connection_id_p) {
 }
 
 FileSystem *CacheFileSystemHandle::GetInternalFileSystem() const {

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -17,11 +17,11 @@ constexpr const char *LAST_MOD_TIMESTAMP_KEY = "last_modified";
 
 connection_t GetConnectionId(optional_ptr<FileOpener> opener) {
 	if (!opener) {
-		return 0;
+		return DConstants::INVALID_INDEX;
 	}
 	auto client_context = FileOpener::TryGetClientContext(opener);
 	if (!client_context) {
-		return 0;
+		return DConstants::INVALID_INDEX;
 	}
 	return client_context->GetConnectionId();
 }
@@ -318,8 +318,12 @@ vector<OpenFileInfo> CacheFileSystem::GlobImpl(const string &path, FileOpener *o
 	auto conn_id = GetConnectionId(opener);
 	auto state = instance_state.lock();
 	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
-	const auto latency_guard = collector.RecordOperationStart(IoOperation::kGlob);
-	auto open_file_info = internal_filesystem->Glob(path, opener);
+
+	vector<OpenFileInfo> open_file_info;
+	{
+		const auto latency_guard = collector.RecordOperationStart(IoOperation::kGlob);
+		open_file_info = internal_filesystem->Glob(path, opener);
+	}
 
 	// Certain filesystem (i.e., s3 filesystem) populates file size within extended file info, make an attempt to
 	// extract file size.

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -1,12 +1,10 @@
 #include "cache_filesystem.hpp"
 
 #include "assert_utils.hpp"
-#include "cache_filesystem_config.hpp"
 #include "cache_filesystem_logger.hpp"
 #include "disk_cache_reader.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "in_memory_cache_reader.hpp"
-#include "temp_profile_collector.hpp"
 #include "utils/include/url_utils.hpp"
 
 namespace duckdb {
@@ -16,6 +14,18 @@ namespace {
 constexpr const char *FILE_SIZE_INFO_KEY = "file_size";
 // For certain filesystems, file open info contains "last_modified" field in the extended stats map.
 constexpr const char *LAST_MOD_TIMESTAMP_KEY = "last_modified";
+
+connection_t GetConnectionId(optional_ptr<FileOpener> opener) {
+	if (!opener) {
+		return 0;
+	}
+	auto client_context = FileOpener::TryGetClientContext(opener);
+	if (!client_context) {
+		return 0;
+	}
+	return client_context->GetConnectionId();
+}
+
 } // namespace
 
 CacheFileSystem::FileHandleCacheKey::FileHandleCacheKey(const string &path_arg, FileOpenFlags flags_arg)
@@ -23,10 +33,11 @@ CacheFileSystem::FileHandleCacheKey::FileHandleCacheKey(const string &path_arg, 
 }
 
 CacheFileSystemHandle::CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs,
-                                             std::function<void(CacheFileSystemHandle &)> dtor_callback_p)
+                                             std::function<void(CacheFileSystemHandle &)> dtor_callback_p,
+                                             connection_t connection_id)
     : FileHandle(fs, internal_file_handle_p->GetPath(), internal_file_handle_p->GetFlags()),
       logger(internal_file_handle_p->logger), internal_file_handle(std::move(internal_file_handle_p)),
-      dtor_callback(std::move(dtor_callback_p)) {
+      dtor_callback(std::move(dtor_callback_p)), connection_id(connection_id) {
 }
 
 FileSystem *CacheFileSystemHandle::GetInternalFileSystem() const {
@@ -53,16 +64,7 @@ void CacheFileSystemHandle::Close() {
 
 CacheFileSystem::CacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p,
                                  weak_ptr<CacheHttpfsInstanceState> instance_state_p)
-    : internal_filesystem(std::move(internal_filesystem_p)),
-      profile_collector([&instance_state_p]() -> BaseProfileCollector & {
-	      auto state = instance_state_p.lock();
-	      if (!state) {
-		      throw InternalException("CacheFileSystem: instance state is no longer valid during construction");
-	      }
-	      return *state->profile_collector;
-      }()),
-      instance_state(std::move(instance_state_p)) {
-	// Register with per-instance registry
+    : internal_filesystem(std::move(internal_filesystem_p)), instance_state(std::move(instance_state_p)) {
 	auto state = instance_state.lock();
 	if (!state) {
 		throw InternalException("CacheFileSystem: instance state is no longer valid during construction");
@@ -106,14 +108,20 @@ void CacheFileSystem::SetMetadataCache() {
 }
 
 bool CacheFileSystem::TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
-	const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kFileRemove);
-	ClearCache(filename);
+	auto conn_id = GetConnectionId(opener);
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kFileRemove);
+	ClearCache(filename, conn_id);
 	return internal_filesystem->TryRemoveFile(filename, opener);
 }
 
 void CacheFileSystem::RemoveFile(const string &filename, optional_ptr<FileOpener> opener) {
-	const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kFileRemove);
-	ClearCache(filename);
+	auto conn_id = GetConnectionId(opener);
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kFileRemove);
+	ClearCache(filename, conn_id);
 	internal_filesystem->RemoveFile(filename, opener);
 }
 
@@ -181,8 +189,10 @@ void CacheFileSystem::ClearCache() {
 	instance_state.lock()->cache_reader_manager.ClearCache();
 }
 
-void CacheFileSystem::ClearCache(const string &filepath) {
-	const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kFilePathCacheClear);
+void CacheFileSystem::ClearCache(const string &filepath, connection_t conn_id) {
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kFilePathCacheClear);
 	const SanitizedCachePath cache_key {filepath};
 	if (metadata_cache != nullptr) {
 		metadata_cache->Clear(cache_key.Path(), [&cache_key](const string &key) { return key == cache_key.Path(); });
@@ -229,21 +239,26 @@ string CacheFileSystem::GetName() const {
 }
 
 void CacheFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
-	const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kWrite);
 	auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kWrite);
 	internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes, location);
-	GetProfileCollector().RecordBytesWritten(nr_bytes);
+	collector.RecordBytesWritten(nr_bytes);
 }
 
 int64_t CacheFileSystem::Write(FileHandle &handle, void *buffer, int64_t nr_bytes) {
-	const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kWrite);
 	auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kWrite);
 	auto bytes_written = internal_filesystem->Write(*disk_cache_handle.internal_file_handle, buffer, nr_bytes);
-	GetProfileCollector().RecordBytesWritten(bytes_written);
+	collector.RecordBytesWritten(bytes_written);
 	return bytes_written;
 }
 
-unique_ptr<FileHandle> CacheFileSystem::CreateCacheFileHandleForRead(unique_ptr<FileHandle> internal_file_handle) {
+unique_ptr<FileHandle> CacheFileSystem::CreateCacheFileHandleForRead(unique_ptr<FileHandle> internal_file_handle,
+                                                                     connection_t conn_id) {
 	if (internal_file_handle == nullptr) {
 		return nullptr;
 	}
@@ -272,7 +287,7 @@ unique_ptr<FileHandle> CacheFileSystem::CreateCacheFileHandleForRead(unique_ptr<
 		}
 		in_use_file_handle_counter->Decrement(cache_key);
 	};
-	return make_uniq<CacheFileSystemHandle>(std::move(internal_file_handle), *this, std::move(dtor_callback));
+	return make_uniq<CacheFileSystemHandle>(std::move(internal_file_handle), *this, std::move(dtor_callback), conn_id);
 }
 
 shared_ptr<CacheFileSystem::FileMetadata> CacheFileSystem::Stats(FileHandle &handle) {
@@ -289,11 +304,11 @@ shared_ptr<CacheFileSystem::FileMetadata> CacheFileSystem::Stats(FileHandle &han
 }
 
 vector<OpenFileInfo> CacheFileSystem::GlobImpl(const string &path, FileOpener *opener) {
-	vector<OpenFileInfo> open_file_info;
-	{
-		const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kGlob);
-		open_file_info = internal_filesystem->Glob(path, opener);
-	}
+	auto conn_id = GetConnectionId(opener);
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kGlob);
+	auto open_file_info = internal_filesystem->Glob(path, opener);
 
 	// Certain filesystem (i.e., s3 filesystem) populates file size within extended file info, make an attempt to
 	// extract file size.
@@ -340,6 +355,7 @@ vector<OpenFileInfo> CacheFileSystem::GlobImpl(const string &path, FileOpener *o
 }
 
 vector<OpenFileInfo> CacheFileSystem::Glob(const string &path, FileOpener *opener) {
+	auto conn_id = GetConnectionId(opener);
 	InitializeGlobalConfig(opener);
 	if (glob_cache == nullptr) {
 		return GlobImpl(path, opener);
@@ -358,7 +374,9 @@ vector<OpenFileInfo> CacheFileSystem::Glob(const string &path, FileOpener *opene
 		return make_shared_ptr<vector<OpenFileInfo>>(std::move(glob_res));
 	});
 	const CacheAccess cache_access = glob_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
-	GetProfileCollector().RecordCacheAccess(CacheEntity::kGlob, cache_access);
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
+	collector.RecordCacheAccess(CacheEntity::kGlob, cache_access, 0);
 	return *res;
 }
 
@@ -366,6 +384,13 @@ vector<OpenFileInfo> CacheFileSystem::Glob(const string &path, FileOpener *opene
 void CacheFileSystem::InitializeGlobalConfig(optional_ptr<FileOpener> opener) {
 	auto instance_state_locked = instance_state.lock();
 	const concurrency::lock_guard<concurrency::mutex> cache_reader_lck(cache_reader_mutex);
+
+	auto conn_id = GetConnectionId(opener);
+	instance_state_locked->profile_collector_manager.SetProfileCollector(conn_id,
+	                                                                     instance_state_locked->config.profile_type);
+
+	instance_state_locked->cache_reader_manager.SetCacheReader(instance_state_locked->config, instance_state);
+
 	SetMetadataCache();
 	SetFileHandleCache();
 	SetGlobCache();
@@ -374,8 +399,10 @@ void CacheFileSystem::InitializeGlobalConfig(optional_ptr<FileOpener> opener) {
 unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenFileInfo &file, FileOpenFlags flags,
                                                                      optional_ptr<FileOpener> opener) {
 	D_ASSERT(flags.OpenForReading());
+	auto conn_id = GetConnectionId(opener);
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
 
-	// Cache is exclusive, so we don't need to acquire lock for avoid repeated access.
 	if (file_handle_cache != nullptr) {
 		FileHandleCacheKey key {file.path, flags};
 		auto get_and_pop_res = file_handle_cache->GetAndPop(key);
@@ -383,28 +410,24 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 			cur_val->Close();
 		}
 		if (get_and_pop_res.target_item != nullptr) {
-			GetProfileCollector().RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheHit);
+			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheHit, 0);
 			DUCKDB_LOG_OPEN_CACHE_HIT((*get_and_pop_res.target_item));
-			return CreateCacheFileHandleForRead(std::move(get_and_pop_res.target_item));
+			return CreateCacheFileHandleForRead(std::move(get_and_pop_res.target_item), conn_id);
 		}
 
-		// Record stats on cache miss.
-		GetProfileCollector().RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheMiss);
+		collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheMiss, 0);
 
-		// Record cache miss caused by exclusive resource in use.
 		const unsigned in_use_count = in_use_file_handle_counter->GetCount(key);
 		if (in_use_count > 0) {
-			GetProfileCollector().RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse);
+			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse, 0);
 		}
 	}
 
-	unique_ptr<FileHandle> file_handle = nullptr;
-	{
-		const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kOpen);
-		file_handle = internal_filesystem->OpenFile(file, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
-	}
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kOpen);
+	auto file_handle =
+	    internal_filesystem->OpenFile(file, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
 	DUCKDB_LOG_OPEN_CACHE_MISS_PTR((file_handle));
-	return CreateCacheFileHandleForRead(std::move(file_handle));
+	return CreateCacheFileHandleForRead(std::move(file_handle), conn_id);
 }
 
 // If the target file is compressed, here we only read and potentially cache compressed content.
@@ -416,7 +439,7 @@ unique_ptr<FileHandle> CacheFileSystem::OpenFileExtended(const OpenFileInfo &fil
 
 	// If setting has already been specified to clear cache, we clear it only once at file open.
 	if (instance_state.lock()->config.clear_cache_on_write) {
-		ClearCache(file.path);
+		ClearCache(file.path, GetConnectionId(opener));
 	}
 
 	if (flags.OpenForReading()) {
@@ -424,10 +447,11 @@ unique_ptr<FileHandle> CacheFileSystem::OpenFileExtended(const OpenFileInfo &fil
 	}
 
 	// Otherwise, we do nothing (i.e. profiling) but wrapping it with cache file handle wrapper.
-	// For write handles, we still need the connection_id for consistency
+	auto conn_id = GetConnectionId(opener);
 	auto file_handle = internal_filesystem->OpenFile(file, flags, opener);
-	return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this,
-	                                        /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {});
+	return make_uniq<CacheFileSystemHandle>(
+	    std::move(file_handle), *this,
+	    /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {}, conn_id);
 }
 
 unique_ptr<FileHandle> CacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
@@ -462,7 +486,9 @@ timestamp_t CacheFileSystem::GetLastModifiedTime(FileHandle &handle) {
 		    return Stats(*disk_cache_handle.internal_file_handle);
 	    });
 	const CacheAccess cache_access = metadata_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
-	GetProfileCollector().RecordCacheAccess(CacheEntity::kMetadata, cache_access);
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
+	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access, 0);
 	return metadata->last_modification_time;
 }
 int64_t CacheFileSystem::GetFileSize(FileHandle &handle) {
@@ -482,7 +508,9 @@ int64_t CacheFileSystem::GetFileSize(FileHandle &handle) {
 		    return Stats(*disk_cache_handle.internal_file_handle);
 	    });
 	const CacheAccess cache_access = metadata_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
-	GetProfileCollector().RecordCacheAccess(CacheEntity::kMetadata, cache_access);
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
+	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access, 0);
 	return metadata->file_size;
 }
 int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -26,6 +26,17 @@ connection_t GetConnectionId(optional_ptr<FileOpener> opener) {
 	return client_context->GetConnectionId();
 }
 
+connection_t GetConnectionIdFromContext(const QueryContext &context) {
+	if (!context.Valid()) {
+		return DConstants::INVALID_INDEX;
+	}
+	auto client_context = context.GetClientContext();
+	if (!client_context) {
+		return DConstants::INVALID_INDEX;
+	}
+	return client_context->GetConnectionId();
+}
+
 } // namespace
 
 CacheFileSystem::FileHandleCacheKey::FileHandleCacheKey(const string &path_arg, FileOpenFlags flags_arg)
@@ -427,8 +438,7 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 	}
 
 	const auto latency_guard = collector.RecordOperationStart(IoOperation::kOpen);
-	auto file_handle =
-	    internal_filesystem->OpenFile(file, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
+	auto file_handle = internal_filesystem->OpenFile(file, flags | FileOpenFlags::FILE_FLAGS_PARALLEL_ACCESS, opener);
 	DUCKDB_LOG_OPEN_CACHE_MISS_PTR((file_handle));
 	return CreateCacheFileHandleForRead(std::move(file_handle), conn_id);
 }
@@ -461,6 +471,15 @@ unique_ptr<FileHandle> CacheFileSystem::OpenFileExtended(const OpenFileInfo &fil
 unique_ptr<FileHandle> CacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
                                                  optional_ptr<FileOpener> opener) {
 	return OpenFileExtended(OpenFileInfo(path), flags, opener);
+}
+
+unique_ptr<FileHandle> CacheFileSystem::OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
+                                                           bool write) {
+	auto file_handle = internal_filesystem->OpenCompressedFile(context, std::move(handle), write);
+	const connection_t conn_id = GetConnectionIdFromContext(context);
+	return make_uniq<CacheFileSystemHandle>(
+	    std::move(file_handle), *this,
+	    /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {}, conn_id);
 }
 
 void CacheFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -403,6 +403,7 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 	auto state = instance_state.lock();
 	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
 
+	// Cache is exclusive, so we don't need to acquire lock for avoid repeated access.
 	if (file_handle_cache != nullptr) {
 		FileHandleCacheKey key {file.path, flags};
 		auto get_and_pop_res = file_handle_cache->GetAndPop(key);
@@ -415,8 +416,10 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 			return CreateCacheFileHandleForRead(std::move(get_and_pop_res.target_item), conn_id);
 		}
 
+		// Record stats on cache miss.
 		collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheMiss, 0);
 
+		// Record cache miss caused by exclusive resource in use.
 		const unsigned in_use_count = in_use_file_handle_counter->GetCount(key);
 		if (in_use_count > 0) {
 			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse, 0);
@@ -447,6 +450,7 @@ unique_ptr<FileHandle> CacheFileSystem::OpenFileExtended(const OpenFileInfo &fil
 	}
 
 	// Otherwise, we do nothing (i.e. profiling) but wrapping it with cache file handle wrapper.
+	// For write handles, we still need the connection_id for consistency
 	auto conn_id = GetConnectionId(opener);
 	auto file_handle = internal_filesystem->OpenFile(file, flags, opener);
 	return make_uniq<CacheFileSystemHandle>(

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -387,7 +387,7 @@ vector<OpenFileInfo> CacheFileSystem::Glob(const string &path, FileOpener *opene
 	const CacheAccess cache_access = glob_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
 	auto state = instance_state.lock();
 	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
-	collector.RecordCacheAccess(CacheEntity::kGlob, cache_access, 0);
+	collector.RecordCacheAccess(CacheEntity::kGlob, cache_access);
 	return *res;
 }
 
@@ -422,18 +422,18 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 			cur_val->Close();
 		}
 		if (get_and_pop_res.target_item != nullptr) {
-			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheHit, 0);
+			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheHit);
 			DUCKDB_LOG_OPEN_CACHE_HIT((*get_and_pop_res.target_item));
 			return CreateCacheFileHandleForRead(std::move(get_and_pop_res.target_item), conn_id);
 		}
 
 		// Record stats on cache miss.
-		collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheMiss, 0);
+		collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheMiss);
 
 		// Record cache miss caused by exclusive resource in use.
 		const unsigned in_use_count = in_use_file_handle_counter->GetCount(key);
 		if (in_use_count > 0) {
-			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse, 0);
+			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse);
 		}
 	}
 
@@ -511,7 +511,7 @@ timestamp_t CacheFileSystem::GetLastModifiedTime(FileHandle &handle) {
 	const CacheAccess cache_access = metadata_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
 	auto state = instance_state.lock();
 	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
-	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access, 0);
+	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access);
 	return metadata->last_modification_time;
 }
 int64_t CacheFileSystem::GetFileSize(FileHandle &handle) {
@@ -533,7 +533,7 @@ int64_t CacheFileSystem::GetFileSize(FileHandle &handle) {
 	const CacheAccess cache_access = metadata_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
 	auto state = instance_state.lock();
 	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
-	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access, 0);
+	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access);
 	return metadata->file_size;
 }
 int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -385,9 +385,7 @@ vector<OpenFileInfo> CacheFileSystem::Glob(const string &path, FileOpener *opene
 		return make_shared_ptr<vector<OpenFileInfo>>(std::move(glob_res));
 	});
 	const CacheAccess cache_access = glob_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
-	auto state = instance_state.lock();
-	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
-	collector.RecordCacheAccess(CacheEntity::kGlob, cache_access);
+	RecordCacheAccess(conn_id, CacheEntity::kGlob, cache_access);
 	return *res;
 }
 
@@ -422,18 +420,18 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 			cur_val->Close();
 		}
 		if (get_and_pop_res.target_item != nullptr) {
-			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheHit);
+			RecordCacheAccess(conn_id, CacheEntity::kFileHandle, CacheAccess::kCacheHit);
 			DUCKDB_LOG_OPEN_CACHE_HIT((*get_and_pop_res.target_item));
 			return CreateCacheFileHandleForRead(std::move(get_and_pop_res.target_item), conn_id);
 		}
 
 		// Record stats on cache miss.
-		collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheMiss);
+		RecordCacheAccess(conn_id, CacheEntity::kFileHandle, CacheAccess::kCacheMiss);
 
 		// Record cache miss caused by exclusive resource in use.
 		const unsigned in_use_count = in_use_file_handle_counter->GetCount(key);
 		if (in_use_count > 0) {
-			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse);
+			RecordCacheAccess(conn_id, CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse);
 		}
 	}
 
@@ -509,9 +507,7 @@ timestamp_t CacheFileSystem::GetLastModifiedTime(FileHandle &handle) {
 		    return Stats(*disk_cache_handle.internal_file_handle);
 	    });
 	const CacheAccess cache_access = metadata_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
-	auto state = instance_state.lock();
-	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
-	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access);
+	RecordCacheAccess(disk_cache_handle.GetConnectionId(), CacheEntity::kMetadata, cache_access);
 	return metadata->last_modification_time;
 }
 int64_t CacheFileSystem::GetFileSize(FileHandle &handle) {
@@ -531,9 +527,7 @@ int64_t CacheFileSystem::GetFileSize(FileHandle &handle) {
 		    return Stats(*disk_cache_handle.internal_file_handle);
 	    });
 	const CacheAccess cache_access = metadata_cache_hit ? CacheAccess::kCacheHit : CacheAccess::kCacheMiss;
-	auto state = instance_state.lock();
-	auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
-	collector.RecordCacheAccess(CacheEntity::kMetadata, cache_access);
+	RecordCacheAccess(disk_cache_handle.GetConnectionId(), CacheEntity::kMetadata, cache_access);
 	return metadata->file_size;
 }
 int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
@@ -557,6 +551,19 @@ int64_t CacheFileSystem::ReadImpl(FileHandle &handle, void *buffer, int64_t nr_b
 	state->cache_reader_manager.GetCacheReader()->ReadAndCache(handle, static_cast<char *>(buffer), location,
 	                                                           bytes_to_read, file_size);
 	return bytes_to_read;
+}
+
+void CacheFileSystem::RecordCacheAccess(connection_t conn_id, CacheEntity cache_entity, CacheAccess cache_access) {
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
+	collector.RecordCacheAccess(cache_entity, cache_access);
+}
+
+void CacheFileSystem::RecordCacheAccess(connection_t conn_id, CacheEntity cache_entity, CacheAccess cache_access,
+                                        idx_t byte_count) {
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
+	collector.RecordCacheAccess(cache_entity, cache_access, byte_count);
 }
 
 } // namespace duckdb

--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -398,6 +398,13 @@ void CacheFileSystem::InitializeGlobalConfig(optional_ptr<FileOpener> opener) {
 	instance_state_locked->profile_collector_manager.SetProfileCollector(conn_id,
 	                                                                     instance_state_locked->config.profile_type);
 
+	if (opener) {
+		auto client_context = FileOpener::TryGetClientContext(opener);
+		if (client_context) {
+			RegisterConnectionCleanupState(*client_context, instance_state);
+		}
+	}
+
 	instance_state_locked->cache_reader_manager.SetCacheReader(instance_state_locked->config, instance_state);
 
 	SetMetadataCache();
@@ -420,18 +427,18 @@ unique_ptr<FileHandle> CacheFileSystem::GetOrCreateFileHandleForRead(const OpenF
 			cur_val->Close();
 		}
 		if (get_and_pop_res.target_item != nullptr) {
-			RecordCacheAccess(conn_id, CacheEntity::kFileHandle, CacheAccess::kCacheHit);
+			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheHit);
 			DUCKDB_LOG_OPEN_CACHE_HIT((*get_and_pop_res.target_item));
 			return CreateCacheFileHandleForRead(std::move(get_and_pop_res.target_item), conn_id);
 		}
 
 		// Record stats on cache miss.
-		RecordCacheAccess(conn_id, CacheEntity::kFileHandle, CacheAccess::kCacheMiss);
+		collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheMiss);
 
 		// Record cache miss caused by exclusive resource in use.
 		const unsigned in_use_count = in_use_file_handle_counter->GetCount(key);
 		if (in_use_count > 0) {
-			RecordCacheAccess(conn_id, CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse);
+			collector.RecordCacheAccess(CacheEntity::kFileHandle, CacheAccess::kCacheEntryInUse);
 		}
 	}
 

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -282,6 +282,7 @@ void UpdateProfileType(ClientContext &context, SetScope scope, Value &parameter)
 	inst_state.config.profile_type = profile_type_str;
 	auto conn_id = context.GetConnectionId();
 	inst_state.profile_collector_manager.SetProfileCollector(conn_id, profile_type_str);
+	RegisterConnectionCleanupState(context, GetInstanceStateShared(*context.db));
 }
 
 void UpdateMaxFanoutSubrequest(ClientContext &context, SetScope scope, Value &parameter) {

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -9,7 +9,6 @@
 #include "base_profile_collector.hpp"
 #include "cache_exclusion_utils.hpp"
 #include "cache_filesystem.hpp"
-#include "cache_filesystem_config.hpp"
 #include "cache_httpfs_instance_state.hpp"
 #include "cache_status_query_function.hpp"
 #include "disk_cache_util.hpp"
@@ -26,7 +25,6 @@
 #include "hffs.hpp"
 #include "httpfs_extension.hpp"
 #include "s3fs.hpp"
-#include "temp_profile_collector.hpp"
 
 #include <algorithm>
 
@@ -45,6 +43,12 @@ DatabaseInstance &GetDatabaseInstance(ExpressionState &state) {
 	auto *executor = state.root.executor;
 	auto &client_context = executor->GetContext();
 	return *client_context.db.get();
+}
+
+connection_t GetConnectionId(ExpressionState &state) {
+	auto *executor = state.root.executor;
+	auto &client_context = executor->GetContext();
+	return client_context.GetConnectionId();
 }
 
 // Clear both in-memory and on-disk data block cache.
@@ -68,9 +72,9 @@ void ClearAllCache(const DataChunk &args, ExpressionState &state, Vector &result
 		cur_cache_fs->ClearCache();
 	}
 
-	// Clear profile collection.
-	CACHE_HTTPFS_ALWAYS_ASSERT(inst_state.profile_collector != nullptr);
-	inst_state.profile_collector->Reset();
+	// Clear profile collection for this connection.
+	auto conn_id = GetConnectionId(state);
+	inst_state.profile_collector_manager.ResetProfileCollector(conn_id);
 
 	result.Reference(Value(SUCCESS));
 }
@@ -86,9 +90,10 @@ void ClearCacheForFile(const DataChunk &args, ExpressionState &state, Vector &re
 	inst_state.cache_reader_manager.ClearCache(filepath);
 
 	// Clear all non data block cache, including file handle cache, glob cache and metadata cache.
+	auto conn_id = GetConnectionId(state);
 	auto cache_filesystem_instances = inst_state.registry.GetAllCacheFs();
 	for (auto *cur_cache_fs : cache_filesystem_instances) {
-		cur_cache_fs->ClearCache(filepath);
+		cur_cache_fs->ClearCache(filepath, conn_id);
 	}
 
 	result.Reference(Value(SUCCESS));
@@ -123,39 +128,26 @@ void GetOnDiskDataCacheSize(const DataChunk &args, ExpressionState &state, Vecto
 void GetProfileStats(const DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &instance = GetDatabaseInstance(state);
 	auto &inst_state = GetInstanceStateOrThrow(instance);
+	auto conn_id = GetConnectionId(state);
 
-	string latest_stat;
-	uint64_t latest_timestamp = 0;
-	const auto cache_file_systems = inst_state.registry.GetAllCacheFs();
-	for (auto *cur_filesystem : cache_file_systems) {
-		auto &profile_collector = cur_filesystem->GetProfileCollector();
-		auto stats_pair = profile_collector.GetHumanReadableStats();
-		const auto &cur_profile_stat = stats_pair.first;
-		const auto &cur_timestamp = stats_pair.second;
-		// Skip collectors that have never been accessed.
-		if (cur_timestamp == 0) {
-			continue;
+	auto *collector = inst_state.profile_collector_manager.GetProfileCollector(conn_id);
+	if (collector) {
+		auto stats_pair = collector->GetHumanReadableStats();
+		auto &latest_stat = stats_pair.first;
+		if (latest_stat.empty()) {
+			latest_stat = "No valid access to cache filesystem";
 		}
-		if (cur_timestamp > latest_timestamp) {
-			latest_timestamp = cur_timestamp;
-			latest_stat = std::move(stats_pair.first);
-			continue;
-		}
-		if (cur_timestamp == latest_timestamp) {
-			latest_stat = MaxValue<string>(latest_stat, cur_profile_stat);
-		}
+		result.Reference(Value(std::move(latest_stat)));
+	} else {
+		result.Reference(Value("No valid access to cache filesystem"));
 	}
-
-	if (latest_stat.empty()) {
-		latest_stat = "No valid access to cache filesystem";
-	}
-	result.Reference(Value(std::move(latest_stat)));
 }
 
 void ResetProfileStats(const DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &instance = GetDatabaseInstance(state);
 	auto &inst_state = GetInstanceStateOrThrow(instance);
-	inst_state.ResetProfileCollector();
+	auto conn_id = GetConnectionId(state);
+	inst_state.profile_collector_manager.ResetProfileCollector(conn_id);
 	result.Reference(Value(SUCCESS));
 }
 
@@ -287,7 +279,9 @@ void UpdateCacheBlockSize(ClientContext &context, SetScope scope, Value &paramet
 void UpdateProfileType(ClientContext &context, SetScope scope, Value &parameter) {
 	auto &inst_state = GetInstanceStateOrThrow(context);
 	auto profile_type_str = parameter.ToString();
-	inst_state.SetProfileCollector(std::move(profile_type_str));
+	inst_state.config.profile_type = profile_type_str;
+	auto conn_id = context.GetConnectionId();
+	inst_state.profile_collector_manager.SetProfileCollector(conn_id, profile_type_str);
 }
 
 void UpdateMaxFanoutSubrequest(ClientContext &context, SetScope scope, Value &parameter) {

--- a/src/cache_httpfs_instance_state.cpp
+++ b/src/cache_httpfs_instance_state.cpp
@@ -1,11 +1,9 @@
 #include "cache_httpfs_instance_state.hpp"
 
-#include "assert_utils.hpp"
 #include "base_profile_collector.hpp"
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
 #include "disk_cache_reader.hpp"
-#include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
@@ -41,23 +39,61 @@ void InstanceCacheFsRegistry::Reset() {
 }
 
 //===--------------------------------------------------------------------===//
+// InstanceProfileCollectorManager implementation
+//===--------------------------------------------------------------------===//
+
+void InstanceProfileCollectorManager::SetProfileCollector(connection_t connection_id, const string &profile_type) {
+	concurrency::lock_guard<concurrency::mutex> lock(mutex);
+
+	auto it = profile_collectors.find(connection_id);
+
+	if (it != profile_collectors.end() && it->second != nullptr && it->second->GetProfilerType() == profile_type) {
+		return;
+	}
+
+	if (profile_type == *NOOP_PROFILE_TYPE) {
+		profile_collectors[connection_id] = make_uniq<NoopProfileCollector>();
+		return;
+	}
+
+	if (profile_type == *TEMP_PROFILE_TYPE) {
+		profile_collectors[connection_id] = make_uniq<TempProfileCollector>();
+		return;
+	}
+
+	// PERSISTENT_PROFILE_TYPE ("duckdb") is declared but not yet implemented;
+	// fall back to noop so the setting is accepted without error.
+	profile_collectors[connection_id] = make_uniq<NoopProfileCollector>();
+}
+
+BaseProfileCollector *InstanceProfileCollectorManager::GetProfileCollector(connection_t connection_id) const {
+	concurrency::lock_guard<concurrency::mutex> lock(mutex);
+	auto it = profile_collectors.find(connection_id);
+	if (it != profile_collectors.end()) {
+		return it->second.get();
+	}
+	return nullptr;
+}
+
+void InstanceProfileCollectorManager::ResetProfileCollector(connection_t connection_id) {
+	concurrency::lock_guard<concurrency::mutex> lock(mutex);
+	auto it = profile_collectors.find(connection_id);
+	if (it != profile_collectors.end() && it->second != nullptr) {
+		it->second->Reset();
+	}
+}
+
+//===--------------------------------------------------------------------===//
 // InstanceCacheReaderManager implementation
 //===--------------------------------------------------------------------===//
 
 void InstanceCacheReaderManager::SetCacheReader(const InstanceConfig &config,
                                                 weak_ptr<CacheHttpfsInstanceState> instance_state_p) {
 	const concurrency::lock_guard<concurrency::mutex> lock(mutex);
-	auto instance_state_locked = instance_state_p.lock();
-	if (!instance_state_locked) {
-		throw InternalException("Instance state is no longer valid when setting cache reader");
-	}
 
 	if (config.cache_type == *ON_DISK_CACHE_TYPE) {
 		if (on_disk_cache_reader == nullptr) {
-			on_disk_cache_reader =
-			    make_uniq<DiskCacheReader>(std::move(instance_state_p), *instance_state_locked->profile_collector);
-		} else {
-			on_disk_cache_reader->SetProfileCollector(*instance_state_locked->profile_collector);
+			on_disk_cache_reader = make_uniq<DiskCacheReader>(std::move(instance_state_p));
 		}
 		internal_cache_reader = on_disk_cache_reader.get();
 		return;
@@ -65,10 +101,7 @@ void InstanceCacheReaderManager::SetCacheReader(const InstanceConfig &config,
 
 	if (config.cache_type == *IN_MEM_CACHE_TYPE) {
 		if (in_mem_cache_reader == nullptr) {
-			in_mem_cache_reader =
-			    make_uniq<InMemoryCacheReader>(std::move(instance_state_p), *instance_state_locked->profile_collector);
-		} else {
-			in_mem_cache_reader->SetProfileCollector(*instance_state_locked->profile_collector);
+			in_mem_cache_reader = make_uniq<InMemoryCacheReader>(std::move(instance_state_p));
 		}
 		internal_cache_reader = in_mem_cache_reader.get();
 		return;
@@ -76,9 +109,7 @@ void InstanceCacheReaderManager::SetCacheReader(const InstanceConfig &config,
 
 	// Fallback to NoopCacheReader.
 	if (noop_cache_reader == nullptr) {
-		noop_cache_reader = make_uniq<NoopCacheReader>(*instance_state_locked->profile_collector);
-	} else {
-		noop_cache_reader->SetProfileCollector(*instance_state_locked->profile_collector);
+		noop_cache_reader = make_uniq<NoopCacheReader>(std::move(instance_state_p));
 	}
 
 	internal_cache_reader = noop_cache_reader.get();
@@ -104,30 +135,8 @@ vector<BaseCacheReader *> InstanceCacheReaderManager::GetCacheReaders() const {
 void InstanceCacheReaderManager::InitializeDiskCacheReader(const vector<string> &cache_directories,
                                                            weak_ptr<CacheHttpfsInstanceState> instance_state_p) {
 	const concurrency::lock_guard<concurrency::mutex> lock(mutex);
-
-	auto instance_state_locked = instance_state_p.lock();
-	if (!instance_state_locked) {
-		throw InternalException("Instance state is no longer valid when initializing disk cache reader");
-	}
-
 	if (on_disk_cache_reader == nullptr) {
-		on_disk_cache_reader =
-		    make_uniq<DiskCacheReader>(std::move(instance_state_p), *instance_state_locked->profile_collector);
-	} else {
-		on_disk_cache_reader->SetProfileCollector(*instance_state_locked->profile_collector);
-	}
-}
-
-void InstanceCacheReaderManager::UpdateProfileCollector(BaseProfileCollector &profile_collector) {
-	const concurrency::lock_guard<concurrency::mutex> lock(mutex);
-	if (noop_cache_reader != nullptr) {
-		noop_cache_reader->SetProfileCollector(profile_collector);
-	}
-	if (in_mem_cache_reader != nullptr) {
-		in_mem_cache_reader->SetProfileCollector(profile_collector);
-	}
-	if (on_disk_cache_reader != nullptr) {
-		on_disk_cache_reader->SetProfileCollector(profile_collector);
+		on_disk_cache_reader = make_uniq<DiskCacheReader>(std::move(instance_state_p));
 	}
 }
 
@@ -189,7 +198,7 @@ CacheHttpfsInstanceState &GetInstanceStateOrThrow(ClientContext &context) {
 	return GetInstanceStateOrThrow(*context.db.get());
 }
 
-shared_ptr<CacheHttpfsInstanceState> GetInstanceConfig(weak_ptr<CacheHttpfsInstanceState> instance_state) {
+shared_ptr<CacheHttpfsInstanceState> GetInstanceConfig(const weak_ptr<CacheHttpfsInstanceState> &instance_state) {
 	auto instance_state_locked = instance_state.lock();
 	if (instance_state_locked == nullptr) {
 		throw InternalException("cache_httpfs instance state is no longer valid");
@@ -197,54 +206,14 @@ shared_ptr<CacheHttpfsInstanceState> GetInstanceConfig(weak_ptr<CacheHttpfsInsta
 	return instance_state_locked;
 }
 
-//===--------------------------------------------------------------------===//
-// CacheHttpfsInstanceState implementation
-//===--------------------------------------------------------------------===//
-
-CacheHttpfsInstanceState::CacheHttpfsInstanceState() : profile_collector(make_uniq<NoopProfileCollector>()) {
-}
-
-BaseProfileCollector &CacheHttpfsInstanceState::GetProfileCollector() {
-	CACHE_HTTPFS_ALWAYS_ASSERT(profile_collector != nullptr);
-	return *profile_collector;
-}
-
-void CacheHttpfsInstanceState::ResetProfileCollector() {
-	SetProfileCollector(*NOOP_PROFILE_TYPE);
-}
-
-void CacheHttpfsInstanceState::SetProfileCollector(string profile_type) {
-	profile_type = StringUtil::Lower(profile_type);
-	if (ALL_PROFILE_TYPES->find(profile_type) == ALL_PROFILE_TYPES->end()) {
-		const vector<string> valid_types(ALL_PROFILE_TYPES->begin(), ALL_PROFILE_TYPES->end());
-		throw InvalidInputException("Invalid cache_httpfs_profile_type '%s'. Valid options are: %s", profile_type,
-		                            StringUtil::Join(valid_types, ", "));
+BaseProfileCollector &GetProfileCollectorOrThrow(const shared_ptr<CacheHttpfsInstanceState> &instance_state,
+                                                 connection_t conn_id) {
+	D_ASSERT(instance_state);
+	auto *collector = instance_state->profile_collector_manager.GetProfileCollector(conn_id);
+	if (!collector) {
+		throw InternalException("CacheFileSystem: no profile collector for connection %llu", conn_id);
 	}
-	config.profile_type = std::move(profile_type);
-
-	// Initialize the profile collector based on the new profile type
-	CACHE_HTTPFS_ALWAYS_ASSERT(profile_collector != nullptr);
-	if (profile_collector->GetProfilerType() == config.profile_type) {
-		return;
-	}
-
-	// Update the profile collector.
-	if (config.profile_type == *NOOP_PROFILE_TYPE) {
-		profile_collector = make_uniq<NoopProfileCollector>();
-	} else if (config.profile_type == *TEMP_PROFILE_TYPE) {
-		profile_collector = make_uniq<TempProfileCollector>();
-	} else {
-		throw InternalException("Invalid profile collector type %s", config.profile_type);
-	}
-
-	// Update all cache readers to use the new collector
-	cache_reader_manager.UpdateProfileCollector(*profile_collector);
-
-	// Update all registered cache filesystems to use the new profile collector
-	auto cache_filesystems = registry.GetAllCacheFs();
-	for (auto *cache_fs : cache_filesystems) {
-		cache_fs->SetProfileCollector(*profile_collector);
-	}
+	return *collector;
 }
 
 } // namespace duckdb

--- a/src/cache_status_query_function.cpp
+++ b/src/cache_status_query_function.cpp
@@ -201,7 +201,9 @@ unique_ptr<GlobalTableFunctionState> CacheAccessInfoQueryFuncInit(ClientContext 
 			aggregated_cache_access_infos[idx].cache_miss_count += cur.cache_miss_count;
 			aggregated_cache_access_infos[idx].cache_miss_by_in_use += cur.cache_miss_by_in_use;
 
+			// For data file cache, record number of bytes to read and to cache.
 			if (idx == static_cast<idx_t>(IoOperation::kRead)) {
+				// Handle number of bytes to read.
 				auto &total_bytes_to_read = aggregated_cache_access_infos[idx].total_bytes_to_read;
 				uint64_t read_value = 0;
 				if (!total_bytes_to_read.IsNull()) {
@@ -209,6 +211,7 @@ unique_ptr<GlobalTableFunctionState> CacheAccessInfoQueryFuncInit(ClientContext 
 				}
 				total_bytes_to_read = Value::UBIGINT(read_value + cur.total_bytes_to_read.GetValue<uint64_t>());
 
+				// Handle number of bytes to cache.
 				auto &total_bytes_to_cache = aggregated_cache_access_infos[idx].total_bytes_to_cache;
 				uint64_t cache_value = 0;
 				if (!total_bytes_to_cache.IsNull()) {

--- a/src/cache_status_query_function.cpp
+++ b/src/cache_status_query_function.cpp
@@ -139,8 +139,8 @@ unique_ptr<FunctionData> CacheAccessInfoQueryFuncBind(ClientContext &context, Ta
 	D_ASSERT(return_types.empty());
 	D_ASSERT(names.empty());
 
-	return_types.reserve(6);
-	names.reserve(6);
+	return_types.reserve(8);
+	names.reserve(8);
 
 	// Cache type.
 	return_types.emplace_back(LogicalType {LogicalTypeId::VARCHAR});
@@ -166,6 +166,14 @@ unique_ptr<FunctionData> CacheAccessInfoQueryFuncBind(ClientContext &context, Ta
 	return_types.emplace_back(LogicalType {LogicalTypeId::UBIGINT});
 	names.emplace_back("number_bytes_to_cache (data cache)");
 
+	// Bytes read from hits.
+	return_types.emplace_back(LogicalType {LogicalTypeId::UBIGINT});
+	names.emplace_back("bytes_read_from_hits (data cache)");
+
+	// Bytes read from misses.
+	return_types.emplace_back(LogicalType {LogicalTypeId::UBIGINT});
+	names.emplace_back("bytes_read_from_misses (data cache)");
+
 	return nullptr;
 }
 
@@ -180,38 +188,47 @@ unique_ptr<GlobalTableFunctionState> CacheAccessInfoQueryFuncInit(ClientContext 
 		aggregated_cache_access_infos[idx].cache_type = CACHE_ENTITY_NAMES[idx];
 	}
 
-	// Get cache access info from all initialized cache readers.
+	// Get cache access info from the per-connection profile collector.
 	auto &inst_state = GetInstanceStateOrThrow(*context.db);
-	const auto cache_readers = inst_state.cache_reader_manager.GetCacheReaders();
-	for (auto *cur_cache_reader : cache_readers) {
-		auto &profiler_collector = cur_cache_reader->GetProfileCollector();
-		auto cache_access_info = profiler_collector.GetCacheAccessInfo();
+	auto conn_id = context.GetConnectionId();
+	auto *collector = inst_state.profile_collector_manager.GetProfileCollector(conn_id);
+	if (collector) {
+		auto cache_access_info = collector->GetCacheAccessInfo();
 		D_ASSERT(cache_access_info.size() == kCacheEntityCount);
 		for (idx_t idx = 0; idx < kCacheEntityCount; ++idx) {
-			auto &cur_cache_access_info = cache_access_info[idx];
-			aggregated_cache_access_infos[idx].cache_hit_count += cur_cache_access_info.cache_hit_count;
-			aggregated_cache_access_infos[idx].cache_miss_count += cur_cache_access_info.cache_miss_count;
-			aggregated_cache_access_infos[idx].cache_miss_by_in_use += cur_cache_access_info.cache_miss_by_in_use;
+			auto &cur = cache_access_info[idx];
+			aggregated_cache_access_infos[idx].cache_hit_count += cur.cache_hit_count;
+			aggregated_cache_access_infos[idx].cache_miss_count += cur.cache_miss_count;
+			aggregated_cache_access_infos[idx].cache_miss_by_in_use += cur.cache_miss_by_in_use;
 
-			// For data file cache, record number of bytes to read and to cache.
 			if (idx == static_cast<idx_t>(IoOperation::kRead)) {
-				// Handle number of bytes to read.
 				auto &total_bytes_to_read = aggregated_cache_access_infos[idx].total_bytes_to_read;
 				uint64_t read_value = 0;
 				if (!total_bytes_to_read.IsNull()) {
 					read_value = total_bytes_to_read.GetValue<uint64_t>();
 				}
-				total_bytes_to_read =
-				    Value::UBIGINT(read_value + cur_cache_access_info.total_bytes_to_read.GetValue<uint64_t>());
+				total_bytes_to_read = Value::UBIGINT(read_value + cur.total_bytes_to_read.GetValue<uint64_t>());
 
-				// Handle number of bytes to cache.
 				auto &total_bytes_to_cache = aggregated_cache_access_infos[idx].total_bytes_to_cache;
 				uint64_t cache_value = 0;
 				if (!total_bytes_to_cache.IsNull()) {
 					cache_value = total_bytes_to_cache.GetValue<uint64_t>();
 				}
-				total_bytes_to_cache =
-				    Value::UBIGINT(cache_value + cur_cache_access_info.total_bytes_to_cache.GetValue<uint64_t>());
+				total_bytes_to_cache = Value::UBIGINT(cache_value + cur.total_bytes_to_cache.GetValue<uint64_t>());
+
+				auto &bytes_hit = aggregated_cache_access_infos[idx].bytes_read_from_hits;
+				uint64_t hit_val = 0;
+				if (!bytes_hit.IsNull()) {
+					hit_val = bytes_hit.GetValue<uint64_t>();
+				}
+				bytes_hit = Value::UBIGINT(hit_val + cur.bytes_read_from_hits.GetValue<uint64_t>());
+
+				auto &bytes_miss = aggregated_cache_access_infos[idx].bytes_read_from_misses;
+				uint64_t miss_val = 0;
+				if (!bytes_miss.IsNull()) {
+					miss_val = bytes_miss.GetValue<uint64_t>();
+				}
+				bytes_miss = Value::UBIGINT(miss_val + cur.bytes_read_from_misses.GetValue<uint64_t>());
 			}
 		}
 	}
@@ -250,6 +267,12 @@ void CacheAccessInfoQueryTableFunc(ClientContext &context, TableFunctionInput &d
 
 		// Used for data cache, total number of bytes to cache.
 		output.SetValue(col++, count, entry.total_bytes_to_cache);
+
+		// Bytes read from hits.
+		output.SetValue(col++, count, entry.bytes_read_from_hits);
+
+		// Bytes read from misses.
+		output.SetValue(col++, count, entry.bytes_read_from_misses);
 
 		count++;
 	}

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -25,10 +25,8 @@
 
 namespace duckdb {
 
-DiskCacheReader::DiskCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p,
-                                 BaseProfileCollector &profile_collector_p)
-    : BaseCacheReader(profile_collector_p, *ON_DISK_CACHE_READER_NAME),
-      local_filesystem(LocalFileSystem::CreateLocal()), instance_state(std::move(instance_state_p)) {
+DiskCacheReader::DiskCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p)
+    : BaseCacheReader(std::move(instance_state_p)), local_filesystem(LocalFileSystem::CreateLocal()) {
 }
 
 string DiskCacheReader::EvictCacheBlockLru() {
@@ -101,6 +99,10 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
                                             CacheReadChunk cache_read_chunk) {
 	SetThreadName("RdCachRdThd");
 
+	auto &cache_handle = handle.Cast<CacheFileSystemHandle>();
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, cache_handle.GetConnectionId());
+
 	// Resolve the on-disk cache path once up-front; use the resolved filepath as the unified key for both in-memory and
 	// on-disk cache.
 	auto cache_file =
@@ -121,7 +123,8 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 			local_filesystem->TryRemoveFile(cache_dest.dest_local_filepath);
 		}
 		if (cache_entry != nullptr) {
-			GetProfileCollector().RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit);
+			collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit,
+			                            cache_read_chunk.bytes_to_copy);
 			DUCKDB_LOG_READ_CACHE_HIT((handle));
 			cache_read_chunk.CopyBufferToRequestedMemory(cache_entry->data);
 			return;
@@ -133,11 +136,12 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 	//
 	// TODO(hjiang): With in-memory cache block involved, we could place disk write to background thread.
 	{
-		const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kDiskCacheRead);
-		auto read_result =
-		    DiskCacheUtil::ReadLocalCacheFile(cache_dest.dest_local_filepath, cache_read_chunk.chunk_size, version_tag);
+		const auto latency_guard = collector.RecordOperationStart(IoOperation::kDiskCacheRead);
+		auto read_result = DiskCacheUtil::ReadLocalCacheFile(cache_dest.dest_local_filepath,
+		                                                     cache_read_chunk.chunk_size, version_tag);
 		if (read_result.cache_hit) {
-			GetProfileCollector().RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit);
+			collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit,
+			                            cache_read_chunk.bytes_to_copy);
 			DUCKDB_LOG_READ_CACHE_HIT((handle));
 			cache_read_chunk.CopyBufferToRequestedMemory(read_result.content);
 
@@ -154,7 +158,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 	}
 
 	// We suffer a cache loss, fallback to remote access then local filesystem write.
-	GetProfileCollector().RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheMiss);
+	collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheMiss, cache_read_chunk.bytes_to_copy);
 	DUCKDB_LOG_READ_CACHE_MISS((handle));
 	auto content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
 	void *addr = const_cast<char *>(content.data());
@@ -162,7 +166,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 	auto *internal_filesystem = disk_cache_handle.GetInternalFileSystem();
 
 	{
-		const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kRead);
+		const auto latency_guard = collector.RecordOperationStart(IoOperation::kRead);
 		internal_filesystem->Read(*disk_cache_handle.internal_file_handle, addr, cache_read_chunk.chunk_size,
 		                          cache_read_chunk.aligned_start_offset);
 	}
@@ -292,8 +296,11 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 	}
 
 	// Record "bytes to read" and "bytes to cache".
-	GetProfileCollector().RecordActualCacheRead(/*cache_size=*/total_bytes_to_cache,
-	                                            /*actual_bytes=*/requested_bytes_to_read);
+	auto &cache_handle = handle.Cast<CacheFileSystemHandle>();
+	auto state_for_profile = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state_for_profile, cache_handle.GetConnectionId());
+	collector.RecordActualCacheRead(/*cache_size=*/total_bytes_to_cache,
+	                                /*actual_bytes=*/requested_bytes_to_read);
 }
 
 void DiskCacheReader::ClearCache() {

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -63,11 +63,11 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
 	// Check local cache first, see if we could do a cached read.
 	const InMemCacheBlock block_key {handle.GetPath(), cache_read_chunk.aligned_start_offset,
 	                                 cache_read_chunk.chunk_size};
-	auto cache_entry = cache_manager->Get(block_key);
+	auto cache_entry = in_mem_cache_manager->Get(block_key);
 
 	// Check cache entry validity and clear if necessary.
 	if (cache_entry != nullptr && !ValidateCacheEntry(cache_entry.get(), version_tag)) {
-		cache_manager->Delete(block_key);
+		in_mem_cache_manager->Delete(block_key);
 		cache_entry = nullptr;
 	}
 
@@ -99,8 +99,8 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
 	    .data = std::move(content),
 	    .version_tag = version_tag,
 	};
-	cache_manager->Put(std::move(block_key),
-	                   make_shared_ptr<InMemoryCacheReader::InMemCacheEntry>(std::move(new_cache_entry)));
+	in_mem_cache_manager->Put(std::move(block_key),
+	                          make_shared_ptr<InMemoryCacheReader::InMemCacheEntry>(std::move(new_cache_entry)));
 }
 
 void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
@@ -112,7 +112,7 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 	const auto config = GetConfig(*instance_state.lock());
 
 	std::call_once(cache_init_flag, [this, &config]() {
-		cache_manager = make_uniq<LruDataCacheManager<InMemCacheBlock, InMemCacheEntry, InMemCacheBlockLess>>(
+		in_mem_cache_manager = make_uniq<LruDataCacheManager<InMemCacheBlock, InMemCacheEntry, InMemCacheBlockLess>>(
 		    config.max_cache_block_count, config.cache_block_timeout_millisec);
 	});
 
@@ -213,11 +213,11 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 }
 
 vector<DataCacheEntryInfo> InMemoryCacheReader::GetCacheEntriesInfo() const {
-	if (cache_manager == nullptr) {
+	if (in_mem_cache_manager == nullptr) {
 		return {};
 	}
 
-	auto keys = cache_manager->Keys();
+	auto keys = in_mem_cache_manager->Keys();
 	vector<DataCacheEntryInfo> cache_entries_info;
 	cache_entries_info.reserve(keys.size());
 	for (auto &cur_key : keys) {
@@ -233,18 +233,18 @@ vector<DataCacheEntryInfo> InMemoryCacheReader::GetCacheEntriesInfo() const {
 }
 
 void InMemoryCacheReader::ClearCache() {
-	if (cache_manager != nullptr) {
-		cache_manager->Clear();
+	if (in_mem_cache_manager != nullptr) {
+		in_mem_cache_manager->Clear();
 	}
 }
 
 void InMemoryCacheReader::ClearCache(const string &fname) {
-	if (cache_manager != nullptr) {
+	if (in_mem_cache_manager != nullptr) {
 		const SanitizedCachePath cache_key {fname};
 		// Start from the first block key for this file (ordered by fname, start_off, blk_size).
-		const InMemCacheBlock start_key {cache_key.Path(), /*start_off=*/0, /*blk_size=*/0};
-		cache_manager->Clear(start_key,
-		                     [&cache_key](const InMemCacheBlock &block) { return block.fname == cache_key.Path(); });
+		const InMemCacheBlock start_key {cache_key.Path(), /*start_off_p=*/0, /*blk_size_p=*/0};
+		in_mem_cache_manager->Clear(
+		    start_key, [&cache_key](const InMemCacheBlock &block) { return block.fname == cache_key.Path(); });
 	}
 }
 

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -56,6 +56,10 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
                                                 CacheReadChunk cache_read_chunk) {
 	SetThreadName("RdCachRdThd");
 
+	auto &cache_handle = handle.Cast<CacheFileSystemHandle>();
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, cache_handle.GetConnectionId());
+
 	// Check local cache first, see if we could do a cached read.
 	const InMemCacheBlock block_key {handle.GetPath(), cache_read_chunk.aligned_start_offset,
 	                                 cache_read_chunk.chunk_size};
@@ -68,14 +72,14 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
 	}
 
 	if (cache_entry != nullptr) {
-		GetProfileCollector().RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit);
+		collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit, cache_read_chunk.bytes_to_copy);
 		DUCKDB_LOG_OPEN_CACHE_HIT((handle));
 		cache_read_chunk.CopyBufferToRequestedMemory(cache_entry->data);
 		return;
 	}
 
 	// We suffer a cache loss, fallback to remote access then local filesystem write.
-	GetProfileCollector().RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheMiss);
+	collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheMiss, cache_read_chunk.bytes_to_copy);
 	DUCKDB_LOG_OPEN_CACHE_MISS((handle));
 	auto content = CreateResizeUninitializedString(cache_read_chunk.chunk_size);
 	void *addr = const_cast<char *>(content.data());
@@ -83,7 +87,7 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
 	auto *internal_filesystem = in_mem_cache_handle.GetInternalFileSystem();
 
 	{
-		const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kRead);
+		const auto latency_guard = collector.RecordOperationStart(IoOperation::kRead);
 		internal_filesystem->Read(*in_mem_cache_handle.internal_file_handle, addr, cache_read_chunk.chunk_size,
 		                          cache_read_chunk.aligned_start_offset);
 	}
@@ -201,8 +205,11 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 	}
 
 	// Record "bytes to read" and "bytes to cache".
-	GetProfileCollector().RecordActualCacheRead(/*cache_size=*/total_bytes_to_cache,
-	                                            /*actual_bytes=*/requested_bytes_to_read);
+	auto &cache_handle_for_profile = handle.Cast<CacheFileSystemHandle>();
+	auto state_for_profile = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state_for_profile, cache_handle_for_profile.GetConnectionId());
+	collector.RecordActualCacheRead(/*cache_size=*/total_bytes_to_cache,
+	                                /*actual_bytes=*/requested_bytes_to_read);
 }
 
 vector<DataCacheEntryInfo> InMemoryCacheReader::GetCacheEntriesInfo() const {

--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -26,15 +26,22 @@ public:
 	BaseCacheReader(const BaseCacheReader &) = delete;
 	BaseCacheReader &operator=(const BaseCacheReader &) = delete;
 
+	// Read from [handle] for an block-size aligned chunk into [start_addr]; cache to local filesystem and return to
+	// user.
 	virtual void ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
 	                          idx_t requested_bytes_to_read, idx_t file_size) = 0;
 
+	// Get status information for all cache entries for the current cache reader. Entries are returned in a random
+	// order.
 	virtual vector<DataCacheEntryInfo> GetCacheEntriesInfo() const = 0;
 
+	// Clear all cache.
 	virtual void ClearCache() = 0;
 
+	// Clear cache for the given [fname].
 	virtual void ClearCache(const string &fname) = 0;
 
+	// Get name for cache reader.
 	virtual string GetName() const {
 		throw NotImplementedException("Base cache reader doesn't implement GetName.");
 	}
@@ -51,6 +58,8 @@ public:
 	}
 
 protected:
+	// Ownership lies in cache httpfs instance state, which gets updated at extension setting update callback.
+	// Refer to [CacheHttpfsInstanceState] for thread-safety guarentee.
 	weak_ptr<CacheHttpfsInstanceState> instance_state;
 };
 

--- a/src/include/base_cache_reader.hpp
+++ b/src/include/base_cache_reader.hpp
@@ -58,8 +58,8 @@ public:
 	}
 
 protected:
-	// Ownership lies in cache httpfs instance state, which gets updated at extension setting update callback.
-	// Refer to [CacheHttpfsInstanceState] for thread-safety guarentee.
+	// Non-owning reference to the per-instance state stored in DuckDB's ObjectCache.
+	// The instance state outlives all cache readers, so the weak_ptr is always valid during normal operation.
 	weak_ptr<CacheHttpfsInstanceState> instance_state;
 };
 

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -51,6 +51,10 @@ public:
 	virtual void RecordOperationEnd(IoOperation io_oper, int64_t latency_millisec) = 0;
 	// Record cache access condition with byte count.
 	virtual void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access, idx_t byte_count) = 0;
+	// Record cache access condition without byte count.
+	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) {
+		RecordCacheAccess(cache_entity, cache_access, 0);
+	}
 	// Record cache size and actual bytes access.
 	virtual void RecordActualCacheRead(idx_t cache_size, idx_t actual_bytes) = 0;
 	// Record bytes written.

--- a/src/include/base_profile_collector.hpp
+++ b/src/include/base_profile_collector.hpp
@@ -49,8 +49,8 @@ public:
 	virtual LatencyGuard RecordOperationStart(IoOperation io_oper) = 0;
 	// Record the finish of operation [io_oper] with the elapse latency.
 	virtual void RecordOperationEnd(IoOperation io_oper, int64_t latency_millisec) = 0;
-	// Record cache access condition.
-	virtual void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) = 0;
+	// Record cache access condition with byte count.
+	virtual void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access, idx_t byte_count) = 0;
 	// Record cache size and actual bytes access.
 	virtual void RecordActualCacheRead(idx_t cache_size, idx_t actual_bytes) = 0;
 	// Record bytes written.

--- a/src/include/cache_entry_info.hpp
+++ b/src/include/cache_entry_info.hpp
@@ -33,9 +33,13 @@ struct CacheAccessInfo {
 	// Only made for data cache.
 	// Record number of bytes to read.
 	Value total_bytes_to_read = Value {};
-	// Only made for daya cache.
+	// Only made for data cache.
 	// Record number of bytes to cache.
 	Value total_bytes_to_cache = Value {};
+	// Bytes served from cache (cache hits).
+	Value bytes_read_from_hits = Value {};
+	// Bytes fetched from remote (cache misses).
+	Value bytes_read_from_misses = Value {};
 };
 
 bool operator<(const CacheAccessInfo &lhs, const CacheAccessInfo &rhs);

--- a/src/include/cache_entry_info.hpp
+++ b/src/include/cache_entry_info.hpp
@@ -36,8 +36,10 @@ struct CacheAccessInfo {
 	// Only made for data cache.
 	// Record number of bytes to cache.
 	Value total_bytes_to_cache = Value {};
+	// Only made for data cache.
 	// Bytes served from cache (cache hits).
 	Value bytes_read_from_hits = Value {};
+	// Only made for data cache.
 	// Bytes fetched from remote (cache misses).
 	Value bytes_read_from_misses = Value {};
 };

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -47,7 +47,7 @@ class CacheFileSystemHandle : public FileHandle {
 public:
 	// @param dtor_callback: callback function to invoke at destructor.
 	CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs,
-	                      std::function<void(CacheFileSystemHandle &)> dtor_callback_p, connection_t connection_id);
+	                      std::function<void(CacheFileSystemHandle &)> dtor_callback_p, connection_t connection_id_p);
 
 	// On cache file handle destruction (for read handles), we place internal file handle to file handle cache to later
 	// reuse.
@@ -118,8 +118,7 @@ public:
 	void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 
 	// For other API calls, delegate to [internal_filesystem] to handle.
-	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-	                                          bool write) override;
+	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle, bool write) override;
 	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override {
 		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
 		return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle, offset_bytes, length_bytes);

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -119,19 +119,7 @@ public:
 
 	// For other API calls, delegate to [internal_filesystem] to handle.
 	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
-	                                          bool write) override {
-		auto file_handle = internal_filesystem->OpenCompressedFile(context, std::move(handle), write);
-		connection_t conn_id = 0;
-		if (context.Valid()) {
-			auto client_context = context.GetClientContext();
-			if (client_context) {
-				conn_id = client_context->GetConnectionId();
-			}
-		}
-		return make_uniq<CacheFileSystemHandle>(
-		    std::move(file_handle), *this,
-		    /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {}, conn_id);
-	}
+	                                          bool write) override;
 	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override {
 		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
 		return internal_filesystem->Trim(*disk_cache_handle.internal_file_handle, offset_bytes, length_bytes);

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -12,7 +12,6 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "exclusive_multi_lru_cache.hpp"
-#include "mutex.hpp"
 #include "shared_value_lru_cache.hpp"
 #include "thread_annotation.hpp"
 
@@ -48,7 +47,7 @@ class CacheFileSystemHandle : public FileHandle {
 public:
 	// @param dtor_callback: callback function to invoke at destructor.
 	CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs,
-	                      std::function<void(CacheFileSystemHandle &)> dtor_callback_p);
+	                      std::function<void(CacheFileSystemHandle &)> dtor_callback_p, connection_t connection_id);
 
 	// On cache file handle destruction (for read handles), we place internal file handle to file handle cache to later
 	// reuse.
@@ -64,9 +63,14 @@ public:
 	// Get version tag.
 	string GetVersionTag();
 
+	connection_t GetConnectionId() const {
+		return connection_id;
+	}
+
 	shared_ptr<Logger> logger;
 	unique_ptr<FileHandle> internal_file_handle;
 	std::function<void(CacheFileSystemHandle &)> dtor_callback;
+	connection_t connection_id;
 };
 
 class CacheFileSystem : public FileSystem {
@@ -81,13 +85,6 @@ public:
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                optional_ptr<FileOpener> opener = nullptr) override;
 	string GetName() const override;
-	BaseProfileCollector &GetProfileCollector() const {
-		return profile_collector.get();
-	}
-	// Update the profile collector reference (called when profile type setting changes)
-	void SetProfileCollector(BaseProfileCollector &profile_collector_p) {
-		profile_collector = profile_collector_p;
-	}
 	// Get file size, which attempts to get metadata cache if possible.
 	int64_t GetFileSize(FileHandle &handle) override;
 	// Get last modification timestamp, which attempts to get metadata cache if possible.
@@ -114,7 +111,7 @@ public:
 
 	// Clear cache entries inside of cache filesystem (i.e. glob cache, file handle cache, metadata cache).
 	// It's worth noting data block cache won't get deleted.
-	void ClearCache(const string &filepath);
+	void ClearCache(const string &filepath, connection_t conn_id = 0);
 
 	// Remove file from both internal filesystem and cache.
 	bool TryRemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
@@ -124,8 +121,16 @@ public:
 	unique_ptr<FileHandle> OpenCompressedFile(QueryContext context, unique_ptr<FileHandle> handle,
 	                                          bool write) override {
 		auto file_handle = internal_filesystem->OpenCompressedFile(context, std::move(handle), write);
-		return make_uniq<CacheFileSystemHandle>(std::move(file_handle), *this,
-		                                        /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {});
+		connection_t conn_id = 0;
+		if (context.Valid()) {
+			auto client_context = context.GetClientContext();
+			if (client_context) {
+				conn_id = client_context->GetConnectionId();
+			}
+		}
+		return make_uniq<CacheFileSystemHandle>(
+		    std::move(file_handle), *this,
+		    /*dtor_callback=*/[](CacheFileSystemHandle & /*unused*/) {}, conn_id);
 	}
 	bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override {
 		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
@@ -158,8 +163,10 @@ public:
 		return internal_filesystem->IsPipe(filename, opener);
 	}
 	void FileSync(FileHandle &handle) override {
-		const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kFileSync);
 		auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
+		auto state = instance_state.lock();
+		auto &collector = GetProfileCollectorOrThrow(state, disk_cache_handle.GetConnectionId());
+		const auto latency_guard = collector.RecordOperationStart(IoOperation::kFileSync);
 		internal_filesystem->FileSync(*disk_cache_handle.internal_file_handle);
 	}
 	string GetHomeDirectory() override {
@@ -267,7 +274,8 @@ private:
 	void InitializeGlobalConfig(optional_ptr<FileOpener> opener) DUCKDB_EXCLUDES(cache_reader_mutex);
 
 	// Create cache file handle.
-	unique_ptr<FileHandle> CreateCacheFileHandleForRead(unique_ptr<FileHandle> internal_file_handle);
+	unique_ptr<FileHandle> CreateCacheFileHandleForRead(unique_ptr<FileHandle> internal_file_handle,
+	                                                    connection_t conn_id);
 
 	// Stat the current file handle, and get all well-known file attributes.
 	//
@@ -311,9 +319,6 @@ private:
 	concurrency::mutex cache_reader_mutex;
 	// Used to access remote files.
 	unique_ptr<FileSystem> internal_filesystem;
-	// Ownership lies in cache httpfs instance state, which gets updated at setting update callback.
-	// Refer to [CacheHttpfsInstanceState] for thread-safety guarentee.
-	std::reference_wrapper<BaseProfileCollector> profile_collector;
 	// Metadata cache, which maps from file path to metadata.
 	using MetadataCache = ThreadSafeSharedValueLruConstCache<string, FileMetadata>;
 	unique_ptr<MetadataCache> metadata_cache;

--- a/src/include/cache_filesystem.hpp
+++ b/src/include/cache_filesystem.hpp
@@ -302,6 +302,10 @@ private:
 	unique_ptr<FileHandle> GetOrCreateFileHandleForRead(const OpenFileInfo &file, FileOpenFlags flags,
 	                                                    optional_ptr<FileOpener> opener);
 
+	// Record cache access for the given connection, resolving the profile collector internally.
+	void RecordCacheAccess(connection_t conn_id, CacheEntity cache_entity, CacheAccess cache_access);
+	void RecordCacheAccess(connection_t conn_id, CacheEntity cache_entity, CacheAccess cache_access, idx_t byte_count);
+
 	// Mutex to protect concurrent access.
 	concurrency::mutex cache_reader_mutex;
 	// Used to access remote files.

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -60,6 +60,7 @@ public:
 	void SetProfileCollector(connection_t connection_id, const string &profile_type);
 	BaseProfileCollector *GetProfileCollector(connection_t connection_id) const;
 	void ResetProfileCollector(connection_t connection_id);
+	void RemoveProfileCollector(connection_t connection_id);
 
 private:
 	mutable concurrency::mutex mutex;
@@ -188,5 +189,9 @@ shared_ptr<CacheHttpfsInstanceState> GetInstanceConfig(const weak_ptr<CacheHttpf
 // always expected (InitializeGlobalConfig guarantees it).
 BaseProfileCollector &GetProfileCollectorOrThrow(const shared_ptr<CacheHttpfsInstanceState> &instance_state,
                                                  connection_t conn_id);
+
+// Register a ClientContextState that removes this connection's profile collector
+// when the connection is destroyed. Safe to call multiple times for the same connection.
+void RegisterConnectionCleanupState(ClientContext &context, weak_ptr<CacheHttpfsInstanceState> instance_state);
 
 } // namespace duckdb

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -144,7 +144,9 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 	static constexpr const char *OBJECT_TYPE = "CacheHttpfsInstanceState";
 	static constexpr const char *CACHE_KEY = "cache_httpfs_instance_state";
 
+	// Extension config for the current duckdb instance.
 	InstanceConfig config;
+	// Cache filesystem registry.
 	InstanceCacheFsRegistry registry;
 	InstanceCacheReaderManager cache_reader_manager;
 	InstanceProfileCollectorManager profile_collector_manager;
@@ -152,6 +154,7 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 
 	CacheHttpfsInstanceState() = default;
 
+	// ObjectCacheEntry interface
 	string GetObjectType() override {
 		return OBJECT_TYPE;
 	}

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -4,18 +4,18 @@
 #pragma once
 
 #include "base_cache_reader.hpp"
+#include "base_profile_collector.hpp"
 #include "cache_exclusion_manager.hpp"
 #include "cache_filesystem_config.hpp"
-#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "filesystem_utils.hpp"
-#include "mutex.hpp"
 #include "thread_annotation.hpp"
 
 namespace duckdb {
@@ -47,11 +47,28 @@ private:
 };
 
 //===--------------------------------------------------------------------===//
-// Per-instance cache reader manager
+// Per-connection profile collector manager
 //===--------------------------------------------------------------------===//
 
 // Forward declaration
 struct InstanceConfig;
+
+// Manages per-connection profile collectors.
+// Each connection has its own profiler so stats can be tracked independently.
+class InstanceProfileCollectorManager {
+public:
+	void SetProfileCollector(connection_t connection_id, const string &profile_type);
+	BaseProfileCollector *GetProfileCollector(connection_t connection_id) const;
+	void ResetProfileCollector(connection_t connection_id);
+
+private:
+	mutable concurrency::mutex mutex;
+	unordered_map<connection_t, unique_ptr<BaseProfileCollector>> profile_collectors DUCKDB_GUARDED_BY(mutex);
+};
+
+//===--------------------------------------------------------------------===//
+// Per-instance cache reader manager
+//===--------------------------------------------------------------------===//
 
 class InstanceCacheReaderManager {
 public:
@@ -60,8 +77,6 @@ public:
 	vector<BaseCacheReader *> GetCacheReaders() const;
 	void InitializeDiskCacheReader(const vector<string> &cache_directories,
 	                               weak_ptr<CacheHttpfsInstanceState> instance_state_p);
-	// Update existing readers to use a new profile collector (when profile type changes).
-	void UpdateProfileCollector(BaseProfileCollector &profile_collector);
 	void ClearCache();
 	void ClearCache(const string &fname);
 	void Reset();
@@ -129,26 +144,14 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 	static constexpr const char *OBJECT_TYPE = "CacheHttpfsInstanceState";
 	static constexpr const char *CACHE_KEY = "cache_httpfs_instance_state";
 
-	// Extension config for the current duckdb instance.
 	InstanceConfig config;
-	// Cache filesystem registry.
 	InstanceCacheFsRegistry registry;
-
 	InstanceCacheReaderManager cache_reader_manager;
+	InstanceProfileCollectorManager profile_collector_manager;
 	CacheExclusionManager exclusion_manager;
-	// Per-database profile collector, which is shared by all cache filesystems and cache readers.
-	//
-	// Thread-safety and ownership guarantee:
-	// - Profile collector is a "singleton" owned by per-database cache httpfs instance state
-	// - Both cache filesystems and cache readers make IO operation, so they hold a reference for profile collector to
-	// record metrics
-	// - Profile collector could be updated at extension setting update callback, which doesn't hold lock intentionally,
-	// based on the assumption that setting update doesn't run concurrently with IO operation
-	unique_ptr<BaseProfileCollector> profile_collector;
 
-	CacheHttpfsInstanceState();
+	CacheHttpfsInstanceState() = default;
 
-	// ObjectCacheEntry interface
 	string GetObjectType() override {
 		return OBJECT_TYPE;
 	}
@@ -156,13 +159,6 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 	static string ObjectType() {
 		return OBJECT_TYPE;
 	}
-
-	// Get profile collector reference
-	BaseProfileCollector &GetProfileCollector();
-	// Reset profile collector.
-	void ResetProfileCollector();
-	// Set the profile collector.
-	void SetProfileCollector(string profile_type);
 };
 
 //===--------------------------------------------------------------------===//
@@ -182,6 +178,12 @@ CacheHttpfsInstanceState &GetInstanceStateOrThrow(DatabaseInstance &instance);
 CacheHttpfsInstanceState &GetInstanceStateOrThrow(ClientContext &context);
 
 // Get instance state as shared_ptr, throw exception if already unreferenced.
-shared_ptr<CacheHttpfsInstanceState> GetInstanceConfig(weak_ptr<CacheHttpfsInstanceState> instance_state);
+shared_ptr<CacheHttpfsInstanceState> GetInstanceConfig(const weak_ptr<CacheHttpfsInstanceState> &instance_state);
+
+// Get the per-connection profile collector, throwing if no collector exists for the given
+// connection. Use this in filesystem and cache reader code where a valid collector is
+// always expected (InitializeGlobalConfig guarantees it).
+BaseProfileCollector &GetProfileCollectorOrThrow(const shared_ptr<CacheHttpfsInstanceState> &instance_state,
+                                                 connection_t conn_id);
 
 } // namespace duckdb

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -57,7 +57,11 @@ struct InstanceConfig;
 // Each connection has its own profiler so stats can be tracked independently.
 class InstanceProfileCollectorManager {
 public:
+	// Sets the BaseProfileCollector for the given connection.
+	// If the collector already exists and the profile type is the same, the function does nothing, otherwise it creates
+	// a new collector and replaces the existing one.
 	void SetProfileCollector(connection_t connection_id, const string &profile_type);
+	// Returns the BaseProfileCollector for the given connection, or nullptr if no collector exists.
 	BaseProfileCollector *GetProfileCollector(connection_t connection_id) const;
 	void ResetProfileCollector(connection_t connection_id);
 	void RemoveProfileCollector(connection_t connection_id);

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -4,7 +4,6 @@
 
 #include "base_cache_reader.hpp"
 #include "cache_filesystem_config.hpp"
-#include "cache_filesystem_config.hpp"
 #include "cache_read_chunk.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/map.hpp"
@@ -25,8 +24,7 @@ struct InstanceConfig;
 
 class DiskCacheReader final : public BaseCacheReader {
 public:
-	// Constructor: cache_directories defines where cache files are stored.
-	DiskCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p, BaseProfileCollector &profile_collector_p);
+	explicit DiskCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p);
 	~DiskCacheReader() override = default;
 
 	string GetName() const override {
@@ -73,8 +71,6 @@ private:
 	// Used to avoid local disk IO.
 	// NOTICE: cache key uses remote filepath, instead of local cache filepath.
 	unique_ptr<InMemCacheManager> in_mem_cache_manager;
-	// Instance state for config lookup.
-	weak_ptr<CacheHttpfsInstanceState> instance_state;
 };
 
 } // namespace duckdb

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -25,7 +25,7 @@ public:
 	~InMemoryCacheReader() override = default;
 
 	string GetName() const override {
-		return "in_mem_cache_reader";
+		return *IN_MEM_CACHE_READER_NAME;
 	}
 
 	void ClearCache() override;

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -19,13 +19,13 @@ struct CacheHttpfsInstanceState;
 class InMemoryCacheReader final : public BaseCacheReader {
 public:
 	// Constructor: config values are read from instance state at runtime (with defaults as fallback).
-	InMemoryCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p, BaseProfileCollector &profile_collector_p)
-	    : BaseCacheReader(profile_collector_p, *IN_MEM_CACHE_READER_NAME), instance_state(std::move(instance_state_p)) {
+	explicit InMemoryCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p)
+	    : BaseCacheReader(std::move(instance_state_p)) {
 	}
 	~InMemoryCacheReader() override = default;
 
 	string GetName() const override {
-		return *IN_MEM_CACHE_READER_NAME;
+		return "in_mem_cache_reader";
 	}
 
 	void ClearCache() override;
@@ -48,9 +48,6 @@ private:
 
 	// Process a single cache read chunk in a worker thread.
 	void ProcessCacheReadChunk(FileHandle &handle, const string &version_tag, CacheReadChunk cache_read_chunk);
-
-	// Instance state for config lookup.
-	weak_ptr<CacheHttpfsInstanceState> instance_state;
 
 	// Once flag to guard against cache's initialization.
 	std::once_flag cache_init_flag;

--- a/src/include/noop_cache_reader.hpp
+++ b/src/include/noop_cache_reader.hpp
@@ -5,16 +5,18 @@
 #pragma once
 
 #include "base_cache_reader.hpp"
-#include "base_profile_collector.hpp"
 #include "cache_filesystem_config.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
 
+struct CacheHttpfsInstanceState;
+
 class NoopCacheReader : public BaseCacheReader {
 public:
-	explicit NoopCacheReader(BaseProfileCollector &profile_collector_p)
-	    : BaseCacheReader(profile_collector_p, *NOOP_CACHE_READER_NAME) {
+	explicit NoopCacheReader(weak_ptr<CacheHttpfsInstanceState> instance_state_p)
+	    : BaseCacheReader(std::move(instance_state_p)) {
 	}
 	~NoopCacheReader() override = default;
 

--- a/src/include/noop_profile_collector.hpp
+++ b/src/include/noop_profile_collector.hpp
@@ -14,7 +14,7 @@ public:
 	LatencyGuard RecordOperationStart(IoOperation io_oper) override;
 	void RecordOperationEnd(IoOperation io_oper, int64_t latency_millisec) override {
 	}
-	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) override {
+	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access, idx_t byte_count) override {
 	}
 	void RecordActualCacheRead(idx_t cache_size, idx_t actual_bytes) override {
 	}

--- a/src/include/temp_profile_collector.hpp
+++ b/src/include/temp_profile_collector.hpp
@@ -20,7 +20,7 @@ public:
 
 	LatencyGuard RecordOperationStart(IoOperation io_oper) override;
 	void RecordOperationEnd(IoOperation io_oper, int64_t latency_millisec) override;
-	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) override;
+	void RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access, idx_t byte_count) override;
 	void RecordActualCacheRead(idx_t cache_bytes, idx_t actual_bytes) override;
 	void RecordBytesWritten(idx_t bytes) override;
 	string GetProfilerType() override {
@@ -41,6 +41,10 @@ private:
 	uint64_t total_bytes_to_read DUCKDB_GUARDED_BY(stats_mutex) = 0;
 	// Total number of bytes to cache.
 	uint64_t total_bytes_to_cache DUCKDB_GUARDED_BY(stats_mutex) = 0;
+	// Number of bytes served from cache (cache hits).
+	uint64_t bytes_read_from_hits DUCKDB_GUARDED_BY(stats_mutex) = 0;
+	// Number of bytes fetched from remote (cache misses).
+	uint64_t bytes_read_from_misses DUCKDB_GUARDED_BY(stats_mutex) = 0;
 	// Total number of bytes written.
 	uint64_t total_bytes_written DUCKDB_GUARDED_BY(stats_mutex) = 0;
 

--- a/src/noop_cache_reader.cpp
+++ b/src/noop_cache_reader.cpp
@@ -1,15 +1,19 @@
 #include "noop_cache_reader.hpp"
 
 #include "cache_filesystem.hpp"
+#include "cache_httpfs_instance_state.hpp"
 
 namespace duckdb {
 
 void NoopCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
                                    idx_t requested_bytes_to_read, idx_t file_size) {
-	auto &disk_cache_handle = handle.Cast<CacheFileSystemHandle>();
-	auto *internal_filesystem = disk_cache_handle.GetInternalFileSystem();
-	const auto latency_guard = GetProfileCollector().RecordOperationStart(IoOperation::kRead);
-	internal_filesystem->Read(*disk_cache_handle.internal_file_handle, buffer, requested_bytes_to_read,
+	auto &cache_handle = handle.Cast<CacheFileSystemHandle>();
+	auto *internal_filesystem = cache_handle.GetInternalFileSystem();
+
+	auto state = instance_state.lock();
+	auto &collector = GetProfileCollectorOrThrow(state, cache_handle.GetConnectionId());
+	const auto latency_guard = collector.RecordOperationStart(IoOperation::kRead);
+	internal_filesystem->Read(*cache_handle.internal_file_handle, buffer, requested_bytes_to_read,
 	                          requested_start_offset);
 }
 

--- a/src/temp_profile_collector.cpp
+++ b/src/temp_profile_collector.cpp
@@ -60,10 +60,18 @@ void TempProfileCollector::RecordOperationEnd(IoOperation io_oper, int64_t laten
 	latest_timestamp = now;
 }
 
-void TempProfileCollector::RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access) {
+void TempProfileCollector::RecordCacheAccess(CacheEntity cache_entity, CacheAccess cache_access, idx_t byte_count) {
 	const concurrency::lock_guard<concurrency::mutex> lck(stats_mutex);
 	const size_t arr_idx = static_cast<size_t>(cache_entity) * kCacheAccessCount + static_cast<size_t>(cache_access);
 	++cache_access_count[arr_idx];
+
+	if (cache_entity == CacheEntity::kData) {
+		if (cache_access == CacheAccess::kCacheHit) {
+			bytes_read_from_hits += byte_count;
+		} else if (cache_access == CacheAccess::kCacheMiss) {
+			bytes_read_from_misses += byte_count;
+		}
+	}
 }
 
 void TempProfileCollector::RecordActualCacheRead(idx_t cache_bytes, idx_t actual_bytes) {
@@ -85,6 +93,8 @@ void TempProfileCollector::Reset() {
 	cache_access_count.fill(0);
 	total_bytes_to_cache = 0;
 	total_bytes_to_read = 0;
+	bytes_read_from_hits = 0;
+	bytes_read_from_misses = 0;
 	total_bytes_written = 0;
 	latest_timestamp = 0;
 }
@@ -105,6 +115,8 @@ vector<CacheAccessInfo> TempProfileCollector::GetCacheAccessInfo() const {
 		if (idx == static_cast<idx_t>(IoOperation::kRead)) {
 			cache_access_info[idx].total_bytes_to_cache = Value::UBIGINT(total_bytes_to_cache);
 			cache_access_info[idx].total_bytes_to_read = Value::UBIGINT(total_bytes_to_read);
+			cache_access_info[idx].bytes_read_from_hits = Value::UBIGINT(bytes_read_from_hits);
+			cache_access_info[idx].bytes_read_from_misses = Value::UBIGINT(bytes_read_from_misses);
 		}
 	}
 	return cache_access_info;
@@ -132,8 +144,11 @@ std::pair<string, uint64_t> TempProfileCollector::GetHumanReadableStats() {
 			stats = StringUtil::Format("%s\n"
 			                           "for data cache, "
 			                           "number of bytes to read = %d\n"
-			                           "number of bytes to cache = %d\n",
-			                           stats, total_bytes_to_read, total_bytes_to_cache);
+			                           "number of bytes to cache = %d\n"
+			                           "bytes read from hits = %d\n"
+			                           "bytes read from misses = %d\n",
+			                           stats, total_bytes_to_read, total_bytes_to_cache, bytes_read_from_hits,
+			                           bytes_read_from_misses);
 		}
 	}
 

--- a/test/sql/cache_access_info.test
+++ b/test/sql/cache_access_info.test
@@ -6,13 +6,13 @@
 
 require cache_httpfs
 
-query IIIIII
+query IIIIIIII
 SELECT * FROM cache_httpfs_cache_access_info_query();
 ----
-metadata	0	0	0	NULL	NULL
-data	0	0	0	0	0
-file handle	0	0	0	NULL	NULL
-glob	0	0	0	NULL	NULL
+metadata	0	0	0	NULL	NULL	NULL	NULL
+data	0	0	0	NULL	NULL	NULL	NULL
+file handle	0	0	0	NULL	NULL	NULL	NULL
+glob	0	0	0	NULL	NULL	NULL	NULL
 
 # Start to record profile.
 statement ok
@@ -31,13 +31,13 @@ SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/du
 ----
 251
 
-query IIIIII
+query IIIIIIII
 SELECT * FROM cache_httpfs_cache_access_info_query();
 ----
-metadata	2	1	0	NULL	NULL
-data	0	1	0	16222	16222
-file handle	0	1	0	NULL	NULL
-glob	0	0	0	NULL	NULL
+metadata	2	1	0	NULL	NULL	NULL	NULL
+data	0	1	0	16222	16222	0	16222
+file handle	0	1	0	NULL	NULL	NULL	NULL
+glob	0	0	0	NULL	NULL	NULL	NULL
 
 # Query second time should show cache hit.
 query I
@@ -45,24 +45,24 @@ SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/du
 ----
 251
 
-query IIIIII
+query IIIIIIII
 SELECT * FROM cache_httpfs_cache_access_info_query();
 ----
-metadata	5	1	0	NULL	NULL
-data	1	1	0	32444	32444
-file handle	1	1	0	NULL	NULL
-glob	0	0	0	NULL	NULL
+metadata	5	1	0	NULL	NULL	NULL	NULL
+data	1	1	0	32444	32444	16222	16222
+file handle	1	1	0	NULL	NULL	NULL	NULL
+glob	0	0	0	NULL	NULL	NULL	NULL
 
 statement ok
 SELECT cache_httpfs_clear_profile();
 
-query IIIIII
+query IIIIIIII
 SELECT * FROM cache_httpfs_cache_access_info_query();
 ----
-metadata	0	0	0	NULL	NULL
-data	0	0	0	0	0
-file handle	0	0	0	NULL	NULL
-glob	0	0	0	NULL	NULL
+metadata	0	0	0	NULL	NULL	NULL	NULL
+data	0	0	0	0	0	0	0
+file handle	0	0	0	NULL	NULL	NULL	NULL
+glob	0	0	0	NULL	NULL	NULL	NULL
 
 # Disable all non data cache fron now on.
 statement ok
@@ -81,22 +81,22 @@ SET cache_httpfs_type='noop';
 statement ok
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 
-query IIIIII
+query IIIIIIII
 SELECT * FROM cache_httpfs_cache_access_info_query();
 ----
-metadata	0	0	0	NULL	NULL
-data	0	0	0	0	0
-file handle	0	0	0	NULL	NULL
-glob	0	0	0	NULL	NULL
+metadata	0	0	0	NULL	NULL	NULL	NULL
+data	0	0	0	0	0	0	0
+file handle	0	0	0	NULL	NULL	NULL	NULL
+glob	0	0	0	NULL	NULL	NULL	NULL
 
 # After disabling cache, uncached read second time.
 statement ok
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 
-query IIIIII
+query IIIIIIII
 SELECT * FROM cache_httpfs_cache_access_info_query();
 ----
-metadata	0	0	0	NULL	NULL
-data	0	0	0	0	0
-file handle	0	0	0	NULL	NULL
-glob	0	0	0	NULL	NULL
+metadata	0	0	0	NULL	NULL	NULL	NULL
+data	0	0	0	0	0	0	0
+file handle	0	0	0	NULL	NULL	NULL	NULL
+glob	0	0	0	NULL	NULL	NULL	NULL

--- a/test/unittest/test_cache_stats_collection_from_unit.cpp
+++ b/test/unittest/test_cache_stats_collection_from_unit.cpp
@@ -55,16 +55,16 @@ TEST_CASE_METHOD(CacheStatsFixture, "Test cache stats collection disabled", "[pr
 
 	// First access, there're no cache entries inside of cache filesystem.
 	[[maybe_unused]] auto file_handle_1 = cache_filesystem->OpenFile(test_filepath, FileOpenFlags::FILE_FLAGS_READ);
-	auto &profiler = cache_filesystem->GetProfileCollector();
-	auto file_handle_cache_info = GetFileHandleCacheInfo(profiler);
+	auto *profiler = helper.GetProfileCollector();
+	REQUIRE(profiler != nullptr);
+	auto file_handle_cache_info = GetFileHandleCacheInfo(*profiler);
 	REQUIRE(file_handle_cache_info.cache_hit_count == 0);
 	REQUIRE(file_handle_cache_info.cache_miss_count == 0);
 	REQUIRE(file_handle_cache_info.cache_miss_by_in_use == 0);
 
 	// Second access, still cache miss, but indicate we should have bigger cache size.
 	[[maybe_unused]] auto file_handle_2 = cache_filesystem->OpenFile(test_filepath, FileOpenFlags::FILE_FLAGS_READ);
-	auto &profiler2 = cache_filesystem->GetProfileCollector();
-	file_handle_cache_info = GetFileHandleCacheInfo(profiler2);
+	file_handle_cache_info = GetFileHandleCacheInfo(*profiler);
 	REQUIRE(file_handle_cache_info.cache_hit_count == 0);
 	REQUIRE(file_handle_cache_info.cache_miss_count == 0);
 	REQUIRE(file_handle_cache_info.cache_miss_by_in_use == 0);
@@ -80,16 +80,16 @@ TEST_CASE_METHOD(CacheStatsFixture, "Test cache stats collection", "[profile col
 
 	// First access, there're no cache entries inside of cache filesystem.
 	[[maybe_unused]] auto file_handle_1 = cache_filesystem->OpenFile(test_filepath, FileOpenFlags::FILE_FLAGS_READ);
-	auto &profiler = cache_filesystem->GetProfileCollector();
-	auto file_handle_cache_info = GetFileHandleCacheInfo(profiler);
+	auto *profiler = helper.GetProfileCollector();
+	REQUIRE(profiler != nullptr);
+	auto file_handle_cache_info = GetFileHandleCacheInfo(*profiler);
 	REQUIRE(file_handle_cache_info.cache_hit_count == 0);
 	REQUIRE(file_handle_cache_info.cache_miss_count == 1);
 	REQUIRE(file_handle_cache_info.cache_miss_by_in_use == 0);
 
 	// Second access, still cache miss, but indicate we should have bigger cache size.
 	[[maybe_unused]] auto file_handle_2 = cache_filesystem->OpenFile(test_filepath, FileOpenFlags::FILE_FLAGS_READ);
-	auto &profiler2 = cache_filesystem->GetProfileCollector();
-	file_handle_cache_info = GetFileHandleCacheInfo(profiler2);
+	file_handle_cache_info = GetFileHandleCacheInfo(*profiler);
 	REQUIRE(file_handle_cache_info.cache_hit_count == 0);
 	REQUIRE(file_handle_cache_info.cache_miss_count == 2);
 	REQUIRE(file_handle_cache_info.cache_miss_by_in_use == 1);
@@ -98,8 +98,7 @@ TEST_CASE_METHOD(CacheStatsFixture, "Test cache stats collection", "[profile col
 	file_handle_1.reset();
 	file_handle_2.reset();
 	[[maybe_unused]] auto file_handle_3 = cache_filesystem->OpenFile(test_filepath, FileOpenFlags::FILE_FLAGS_READ);
-	auto &profiler3 = cache_filesystem->GetProfileCollector();
-	file_handle_cache_info = GetFileHandleCacheInfo(profiler3);
+	file_handle_cache_info = GetFileHandleCacheInfo(*profiler);
 	REQUIRE(file_handle_cache_info.cache_hit_count == 1);
 	REQUIRE(file_handle_cache_info.cache_miss_count == 2);
 	REQUIRE(file_handle_cache_info.cache_miss_by_in_use == 1);

--- a/test/unittest/test_filesystem_config_from_unit.cpp
+++ b/test/unittest/test_filesystem_config_from_unit.cpp
@@ -91,8 +91,9 @@ TEST_CASE_METHOD(FilesystemConfigFixture, "Filesystem profile config test", "[fi
 		auto *cache_fs = helper.GetCacheFileSystem();
 
 		cache_fs->OpenFile(test_filename, FileOpenFlags::FILE_FLAGS_READ);
-		auto &profiler = cache_fs->GetProfileCollector();
-		[[maybe_unused]] auto &noop_profiler = profiler.Cast<NoopProfileCollector>();
+		auto *profiler = helper.GetProfileCollector();
+		REQUIRE(profiler != nullptr);
+		[[maybe_unused]] auto &noop_profiler = profiler->Cast<NoopProfileCollector>();
 	}
 
 	// Check temp profiler.
@@ -103,7 +104,8 @@ TEST_CASE_METHOD(FilesystemConfigFixture, "Filesystem profile config test", "[fi
 		auto *cache_fs = helper.GetCacheFileSystem();
 
 		cache_fs->OpenFile(test_filename, FileOpenFlags::FILE_FLAGS_READ);
-		auto &profiler = cache_fs->GetProfileCollector();
-		[[maybe_unused]] auto &temp_profiler = profiler.Cast<TempProfileCollector>();
+		auto *profiler = helper.GetProfileCollector();
+		REQUIRE(profiler != nullptr);
+		[[maybe_unused]] auto &temp_profiler = profiler->Cast<TempProfileCollector>();
 	}
 }

--- a/test/unittest/test_io_operation_latency.cpp
+++ b/test/unittest/test_io_operation_latency.cpp
@@ -61,8 +61,9 @@ TEST_CASE("Test IO operation latency recording", "[io operation latency]") {
 	auto *cache_filesystem = helper.GetCacheFileSystem();
 
 	// Clear profile to start fresh
-	auto &profiler = cache_filesystem->GetProfileCollector();
-	profiler.Reset();
+	auto *profiler = helper.GetProfileCollector();
+	REQUIRE(profiler != nullptr);
+	profiler->Reset();
 
 	// Perform open operation
 	{
@@ -92,7 +93,7 @@ TEST_CASE("Test IO operation latency recording", "[io operation latency]") {
 	cache_filesystem->ClearCache(TEST_FILENAME_1);
 
 	// Get profile stats and verify operations are recorded
-	auto stats_pair = profiler.GetHumanReadableStats();
+	auto stats_pair = profiler->GetHumanReadableStats();
 	const string &profile = stats_pair.first;
 
 	// Verify all operations we performed are present in the profile

--- a/test/unittest/test_latency_guard.cpp
+++ b/test/unittest/test_latency_guard.cpp
@@ -19,7 +19,7 @@ public:
 		(void)latency_millisec; // Suppress unused parameter warning.
 		++record_end_count;
 	}
-	void RecordCacheAccess(CacheEntity, CacheAccess) override {
+	void RecordCacheAccess(CacheEntity, CacheAccess, idx_t) override {
 	}
 	void RecordActualCacheRead(idx_t, idx_t) override {
 	}

--- a/test/unittest/test_utils.cpp
+++ b/test/unittest/test_utils.cpp
@@ -34,8 +34,8 @@ TestCacheFileSystemHelper::TestCacheFileSystemHelper(TestCacheConfig config) : d
 	// Cache behavior
 	inst_config.clear_cache_on_write = config.clear_cache_on_write;
 
-	// Initialize profile collector
-	instance_state->SetProfileCollector(inst_config.profile_type);
+	// Initialize profile collector for connection 0 (test default)
+	instance_state->profile_collector_manager.SetProfileCollector(0, inst_config.profile_type);
 
 	// Ensure cache directories exist
 	auto local_fs = LocalFileSystem::CreateLocal();
@@ -67,6 +67,10 @@ BaseCacheReader &TestCacheFileSystemHelper::GetCacheReader() {
 
 InstanceConfig &TestCacheFileSystemHelper::GetConfig() {
 	return instance_state->config;
+}
+
+BaseProfileCollector *TestCacheFileSystemHelper::GetProfileCollector(connection_t connection_id) {
+	return instance_state->profile_collector_manager.GetProfileCollector(connection_id);
 }
 
 void InitializeCacheReaderForTest(shared_ptr<CacheHttpfsInstanceState> &instance_state, const InstanceConfig &config) {

--- a/test/unittest/test_utils.hpp
+++ b/test/unittest/test_utils.hpp
@@ -3,9 +3,11 @@
 #pragma once
 
 #include "base_cache_reader.hpp"
+#include "base_profile_collector.hpp"
 #include "cache_filesystem.hpp"
 #include "cache_httpfs_instance_state.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/main/database.hpp"
 
@@ -66,6 +68,9 @@ public:
 
 	// Get the config for inspection/modification
 	InstanceConfig &GetConfig();
+
+	// Get profile collector for the given connection.
+	BaseProfileCollector *GetProfileCollector(connection_t connection_id = 0);
 
 private:
 	DuckDB db;


### PR DESCRIPTION
Move profiling from a single shared `BaseProfileCollector` to a **per-connection model** (`connection_t` → `BaseProfileCollector` map) so that concurrent DuckDB connections on the same instance each get **isolated profiling data**.

Previously, a single global collector was shared across all connections, making it impossible to attribute cache hits, misses, and I/O latencies to individual connections.

### Key changes

- **`InstanceProfileCollectorManager`** — new class in `CacheHttpfsInstanceState` managing a `connection_t` → `unique_ptr<BaseProfileCollector>` map (mutex-guarded).
- **`CacheFileSystemHandle`** now carries a `connection_id`, propagated from `FileOpener` → `ClientContext`.
- **`CacheFileSystem`** no longer holds a direct `BaseProfileCollector` reference; all methods resolve the collector dynamically via `GetProfileCollectorOrThrow(state, conn_id)`.
- **`BaseCacheReader`** (and `Noop`/`Disk`/`InMemory` subclasses) replaced their `BaseProfileCollector` reference with a `weak_ptr<CacheHttpfsInstanceState>`, looking up the per-connection collector at call time.
- **`RecordCacheAccess`** now accepts `idx_t byte_count`, enabling tracking of `bytes_read_from_hits` / `bytes_read_from_misses` in `TempProfileCollector` and `CacheAccessInfo`.