### PR TITLE
Fix disabled external access

### DIFF
--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -517,6 +517,7 @@ void LoadInternal(ExtensionLoader &loader) {
 	auto state = make_shared_ptr<CacheHttpfsInstanceState>();
 	// Register instance state with duckdb database instance.
 	SetInstanceState(instance, state);
+	state->db_config = &instance.config;
 
 	// Ensure cache directory exists
 	auto local_fs = LocalFileSystem::CreateLocal();

--- a/src/cache_httpfs_instance_state.cpp
+++ b/src/cache_httpfs_instance_state.cpp
@@ -4,6 +4,8 @@
 #include "cache_filesystem.hpp"
 #include "cache_filesystem_config.hpp"
 #include "disk_cache_reader.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/client_context_state.hpp"
@@ -18,6 +20,14 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 // CacheHttpfsInstanceState implementation
 //===--------------------------------------------------------------------===//
+
+bool CacheHttpfsInstanceState::CanAccessFile(const string &path) {
+	if (!db_config) {
+		throw InternalException("DB config is not set!");
+	}
+	return db_config->CanAccessFile(path, FileType::FILE_TYPE_REGULAR);
+	// TODO(hjiang): add logging if requested file not accessible.
+}
 
 CacheHttpfsInstanceState::~CacheHttpfsInstanceState() {
 	// Clear in-memory cache entries to prevent potential invalid memory access.

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -134,7 +134,9 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 	// deleted by cleanup thread and lead to data race.
 	//
 	// TODO(hjiang): With in-memory cache block involved, we could place disk write to background thread.
-	{
+	// Check local disk access before serving from cache.
+	const bool can_access_cache_file = state->CanAccessFile(cache_dest.dest_local_filepath);
+	if (can_access_cache_file) {
 		const auto latency_guard = collector.RecordOperationStart(IoOperation::kDiskCacheRead);
 		const DiskCacheUtil::ReadOption read_options {
 		    // If on-disk in-memory cache is enabled, use direct IO to avoid double buffering.
@@ -179,6 +181,9 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 
 	// Attempt to cache file locally.
 	// We're tolerate of local cache file write failure, which doesn't affect returned content correctness.
+	if (!can_access_cache_file) {
+		return;
+	}
 	try {
 		DiskCacheUtil::StoreLocalCacheFile(cache_directory, cache_dest, content, version_tag, config,
 		                                   [this]() { return EvictCacheBlockLru(); });

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -13,7 +13,9 @@
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
+#include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/vector.hpp"
+#include "duckdb/main/config.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "filesystem_utils.hpp"
 #include "thread_annotation.hpp"
@@ -162,6 +164,8 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 
 	// Extension config for the current duckdb instance.
 	InstanceConfig config;
+	// Database config.
+	optional_ptr<DBConfig> db_config;
 	// Cache filesystem registry.
 	InstanceCacheFsRegistry registry;
 	InstanceCacheReaderManager cache_reader_manager;
@@ -190,6 +194,8 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 	void ResetProfileCollector();
 	// Set the profile collector.
 	void SetProfileCollector(string profile_type);
+	// Return if the path is allowed by current DB config.
+	bool CanAccessFile(const string &path);
 };
 
 //===--------------------------------------------------------------------===//

--- a/test/sql/disable_external_access.test
+++ b/test/sql/disable_external_access.test
@@ -1,0 +1,79 @@
+# name: test/sql/disable_external_access.test
+# description: test that caching filesystem respects enable_external_access when serving from cache
+# group: [sql]
+
+require notwindows
+
+require cache_httpfs
+
+require parquet
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+statement ok
+SET cache_httpfs_profile_type='temp';
+
+statement ok
+SET cache_httpfs_disk_cache_reader_enable_memory_cache=false;
+
+statement ok
+SET cache_httpfs_cache_directory='/tmp/duckdb_cache_httpfs_cache_1';
+
+# Cache directory isn't inclued in the allowed directory lists.
+statement ok
+SET allowed_directories=['https://raw.githubusercontent.com/', '/tmp/duckdb_cache_httpfs_cache'];
+
+statement ok
+SET enable_external_access = false;
+
+query I
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+----
+251
+
+query I
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+----
+251
+
+query II
+SELECT cache_hit_count, cache_miss_count FROM cache_httpfs_cache_access_info_query() WHERE cache_type = 'data';
+----
+0	2
+
+# =============================================
+# Restart the database to allow disk access.
+# =============================================
+restart
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+statement ok
+SET cache_httpfs_profile_type='temp';
+
+statement ok
+SET cache_httpfs_disk_cache_reader_enable_memory_cache=false;
+
+# Switch cache directory to make it allowed.
+statement ok
+SET cache_httpfs_cache_directory='/tmp/duckdb_cache_httpfs_cache';
+
+statement ok
+SET enable_external_access = false;
+
+query I
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+----
+251
+
+query I
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+----
+251
+
+query II
+SELECT cache_hit_count, cache_miss_count FROM cache_httpfs_cache_access_info_query() WHERE cache_type = 'data';
+----
+1	1


### PR DESCRIPTION
Closes https://github.com/dentiny/duck-read-cache-fs/issues/457

This PR fixes the disable external access by checking whether disk cache files are accessible.