### PR TITLE
Fix duplicate key insertion for LRU cache

### DIFF
--- a/src/utils/include/copiable_value_lru_cache.hpp
+++ b/src/utils/include/copiable_value_lru_cache.hpp
@@ -50,6 +50,15 @@ public:
 
 	// Insert `value` with key `key`. This will replace any previous entry with the same key.
 	void Put(Key key, Val value) {
+		// Check if the key already exists in the cache.
+		auto existing = entry_map.find(key);
+		if (existing != entry_map.end()) {
+			auto old_lru_iter = existing->second.lru_iterator;
+			entry_map.erase(existing);
+			lru_list.erase(old_lru_iter);
+		}
+
+		// Now we could insert the new key-value fresh new.
 		lru_list.emplace_front(key);
 		Entry new_entry {
 		    .value = std::move(value),

--- a/src/utils/include/exclusive_lru_cache.hpp
+++ b/src/utils/include/exclusive_lru_cache.hpp
@@ -58,6 +58,15 @@ public:
 	// 1. Caller is able to do processing for the value.
 	// 2. For thread-safe lru cache, processing could be moved out of critical section.
 	unique_ptr<Val> Put(Key key, unique_ptr<Val> value) {
+		// Check if the key already exists in the cache.
+		auto existing = entry_map.find(key);
+		if (existing != entry_map.end()) {
+			auto old_lru_iter = existing->second.lru_iterator;
+			entry_map.erase(existing);
+			lru_list.erase(old_lru_iter);
+		}
+
+		// Now we could insert the new key-value fresh new.
 		lru_list.emplace_front(key);
 		Entry new_entry {
 		    .value = std::move(value),

--- a/src/utils/include/shared_value_lru_cache.hpp
+++ b/src/utils/include/shared_value_lru_cache.hpp
@@ -48,6 +48,15 @@ public:
 
 	// Insert `value` with key `key`. This will replace any previous entry with the same key.
 	void Put(Key key, shared_ptr<Val> value) {
+		// Check if the key already exists in the cache.
+		auto existing = entry_map.find(key);
+		if (existing != entry_map.end()) {
+			auto old_lru_iter = existing->second.lru_iterator;
+			entry_map.erase(existing);
+			lru_list.erase(old_lru_iter);
+		}
+
+		// Now we could insert the new key-value fresh new.
 		lru_list.emplace_front(key);
 		Entry new_entry {
 		    .value = std::move(value),

--- a/test/unittest/test_copiable_value_lru_cache.cpp
+++ b/test/unittest/test_copiable_value_lru_cache.cpp
@@ -191,3 +191,32 @@ TEST_CASE("CopiableValueLru GetOrCreate exception propagates to waiting threads"
 	auto result = cache.GetOrCreate(key, good_factory);
 	REQUIRE(result == key);
 }
+
+TEST_CASE("CopiableValueLru DuplicateKeyPut", "[exclusive lru test]") {
+	using CacheType = ThreadSafeCopiableValLruCache<string, string>;
+	CacheType cache {/*max_entries_p=*/3, /*timeout_millisec_p=*/0};
+
+	cache.Put("a", string("a1"));
+	cache.Put("b", string("b1"));
+	cache.Put("c", string("c1"));
+
+	// Insert duplicate keys.
+	cache.Put("a", string("a2"));
+	cache.Put("a", string("a3"));
+
+	// The latest value for "a" must be visible.
+	auto val = cache.Get("a");
+	REQUIRE(val.has_value());
+	REQUIRE(*val == "a3");
+
+	val = cache.Get("b");
+	REQUIRE(val.has_value());
+	REQUIRE(*val == "b1");
+
+	val = cache.Get("c");
+	REQUIRE(val.has_value());
+	REQUIRE(*val == "c1");
+
+	auto keys = cache.Keys();
+	REQUIRE(keys.size() == 3);
+}

--- a/test/unittest/test_exclusive_lru_cache.cpp
+++ b/test/unittest/test_exclusive_lru_cache.cpp
@@ -130,3 +130,31 @@ TEST_CASE("ExclusiveLru Evicted value", "[exclusive lru test]") {
 	REQUIRE(values.size() == 1);
 	REQUIRE(*values[0] == "val3");
 }
+
+TEST_CASE("ExclusiveLru DuplicateKeyPut", "[exclusive lru test]") {
+	ThreadSafeExclusiveLruCache<std::string, std::string> cache {/*max_entries_p=*/3, /*timeout_millisec_p=*/0};
+
+	cache.Put("a", make_uniq<std::string>("a1"));
+	cache.Put("b", make_uniq<std::string>("b1"));
+	cache.Put("c", make_uniq<std::string>("c1"));
+
+	// Insert duplicate keys.
+	cache.Put("a", make_uniq<std::string>("a2"));
+	cache.Put("a", make_uniq<std::string>("a3"));
+
+	// The latest value for "a" must be visible.
+	auto val = cache.GetAndPop("a");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "a3");
+
+	val = cache.GetAndPop("b");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "b1");
+
+	val = cache.GetAndPop("c");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "c1");
+
+	auto remaining = cache.ClearAndGetValues();
+	REQUIRE(remaining.empty());
+}

--- a/test/unittest/test_shared_value_lru_cache.cpp
+++ b/test/unittest/test_shared_value_lru_cache.cpp
@@ -193,3 +193,32 @@ TEST_CASE("SharedValueLru GetOrCreate exception propagates to waiting threads", 
 	REQUIRE(result != nullptr);
 	REQUIRE(*result == key);
 }
+
+TEST_CASE("SharedValueLru DuplicateKeyPut", "[exclusive lru test]") {
+	using CacheType = ThreadSafeSharedValueLruCache<string, string>;
+	CacheType cache {/*max_entries_p=*/3, /*timeout_millisec_p=*/0};
+
+	cache.Put("a", make_shared_ptr<string>("a1"));
+	cache.Put("b", make_shared_ptr<string>("b1"));
+	cache.Put("c", make_shared_ptr<string>("c1"));
+
+	// Insert duplicate keys.
+	cache.Put("a", make_shared_ptr<string>("a2"));
+	cache.Put("a", make_shared_ptr<string>("a3"));
+
+	// The latest value for "a" must be visible.
+	auto val = cache.Get("a");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "a3");
+
+	val = cache.Get("b");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "b1");
+
+	val = cache.Get("c");
+	REQUIRE(val != nullptr);
+	REQUIRE(*val == "c1");
+
+	auto keys = cache.Keys();
+	REQUIRE(keys.size() == 3);
+}


### PR DESCRIPTION
Currently whenever a new key is inserted, we always push it to the front of the LRU list, which leads to duplicate keys.
The fix in this PR is to check existence and remove if any.