### PR TITLE
Override DuckDB encryption util

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,13 @@ if(UNIX OR APPLE)
   )
 endif()
 
+# Override DuckDB encryption library, mimics httpfs extension behavior.
+if (NOT EMSCRIPTEN)
+  add_definitions(-DOVERRIDE_ENCRYPTION_UTILS=1)
+else()
+  set(DUCKDB_EXTENSION_HTTPFS_LINKED_LIBS "../../third_party/mbedtls/libduckdb_mbedtls.a")
+endif()
+
 # Check if compiler is Clang (case-insensitive check)
 string(TOLOWER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_ID_LOWER)
 string(TOLOWER "${CMAKE_CXX_COMPILER}" CMAKE_CXX_COMPILER_LOWER)

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,7 @@ HTTPFS_TEST_BLACKLIST := \
 	test/sql/logging/http_logging.test \
 	test/sql/settings/test_disabled_file_system_httpfs.test \
 	test/sql/storage/external_file_cache/external_file_cache_read_blob.test_slow \
-	test/sql/copy/encryption/different_aes_engines.test \
-	test/sql/copy/parquet/parquet_encryption_mbedtls_openssl.test \
-	test/sql/copy/parquet/parquet_encryption_httpfs.test \
-	test/sql/copy/s3/glob_s3_recursive.test_slow \
-	test/sql/crypto/test_openssl_crypto.test
+	test/sql/copy/s3/glob_s3_recursive.test_slow
 
 # Prepare httpfs tests: rewrite require directives, inject cache clear, and remove blacklisted tests.
 define PREPARE_HTTPFS_TESTS


### PR DESCRIPTION
Closes https://github.com/dentiny/duck-read-cache-fs/issues/462

Override DuckDB core's Mbed TLS with openssl for better performance. See [blog](https://duckdb.org/2025/11/19/encryption-in-duckdb) for details.