### PR TITLE
Fix valid max fanout

### DIFF
--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -292,9 +292,6 @@ void UpdateProfileType(ClientContext &context, SetScope scope, Value &parameter)
 void UpdateMaxFanoutSubrequest(ClientContext &context, SetScope scope, Value &parameter) {
 	auto &inst_state = GetInstanceStateOrThrow(context);
 	const auto max_subrequest_count = parameter.GetValue<uint64_t>();
-	if (max_subrequest_count == 0) {
-		throw InvalidInputException("cache_httpfs_max_fanout_subrequest must be greater than 0");
-	}
 	inst_state.config.max_subrequest_count = max_subrequest_count;
 }
 

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -45,10 +45,10 @@ extern const NoDestructor<unordered_set<string>> ALL_PROFILE_TYPES;
 extern const idx_t DEFAULT_CACHE_BLOCK_SIZE;
 
 // Default to use on-disk cache filesystem.
-extern NoDestructor<string> DEFAULT_CACHE_TYPE;
+extern const NoDestructor<string> DEFAULT_CACHE_TYPE;
 
 // Default to timestamp-based on-disk cache eviction policy.
-extern NoDestructor<string> DEFAULT_ON_DISK_EVICTION_POLICY;
+extern const NoDestructor<string> DEFAULT_ON_DISK_EVICTION_POLICY;
 
 // To prevent go out of disk space, we set a threshold to disallow local caching if insufficient. It applies to all
 // filesystems. The value here is the decimal representation for percentage value; for example, 0.05 means 5%.

--- a/test/sql/invalid_extension_config.test
+++ b/test/sql/invalid_extension_config.test
@@ -93,9 +93,3 @@ statement error
 SET cache_httpfs_glob_cache_entry_timeout_millisec=0;
 ----
 cache_httpfs_glob_cache_entry_timeout_millisec must be greater than 0
-
-# Test cache_httpfs_max_fanout_subrequest - zero value
-statement error
-SET cache_httpfs_max_fanout_subrequest=0;
-----
-cache_httpfs_max_fanout_subrequest must be greater than 0

--- a/test/sql/max_subrequest_fanout.test
+++ b/test/sql/max_subrequest_fanout.test
@@ -45,3 +45,14 @@ query I
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
+
+# //===--------------------------------------------------------------------===//
+# // Subrequest number 0, which means no limit
+# //===--------------------------------------------------------------------===//
+statement ok
+SET cache_httpfs_max_fanout_subrequest=0
+
+query I
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
+----
+251


### PR DESCRIPTION
According to the [doc](https://github.com/dentiny/duck-read-cache-fs/blob/d5e83155ef933c6a16fb5cd0ea78e6b2839b2d49/src/cache_httpfs_extension.cpp#L597), 0 is a valid limit for max fanout, so we shouldn't reject it.