### PR TITLE
[2/N] Implement object cache managed data cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(EXTENSION_SOURCES
     src/in_mem_cache_block.cpp
     src/in_mem_cache_remap.cpp
     src/in_memory_cache_reader.cpp
+    src/object_cache_data_cache_storage.cpp
     src/histogram.cpp
     src/filesystem_status_query_function.cpp
     src/io_operations.cpp

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -519,7 +519,6 @@ void LoadInternal(ExtensionLoader &loader) {
 	auto state = make_shared_ptr<CacheHttpfsInstanceState>();
 	// Register instance state with duckdb database instance.
 	SetInstanceState(instance, state);
-	state->db_config = &instance.config;
 	state->db_instance = &instance;
 
 	// Ensure cache directory exists

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -520,6 +520,7 @@ void LoadInternal(ExtensionLoader &loader) {
 	// Register instance state with duckdb database instance.
 	SetInstanceState(instance, state);
 	state->db_config = &instance.config;
+	state->db_instance = &instance;
 
 	// Ensure cache directory exists
 	auto local_fs = LocalFileSystem::CreateLocal();

--- a/src/cache_httpfs_instance_state.cpp
+++ b/src/cache_httpfs_instance_state.cpp
@@ -22,10 +22,10 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 
 bool CacheHttpfsInstanceState::CanAccessFile(const string &path) {
-	if (!db_config) {
-		throw InternalException("DB config is not set!");
+	if (!db_instance) {
+		throw InternalException("DB instance is not set!");
 	}
-	return db_config->CanAccessFile(path, FileType::FILE_TYPE_REGULAR);
+	return db_instance->config.CanAccessFile(path, FileType::FILE_TYPE_REGULAR);
 	// TODO(hjiang): add logging if requested file not accessible.
 }
 

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -46,13 +46,14 @@ string DiskCacheReader::EvictCacheBlockLru() {
 	return filepath;
 }
 
-bool DiskCacheReader::ValidateCacheEntry(const InMemCacheDataEntry &cache_entry, const string &version_tag) {
-	// Empty version tags means cache validation is disabled.
-	if (version_tag.empty()) {
-		return true;
-	}
-	return cache_entry.version_tag == version_tag;
+namespace {
+
+// Empty version_tag means cache validation is disabled => always valid.
+bool ValidateVersionTag(const string &cached, const string &expected) {
+	return expected.empty() || cached == expected;
 }
+
+} // namespace
 
 // TODO(hjiang): For oversized filepath, both in-memory cache and on-disk cache stores resolved path, which uses SHA-256
 // instead of original filename, likely we should do a translation here. On-disk cache stores original filepath in file
@@ -119,16 +120,16 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 
 	// Attempt in-memory cache first, so potentially we don't need to access disk storage.
 	if (in_mem_storage != nullptr) {
-		auto cache_entry = in_mem_storage->Get(block_key);
-		if (cache_entry != nullptr && !ValidateCacheEntry(*cache_entry, version_tag)) {
+		auto pinned = in_mem_storage->Get(block_key);
+		if (pinned && !ValidateVersionTag(pinned->VersionTag(), version_tag)) {
+			pinned.reset();
 			in_mem_storage->Delete(block_key);
-			cache_entry = nullptr;
 			local_filesystem->TryRemoveFile(cache_dest.dest_local_filepath);
 		}
-		if (cache_entry != nullptr) {
+		if (pinned) {
 			collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit, cache_read_chunk.bytes_to_copy);
 			DUCKDB_LOG_READ_CACHE_HIT((handle));
-			cache_read_chunk.CopyBufferToRequestedMemory(cache_entry->data);
+			cache_read_chunk.CopyBufferToRequestedMemory(pinned->Data());
 			return;
 		}
 	}
@@ -155,11 +156,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 
 			// Update in-memory cache if applicable.
 			if (in_mem_storage != nullptr) {
-				InMemCacheDataEntry new_cache_entry {
-				    .data = std::move(read_result.content),
-				    .version_tag = version_tag,
-				};
-				in_mem_storage->Put(block_key, make_shared_ptr<InMemCacheDataEntry>(std::move(new_cache_entry)));
+				in_mem_storage->Put(block_key, std::move(read_result.content), version_tag);
 			}
 			return;
 		}
@@ -193,11 +190,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 
 		// Update in-memory cache if applicable.
 		if (in_mem_storage != nullptr) {
-			InMemCacheDataEntry new_cache_entry {
-			    .data = std::move(content),
-			    .version_tag = version_tag,
-			};
-			in_mem_storage->Put(block_key, make_shared_ptr<InMemCacheDataEntry>(std::move(new_cache_entry)));
+			in_mem_storage->Put(block_key, std::move(content), version_tag);
 		}
 	} catch (...) {
 	}
@@ -213,7 +206,7 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 	const auto &config = instance_state_locked->config;
 	std::call_once(cache_init_flag, [this, &config]() {
 		if (config.enable_disk_reader_mem_cache) {
-			in_mem_storage = make_uniq<ExtensionBoundedDataCacheStorage>(
+			in_mem_storage = make_shared_ptr<ExtensionBoundedDataCacheStorage>(
 			    config.disk_reader_max_mem_cache_block_count, config.disk_reader_max_mem_cache_timeout_millisec);
 		}
 	});
@@ -372,7 +365,8 @@ void DiskCacheReader::RemapInMemoryDataBlocksForNewBlockSize(idx_t new_block_siz
 	// TODO: pass known remote file sizes (e.g. from metadata cache) so remap matches EOF behavior of real reads.
 	auto rebuilt = RemapInMemCacheEntries(std::move(taken), new_block_size, /*file_size_by_path=*/ {});
 	for (auto &kv : rebuilt) {
-		in_mem_storage->Put(std::move(kv.first), std::move(kv.second));
+		auto &entry = kv.second;
+		in_mem_storage->Put(std::move(kv.first), std::move(entry->data), std::move(entry->version_tag));
 	}
 }
 

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -46,15 +46,6 @@ string DiskCacheReader::EvictCacheBlockLru() {
 	return filepath;
 }
 
-namespace {
-
-// Empty version_tag means cache validation is disabled => always valid.
-bool ValidateVersionTag(const string &cached, const string &expected) {
-	return expected.empty() || cached == expected;
-}
-
-} // namespace
-
 // TODO(hjiang): For oversized filepath, both in-memory cache and on-disk cache stores resolved path, which uses SHA-256
 // instead of original filename, likely we should do a translation here. On-disk cache stores original filepath in file
 // attributes, in-memory cache should do the same thing.
@@ -120,12 +111,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 
 	// Attempt in-memory cache first, so potentially we don't need to access disk storage.
 	if (in_mem_storage != nullptr) {
-		auto pinned = in_mem_storage->Get(block_key);
-		if (pinned && !ValidateVersionTag(pinned->VersionTag(), version_tag)) {
-			pinned.reset();
-			in_mem_storage->Delete(block_key);
-			local_filesystem->TryRemoveFile(cache_dest.dest_local_filepath);
-		}
+		auto pinned = in_mem_storage->Get(block_key, version_tag);
 		if (pinned) {
 			collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit, cache_read_chunk.bytes_to_copy);
 			DUCKDB_LOG_READ_CACHE_HIT((handle));

--- a/src/extension_bounded_data_cache_storage.cpp
+++ b/src/extension_bounded_data_cache_storage.cpp
@@ -15,16 +15,16 @@ void ExtensionBoundedDataCacheStorage::Put(InMemCacheBlock key, PageAlignedDataC
 	lru_cache.Put(std::move(key), std::move(entry));
 }
 
-unique_ptr<PinnedBlock> ExtensionBoundedDataCacheStorage::Get(const InMemCacheBlock &key) {
+optional<PinnedBlock> ExtensionBoundedDataCacheStorage::Get(const InMemCacheBlock &key) {
 	auto entry = lru_cache.Get(key);
 	if (entry == nullptr) {
-		return nullptr;
+		return nullopt;
 	}
 	// The shared_ptr<InMemCacheDataEntry> kept inside PinnedBlock pins the chunk for the read's duration.
 	const PageAlignedDataChunk *chunk_ptr = &entry->data;
 	string version_tag = entry->version_tag;
 	shared_ptr<void> keep_alive = std::move(entry);
-	return make_uniq<PinnedBlock>(std::move(keep_alive), chunk_ptr, std::move(version_tag));
+	return PinnedBlock {std::move(keep_alive), chunk_ptr, std::move(version_tag)};
 }
 
 bool ExtensionBoundedDataCacheStorage::Delete(const InMemCacheBlock &key) {

--- a/src/extension_bounded_data_cache_storage.cpp
+++ b/src/extension_bounded_data_cache_storage.cpp
@@ -15,16 +15,20 @@ void ExtensionBoundedDataCacheStorage::Put(InMemCacheBlock key, PageAlignedDataC
 	lru_cache.Put(std::move(key), std::move(entry));
 }
 
-optional<PinnedBlock> ExtensionBoundedDataCacheStorage::Get(const InMemCacheBlock &key) {
+optional<PinnedBlock> ExtensionBoundedDataCacheStorage::Get(const InMemCacheBlock &key,
+                                                            const string &expected_version_tag) {
 	auto entry = lru_cache.Get(key);
 	if (entry == nullptr) {
 		return nullopt;
 	}
-	// The shared_ptr<InMemCacheDataEntry> kept inside PinnedBlock pins the chunk for the read's duration.
+	if (!PinnedBlock::ValidateVersionTag(entry->version_tag, expected_version_tag)) {
+		lru_cache.Delete(key);
+		return nullopt;
+	}
+
 	const PageAlignedDataChunk *chunk_ptr = &entry->data;
-	string version_tag = entry->version_tag;
 	shared_ptr<void> keep_alive = std::move(entry);
-	return PinnedBlock {std::move(keep_alive), chunk_ptr, std::move(version_tag)};
+	return PinnedBlock {std::move(keep_alive), chunk_ptr};
 }
 
 bool ExtensionBoundedDataCacheStorage::Delete(const InMemCacheBlock &key) {

--- a/src/extension_bounded_data_cache_storage.cpp
+++ b/src/extension_bounded_data_cache_storage.cpp
@@ -1,17 +1,30 @@
 #include "extension_bounded_data_cache_storage.hpp"
 
+#include "duckdb/common/helper.hpp"
+
 namespace duckdb {
 
 ExtensionBoundedDataCacheStorage::ExtensionBoundedDataCacheStorage(size_t max_entries, uint64_t timeout_millisec)
     : lru_cache(max_entries, timeout_millisec) {
 }
 
-void ExtensionBoundedDataCacheStorage::Put(InMemCacheBlock key, shared_ptr<InMemCacheDataEntry> value) {
-	lru_cache.Put(std::move(key), std::move(value));
+void ExtensionBoundedDataCacheStorage::Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) {
+	auto entry = make_shared_ptr<InMemCacheDataEntry>();
+	entry->data = std::move(chunk);
+	entry->version_tag = std::move(version_tag);
+	lru_cache.Put(std::move(key), std::move(entry));
 }
 
-shared_ptr<InMemCacheDataEntry> ExtensionBoundedDataCacheStorage::Get(const InMemCacheBlock &key) {
-	return lru_cache.Get(key);
+unique_ptr<PinnedBlock> ExtensionBoundedDataCacheStorage::Get(const InMemCacheBlock &key) {
+	auto entry = lru_cache.Get(key);
+	if (entry == nullptr) {
+		return nullptr;
+	}
+	// The shared_ptr<InMemCacheDataEntry> kept inside PinnedBlock pins the chunk for the read's duration.
+	const PageAlignedDataChunk *chunk_ptr = &entry->data;
+	string version_tag = entry->version_tag;
+	shared_ptr<void> keep_alive = std::move(entry);
+	return make_uniq<PinnedBlock>(std::move(keep_alive), chunk_ptr, std::move(version_tag));
 }
 
 bool ExtensionBoundedDataCacheStorage::Delete(const InMemCacheBlock &key) {

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -45,15 +45,6 @@ InMemoryCacheReaderConfig GetConfig(const CacheHttpfsInstanceState &instance_sta
 
 } // namespace
 
-namespace {
-
-// Empty version_tag means cache validation is disabled => always valid.
-bool ValidateVersionTag(const string &cached, const string &expected) {
-	return expected.empty() || cached == expected;
-}
-
-} // namespace
-
 void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string &version_tag,
                                                 CacheReadChunk cache_read_chunk) {
 	SetThreadName("RdCachRdThd");
@@ -65,13 +56,7 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
 	// Check local cache first, see if we could do a cached read.
 	const InMemCacheBlock block_key {handle.GetPath(), cache_read_chunk.aligned_start_offset,
 	                                 cache_read_chunk.chunk_size};
-	auto pinned = storage->Get(block_key);
-
-	// Check cache entry validity and clear if necessary.
-	if (pinned && !ValidateVersionTag(pinned->VersionTag(), version_tag)) {
-		pinned.reset();
-		storage->Delete(block_key);
-	}
+	auto pinned = storage->Get(block_key, version_tag);
 
 	if (pinned) {
 		collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit, cache_read_chunk.bytes_to_copy);

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -45,13 +45,14 @@ InMemoryCacheReaderConfig GetConfig(const CacheHttpfsInstanceState &instance_sta
 
 } // namespace
 
-bool InMemoryCacheReader::ValidateCacheEntry(const InMemCacheDataEntry &cache_entry, const string &version_tag) {
-	// Empty version tags means cache validation is disabled.
-	if (version_tag.empty()) {
-		return true;
-	}
-	return cache_entry.version_tag == version_tag;
+namespace {
+
+// Empty version_tag means cache validation is disabled => always valid.
+bool ValidateVersionTag(const string &cached, const string &expected) {
+	return expected.empty() || cached == expected;
 }
+
+} // namespace
 
 void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string &version_tag,
                                                 CacheReadChunk cache_read_chunk) {
@@ -64,18 +65,18 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
 	// Check local cache first, see if we could do a cached read.
 	const InMemCacheBlock block_key {handle.GetPath(), cache_read_chunk.aligned_start_offset,
 	                                 cache_read_chunk.chunk_size};
-	auto cache_entry = storage->Get(block_key);
+	auto pinned = storage->Get(block_key);
 
 	// Check cache entry validity and clear if necessary.
-	if (cache_entry != nullptr && !ValidateCacheEntry(*cache_entry, version_tag)) {
+	if (pinned && !ValidateVersionTag(pinned->VersionTag(), version_tag)) {
+		pinned.reset();
 		storage->Delete(block_key);
-		cache_entry = nullptr;
 	}
 
-	if (cache_entry != nullptr) {
+	if (pinned) {
 		collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit, cache_read_chunk.bytes_to_copy);
 		DUCKDB_LOG_OPEN_CACHE_HIT((handle));
-		cache_read_chunk.CopyBufferToRequestedMemory(cache_entry->data);
+		cache_read_chunk.CopyBufferToRequestedMemory(pinned->Data());
 		return;
 	}
 
@@ -96,11 +97,7 @@ void InMemoryCacheReader::ProcessCacheReadChunk(FileHandle &handle, const string
 	// Copy to destination buffer.
 	cache_read_chunk.CopyBufferToRequestedMemory(content);
 
-	InMemCacheDataEntry new_cache_entry {
-	    .data = std::move(content),
-	    .version_tag = version_tag,
-	};
-	storage->Put(std::move(block_key), make_shared_ptr<InMemCacheDataEntry>(std::move(new_cache_entry)));
+	storage->Put(std::move(block_key), std::move(content), version_tag);
 }
 
 void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t requested_start_offset,
@@ -112,8 +109,8 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 	const auto config = GetConfig(*instance_state.lock());
 
 	std::call_once(cache_init_flag, [this, &config]() {
-		storage = make_uniq<ExtensionBoundedDataCacheStorage>(config.max_cache_block_count,
-		                                                      config.cache_block_timeout_millisec);
+		storage = make_shared_ptr<ExtensionBoundedDataCacheStorage>(config.max_cache_block_count,
+		                                                            config.cache_block_timeout_millisec);
 	});
 
 	const idx_t block_size = config.cache_block_size;
@@ -256,7 +253,8 @@ void InMemoryCacheReader::RemapInMemoryDataBlocksForNewBlockSize(idx_t new_block
 	// TODO: pass known remote file sizes (e.g. from metadata cache) so remap matches EOF behavior of real reads.
 	auto rebuilt = RemapInMemCacheEntries(std::move(taken), new_block_size, /*file_size_by_path=*/ {});
 	for (auto &kv : rebuilt) {
-		storage->Put(std::move(kv.first), std::move(kv.second));
+		auto &entry = kv.second;
+		storage->Put(std::move(kv.first), std::move(entry->data), std::move(entry->version_tag));
 	}
 }
 

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -165,9 +165,8 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 
 	// Extension config for the current duckdb instance.
 	InstanceConfig config;
-	// Database config.
-	optional_ptr<DBConfig> db_config;
-	// Database instance. Set in LoadInternal so storage backends can reach `GetObjectCache()`.
+	// Database instance; instance state is the stored in object cache (which is part of db instance), so data member is
+	// guanranteed valid.
 	optional_ptr<DatabaseInstance> db_instance;
 	// Cache filesystem registry.
 	InstanceCacheFsRegistry registry;

--- a/src/include/cache_httpfs_instance_state.hpp
+++ b/src/include/cache_httpfs_instance_state.hpp
@@ -167,6 +167,8 @@ struct CacheHttpfsInstanceState : public ObjectCacheEntry {
 	InstanceConfig config;
 	// Database config.
 	optional_ptr<DBConfig> db_config;
+	// Database instance. Set in LoadInternal so storage backends can reach `GetObjectCache()`.
+	optional_ptr<DatabaseInstance> db_instance;
 	// Cache filesystem registry.
 	InstanceCacheFsRegistry registry;
 	InstanceCacheReaderManager cache_reader_manager;

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -47,9 +47,6 @@ public:
 	string EvictCacheBlockLru();
 
 private:
-	// Return whether the given cache entry is still valid and usable.
-	bool ValidateCacheEntry(const InMemCacheDataEntry &cache_entry, const string &version_tag);
-
 	// Process a single cache read chunk in a worker thread.
 	void ProcessCacheReadChunk(FileHandle &handle, const InstanceConfig &config, const string &version_tag,
 	                           CacheReadChunk cache_read_chunk);
@@ -66,7 +63,8 @@ private:
 	// In-memory cache to store blocks; late initialized after first access.
 	// Used to avoid local disk IO.
 	// NOTICE: cache key uses remote filepath, instead of local cache filepath.
-	unique_ptr<InMemoryDataCacheStorage> in_mem_storage;
+	// shared_ptr so the `ObjectCacheStorage` backend (M2) can hand out weak_ptr back-refs to its blocks.
+	shared_ptr<InMemoryDataCacheStorage> in_mem_storage;
 };
 
 } // namespace duckdb

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -63,7 +63,6 @@ private:
 	// In-memory cache to store blocks; late initialized after first access.
 	// Used to avoid local disk IO.
 	// NOTICE: cache key uses remote filepath, instead of local cache filepath.
-	// shared_ptr so the `ObjectCacheStorage` backend (M2) can hand out weak_ptr back-refs to its blocks.
 	shared_ptr<InMemoryDataCacheStorage> in_mem_storage;
 };
 

--- a/src/include/extension_bounded_data_cache_storage.hpp
+++ b/src/include/extension_bounded_data_cache_storage.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "in_memory_data_cache_storage.hpp"
 #include "shared_value_lru_cache.hpp"
@@ -23,8 +24,8 @@ public:
 
 	~ExtensionBoundedDataCacheStorage() override = default;
 
-	void Put(InMemCacheBlock key, shared_ptr<InMemCacheDataEntry> value) override;
-	shared_ptr<InMemCacheDataEntry> Get(const InMemCacheBlock &key) override;
+	void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) override;
+	unique_ptr<PinnedBlock> Get(const InMemCacheBlock &key) override;
 	bool Delete(const InMemCacheBlock &key) override;
 	void Clear() override;
 	void Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) override;

--- a/src/include/extension_bounded_data_cache_storage.hpp
+++ b/src/include/extension_bounded_data_cache_storage.hpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 
 #include "duckdb/common/shared_ptr.hpp"
-#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "in_memory_data_cache_storage.hpp"
 #include "shared_value_lru_cache.hpp"
@@ -25,7 +24,7 @@ public:
 	~ExtensionBoundedDataCacheStorage() override = default;
 
 	void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) override;
-	unique_ptr<PinnedBlock> Get(const InMemCacheBlock &key) override;
+	optional<PinnedBlock> Get(const InMemCacheBlock &key) override;
 	bool Delete(const InMemCacheBlock &key) override;
 	void Clear() override;
 	void Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) override;

--- a/src/include/extension_bounded_data_cache_storage.hpp
+++ b/src/include/extension_bounded_data_cache_storage.hpp
@@ -24,7 +24,7 @@ public:
 	~ExtensionBoundedDataCacheStorage() override = default;
 
 	void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) override;
-	optional<PinnedBlock> Get(const InMemCacheBlock &key) override;
+	optional<PinnedBlock> Get(const InMemCacheBlock &key, const string &expected_version_tag) override;
 	bool Delete(const InMemCacheBlock &key) override;
 	void Clear() override;
 	void Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) override;

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -38,16 +38,14 @@ public:
 	void RemapInMemoryDataBlocksForNewBlockSize(idx_t new_block_size) override;
 
 private:
-	// Return whether the given cache entry is still valid and usable.
-	bool ValidateCacheEntry(const InMemCacheDataEntry &cache_entry, const string &version_tag);
-
 	// Process a single cache read chunk in a worker thread.
 	void ProcessCacheReadChunk(FileHandle &handle, const string &version_tag, CacheReadChunk cache_read_chunk);
 
 	// Once flag to guard against cache's initialization.
 	std::once_flag cache_init_flag;
 	// In-memory cache to store blocks; late initialized after first access.
-	unique_ptr<InMemoryDataCacheStorage> storage;
+	// shared_ptr so the `ObjectCacheStorage` backend (M2) can hand out weak_ptr back-refs to its blocks.
+	shared_ptr<InMemoryDataCacheStorage> storage;
 };
 
 } // namespace duckdb

--- a/src/include/in_memory_cache_reader.hpp
+++ b/src/include/in_memory_cache_reader.hpp
@@ -44,7 +44,6 @@ private:
 	// Once flag to guard against cache's initialization.
 	std::once_flag cache_init_flag;
 	// In-memory cache to store blocks; late initialized after first access.
-	// shared_ptr so the `ObjectCacheStorage` backend (M2) can hand out weak_ptr back-refs to its blocks.
 	shared_ptr<InMemoryDataCacheStorage> storage;
 };
 

--- a/src/include/in_memory_data_cache_storage.hpp
+++ b/src/include/in_memory_data_cache_storage.hpp
@@ -23,21 +23,21 @@ namespace duckdb {
 // which pins the block against concurrent eviction for the duration of the read.
 class PinnedBlock {
 public:
-	PinnedBlock(shared_ptr<void> keep_alive, const PageAlignedDataChunk *chunk, string version_tag)
-	    : keep_alive_(std::move(keep_alive)), chunk_(chunk), version_tag_(std::move(version_tag)) {
+	PinnedBlock(shared_ptr<void> keep_alive_p, const PageAlignedDataChunk *chunk_p, string version_tag_p)
+	    : keep_alive(std::move(keep_alive_p)), chunk(chunk_p), version_tag(std::move(version_tag_p)) {
 	}
 
 	const PageAlignedDataChunk &Data() const {
-		return *chunk_;
+		return *chunk;
 	}
 	const string &VersionTag() const {
-		return version_tag_;
+		return version_tag;
 	}
 
 private:
-	shared_ptr<void> keep_alive_;
-	const PageAlignedDataChunk *chunk_;
-	string version_tag_;
+	shared_ptr<void> keep_alive;
+	const PageAlignedDataChunk *chunk;
+	string version_tag;
 };
 
 class InMemoryDataCacheStorage {

--- a/src/include/in_memory_data_cache_storage.hpp
+++ b/src/include/in_memory_data_cache_storage.hpp
@@ -30,6 +30,7 @@ public:
 
 private:
 	shared_ptr<void> keep_alive;
+	// Owned by `keep_alive`.
 	const PageAlignedDataChunk *chunk;
 	string version_tag;
 };
@@ -42,7 +43,6 @@ public:
 	virtual void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) = 0;
 
 	// Returns nullopt on miss or if the entry is no longer valid (e.g. timed out).
-	// The returned PinnedBlock pins the underlying bytes for the duration of its lifetime.
 	virtual optional<PinnedBlock> Get(const InMemCacheBlock &key) = 0;
 
 	// Returns true if [key] was present and removed.
@@ -57,8 +57,7 @@ public:
 	// Snapshot of currently-live keys; ordering is unspecified.
 	virtual vector<InMemCacheBlock> Keys() const = 0;
 
-	// Drain all entries. Each returned entry owns its chunk (in `object_cache` mode the corresponding
-	// ObjectCache entry has been removed before the chunk was moved out).
+	// Drain all entries.
 	virtual vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> Take() = 0;
 };
 

--- a/src/include/in_memory_data_cache_storage.hpp
+++ b/src/include/in_memory_data_cache_storage.hpp
@@ -17,22 +17,22 @@ namespace duckdb {
 
 class PinnedBlock {
 public:
-	PinnedBlock(shared_ptr<void> keep_alive_p, const PageAlignedDataChunk *chunk_p, string version_tag_p)
-	    : keep_alive(std::move(keep_alive_p)), chunk(chunk_p), version_tag(std::move(version_tag_p)) {
+	PinnedBlock(shared_ptr<void> keep_alive_p, const PageAlignedDataChunk *chunk_p)
+	    : keep_alive(std::move(keep_alive_p)), chunk(chunk_p) {
 	}
 
 	const PageAlignedDataChunk &Data() const {
 		return *chunk;
 	}
-	const string &VersionTag() const {
-		return version_tag;
+
+	static bool ValidateVersionTag(const string &cached, const string &expected_version_tag) {
+		return expected_version_tag.empty() || cached == expected_version_tag;
 	}
 
 private:
 	shared_ptr<void> keep_alive;
 	// Owned by `keep_alive`.
 	const PageAlignedDataChunk *chunk;
-	string version_tag;
 };
 
 class InMemoryDataCacheStorage {
@@ -42,8 +42,8 @@ public:
 	// Insert or replace the entry for [key]. Storage takes ownership of [chunk].
 	virtual void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) = 0;
 
-	// Returns nullopt on miss or if the entry is no longer valid (e.g. timed out).
-	virtual optional<PinnedBlock> Get(const InMemCacheBlock &key) = 0;
+	// Returns nullopt on miss or if the entry is no longer valid (e.g. timed out, version mismatch).
+	virtual optional<PinnedBlock> Get(const InMemCacheBlock &key, const string &expected_version_tag) = 0;
 
 	// Returns true if [key] was present and removed.
 	virtual bool Delete(const InMemCacheBlock &key) = 0;

--- a/src/include/in_memory_data_cache_storage.hpp
+++ b/src/include/in_memory_data_cache_storage.hpp
@@ -7,20 +7,14 @@
 
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/string.hpp"
-#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "in_mem_cache_block.hpp"
 #include "in_mem_cache_data_entry.hpp"
+#include "optional.hpp"
 #include "page_aligned_data_chunk.hpp"
 
 namespace duckdb {
 
-// RAII view over a cached block returned by `InMemoryDataCacheStorage::Get`.
-// The block stays alive (and the underlying bytes valid) for the lifetime of the PinnedBlock.
-//
-// In `extension` mode `keep_alive` owns a `shared_ptr<InMemCacheDataEntry>` (the LRU map's value).
-// In `object_cache` mode it owns a `shared_ptr<CacheHttpfsDataBlock>` fetched from ObjectCache,
-// which pins the block against concurrent eviction for the duration of the read.
 class PinnedBlock {
 public:
 	PinnedBlock(shared_ptr<void> keep_alive_p, const PageAlignedDataChunk *chunk_p, string version_tag_p)
@@ -47,9 +41,9 @@ public:
 	// Insert or replace the entry for [key]. Storage takes ownership of [chunk].
 	virtual void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) = 0;
 
-	// Returns nullptr on miss or if the entry is no longer valid (e.g. timed out).
+	// Returns nullopt on miss or if the entry is no longer valid (e.g. timed out).
 	// The returned PinnedBlock pins the underlying bytes for the duration of its lifetime.
-	virtual unique_ptr<PinnedBlock> Get(const InMemCacheBlock &key) = 0;
+	virtual optional<PinnedBlock> Get(const InMemCacheBlock &key) = 0;
 
 	// Returns true if [key] was present and removed.
 	virtual bool Delete(const InMemCacheBlock &key) = 0;

--- a/src/include/in_memory_data_cache_storage.hpp
+++ b/src/include/in_memory_data_cache_storage.hpp
@@ -6,21 +6,50 @@
 #include <utility>
 
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "in_mem_cache_block.hpp"
 #include "in_mem_cache_data_entry.hpp"
+#include "page_aligned_data_chunk.hpp"
 
 namespace duckdb {
+
+// RAII view over a cached block returned by `InMemoryDataCacheStorage::Get`.
+// The block stays alive (and the underlying bytes valid) for the lifetime of the PinnedBlock.
+//
+// In `extension` mode `keep_alive` owns a `shared_ptr<InMemCacheDataEntry>` (the LRU map's value).
+// In `object_cache` mode it owns a `shared_ptr<CacheHttpfsDataBlock>` fetched from ObjectCache,
+// which pins the block against concurrent eviction for the duration of the read.
+class PinnedBlock {
+public:
+	PinnedBlock(shared_ptr<void> keep_alive, const PageAlignedDataChunk *chunk, string version_tag)
+	    : keep_alive_(std::move(keep_alive)), chunk_(chunk), version_tag_(std::move(version_tag)) {
+	}
+
+	const PageAlignedDataChunk &Data() const {
+		return *chunk_;
+	}
+	const string &VersionTag() const {
+		return version_tag_;
+	}
+
+private:
+	shared_ptr<void> keep_alive_;
+	const PageAlignedDataChunk *chunk_;
+	string version_tag_;
+};
 
 class InMemoryDataCacheStorage {
 public:
 	virtual ~InMemoryDataCacheStorage() = default;
 
-	// Insert or replace the entry for [key].
-	virtual void Put(InMemCacheBlock key, shared_ptr<InMemCacheDataEntry> value) = 0;
+	// Insert or replace the entry for [key]. Storage takes ownership of [chunk].
+	virtual void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) = 0;
 
 	// Returns nullptr on miss or if the entry is no longer valid (e.g. timed out).
-	virtual shared_ptr<InMemCacheDataEntry> Get(const InMemCacheBlock &key) = 0;
+	// The returned PinnedBlock pins the underlying bytes for the duration of its lifetime.
+	virtual unique_ptr<PinnedBlock> Get(const InMemCacheBlock &key) = 0;
 
 	// Returns true if [key] was present and removed.
 	virtual bool Delete(const InMemCacheBlock &key) = 0;
@@ -34,7 +63,8 @@ public:
 	// Snapshot of currently-live keys; ordering is unspecified.
 	virtual vector<InMemCacheBlock> Keys() const = 0;
 
-	// Drain all entries.
+	// Drain all entries. Each returned entry owns its chunk (in `object_cache` mode the corresponding
+	// ObjectCache entry has been removed before the chunk was moved out).
 	virtual vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> Take() = 0;
 };
 

--- a/src/include/object_cache_data_cache_storage.hpp
+++ b/src/include/object_cache_data_cache_storage.hpp
@@ -10,7 +10,6 @@
 #include "duckdb/common/optional_ptr.hpp"
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/string.hpp"
-#include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "in_mem_cache_block.hpp"
 #include "in_memory_data_cache_storage.hpp"
@@ -38,7 +37,7 @@ public:
 	~ObjectCacheStorage() override;
 
 	void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) override;
-	unique_ptr<PinnedBlock> Get(const InMemCacheBlock &key) override;
+	optional<PinnedBlock> Get(const InMemCacheBlock &key) override;
 	bool Delete(const InMemCacheBlock &key) override;
 	void Clear() override;
 	void Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) override;

--- a/src/include/object_cache_data_cache_storage.hpp
+++ b/src/include/object_cache_data_cache_storage.hpp
@@ -1,0 +1,69 @@
+// ObjectCache-backed in-memory data block cache.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <utility>
+
+#include "duckdb/common/map.hpp"
+#include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include "in_mem_cache_block.hpp"
+#include "in_memory_data_cache_storage.hpp"
+#include "mutex.hpp"
+#include "thread_annotation.hpp"
+
+namespace duckdb {
+
+// Forward declarations.
+class DatabaseInstance;
+struct CacheHttpfsDataBlock;
+
+// ObjectCache-backed in-memory data block cache.
+//
+// Blocks are page-aligned, allocated by the reader. Byte-cap LRU eviction is delegated to
+// ObjectCache. A metadata-only map is kept for status queries.
+class ObjectCacheStorage final : public InMemoryDataCacheStorage, public enable_shared_from_this<ObjectCacheStorage> {
+public:
+	// @param timeout_millisec: 0 disables lazy timeout-based eviction; ObjectCache LRU still applies.
+	ObjectCacheStorage(DatabaseInstance &db_instance, uint64_t timeout_millisec);
+
+	ObjectCacheStorage(const ObjectCacheStorage &) = delete;
+	ObjectCacheStorage &operator=(const ObjectCacheStorage &) = delete;
+
+	~ObjectCacheStorage() override;
+
+	void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) override;
+	unique_ptr<PinnedBlock> Get(const InMemCacheBlock &key) override;
+	bool Delete(const InMemCacheBlock &key) override;
+	void Clear() override;
+	void Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) override;
+	vector<InMemCacheBlock> Keys() const override;
+	vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> Take() override;
+
+	void OnEntryDestroyed(const InMemCacheBlock &key, const CacheHttpfsDataBlock *block) noexcept;
+
+private:
+	struct EntryMeta {
+		string oc_key;
+		idx_t length = 0;
+		string version_tag;
+		uint64_t insertion_time_ms = 0;
+		// Identity of the block currently installed under `oc_key`. The destructor compares against
+		// this so a lingering ~CacheHttpfsDataBlock from a previously-displaced block cannot evict
+		// the metadata of the block that replaced it.
+		const CacheHttpfsDataBlock *block_ptr = nullptr;
+	};
+
+	DatabaseInstance &db_instance;
+	const uint64_t timeout_millisec;
+
+	mutable concurrency::mutex mu;
+	map<InMemCacheBlock, EntryMeta, InMemCacheBlockLess> entries DUCKDB_GUARDED_BY(mu);
+};
+
+} // namespace duckdb

--- a/src/include/object_cache_data_cache_storage.hpp
+++ b/src/include/object_cache_data_cache_storage.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <utility>
@@ -44,7 +45,7 @@ public:
 	vector<InMemCacheBlock> Keys() const override;
 	vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> Take() override;
 
-	void OnEntryDestroyed(const InMemCacheBlock &key, const CacheHttpfsDataBlock *block) noexcept;
+	void OnEntryDestroyed(const InMemCacheBlock &key, uint64_t block_id) noexcept;
 
 private:
 	struct EntryMeta {
@@ -52,12 +53,14 @@ private:
 		idx_t length = 0;
 		string version_tag;
 		uint64_t insertion_time_ms = 0;
-		const CacheHttpfsDataBlock *block_ptr = nullptr;
+		uint64_t block_id = 0;
 	};
 
 	DatabaseInstance &db_instance;
 	// TODO(hjiang): the extension provides configurable timeout.
 	const uint64_t timeout_millisec;
+	// Monotonically increasing per-storage-instance counter used to identify a block.
+	std::atomic<uint64_t> next_block_id {0};
 
 	mutable concurrency::mutex mu;
 	// Record to clear all cache entries, use ordered map for range query.

--- a/src/include/object_cache_data_cache_storage.hpp
+++ b/src/include/object_cache_data_cache_storage.hpp
@@ -37,7 +37,7 @@ public:
 	~ObjectCacheStorage() override;
 
 	void Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) override;
-	optional<PinnedBlock> Get(const InMemCacheBlock &key) override;
+	optional<PinnedBlock> Get(const InMemCacheBlock &key, const string &expected_version_tag) override;
 	bool Delete(const InMemCacheBlock &key) override;
 	void Clear() override;
 	void Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) override;

--- a/src/include/object_cache_data_cache_storage.hpp
+++ b/src/include/object_cache_data_cache_storage.hpp
@@ -48,13 +48,10 @@ public:
 
 private:
 	struct EntryMeta {
-		string oc_key;
+		string obj_cache_key;
 		idx_t length = 0;
 		string version_tag;
 		uint64_t insertion_time_ms = 0;
-		// Identity of the block currently installed under `oc_key`. The destructor compares against
-		// this so a lingering ~CacheHttpfsDataBlock from a previously-displaced block cannot evict
-		// the metadata of the block that replaced it.
 		const CacheHttpfsDataBlock *block_ptr = nullptr;
 	};
 
@@ -62,6 +59,9 @@ private:
 	const uint64_t timeout_millisec;
 
 	mutable concurrency::mutex mu;
+	// Record to clear all cache entries, use ordered map for range query.
+	// When a cache entry is evicted from object cache, it's also removed from `entries` to keep consistency and avoid
+	// memory leak.
 	map<InMemCacheBlock, EntryMeta, InMemCacheBlockLess> entries DUCKDB_GUARDED_BY(mu);
 };
 

--- a/src/include/object_cache_data_cache_storage.hpp
+++ b/src/include/object_cache_data_cache_storage.hpp
@@ -56,6 +56,7 @@ private:
 	};
 
 	DatabaseInstance &db_instance;
+	// TODO(hjiang): the extension provides configurable timeout.
 	const uint64_t timeout_millisec;
 
 	mutable concurrency::mutex mu;

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -93,7 +93,7 @@ void ObjectCacheStorage::Put(InMemCacheBlock key, PageAlignedDataChunk chunk, st
 	}
 }
 
-unique_ptr<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
+optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 	string oc_key;
 	string version_tag;
 	bool stale = false;
@@ -101,7 +101,7 @@ unique_ptr<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
 		auto it = entries.find(key);
 		if (it == entries.end()) {
-			return nullptr;
+			return nullopt;
 		}
 		oc_key = it->second.oc_key;
 		version_tag = it->second.version_tag;
@@ -117,19 +117,19 @@ unique_ptr<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 	if (stale) {
 		// Outside the lock: destructor finalises the map removal.
 		oc.Delete(oc_key);
-		return nullptr;
+		return nullopt;
 	}
 
 	auto block = oc.Get<CacheHttpfsDataBlock>(oc_key);
 	if (block == nullptr) {
 		// OC LRU just evicted; destructor either fired already (map cleaned) or will fire when
 		// the lingering shared_ref drops. Treat as a miss.
-		return nullptr;
+		return nullopt;
 	}
 
 	const PageAlignedDataChunk *chunk_ptr = &block->data;
 	shared_ptr<void> keep_alive = std::move(block);
-	return make_uniq<PinnedBlock>(std::move(keep_alive), chunk_ptr, std::move(version_tag));
+	return PinnedBlock {std::move(keep_alive), chunk_ptr, std::move(version_tag)};
 }
 
 bool ObjectCacheStorage::Delete(const InMemCacheBlock &key) {

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -22,14 +22,16 @@ struct CacheHttpfsDataBlock : public ObjectCacheEntry {
 	InMemCacheBlock key;
 	weak_ptr<ObjectCacheStorage> storage;
 	PageAlignedDataChunk data;
+	uint64_t block_id;
 
-	CacheHttpfsDataBlock(InMemCacheBlock key_p, weak_ptr<ObjectCacheStorage> storage_p, PageAlignedDataChunk data_p)
-	    : key(std::move(key_p)), storage(std::move(storage_p)), data(std::move(data_p)) {
+	CacheHttpfsDataBlock(InMemCacheBlock key_p, weak_ptr<ObjectCacheStorage> storage_p, PageAlignedDataChunk data_p,
+	                     uint64_t block_id_p)
+	    : key(std::move(key_p)), storage(std::move(storage_p)), data(std::move(data_p)), block_id(block_id_p) {
 	}
 
 	~CacheHttpfsDataBlock() override {
 		if (auto s = storage.lock()) {
-			s->OnEntryDestroyed(key, this);
+			s->OnEntryDestroyed(key, block_id);
 		}
 	}
 
@@ -70,19 +72,19 @@ void ObjectCacheStorage::Put(InMemCacheBlock key, PageAlignedDataChunk chunk, st
 	string obj_cache_key = MakeObjCacheKey(key);
 	const idx_t length = chunk.length;
 	const uint64_t now = NumericCast<uint64_t>(GetSteadyNowMilliSecSinceEpoch());
+	const uint64_t block_id = next_block_id.fetch_add(1);
 
-	auto block =
-	    make_shared_ptr<CacheHttpfsDataBlock>(key, weak_ptr<ObjectCacheStorage>(shared_from_this()), std::move(chunk));
-	const CacheHttpfsDataBlock *block_ptr = block.get();
+	auto block = make_shared_ptr<CacheHttpfsDataBlock>(key, weak_ptr<ObjectCacheStorage>(shared_from_this()),
+	                                                   std::move(chunk), block_id);
 
 	EntryMeta meta;
-	meta.obj_cache_key = std::move(obj_cache_key);
+	meta.obj_cache_key = obj_cache_key;
 	meta.length = length;
 	meta.version_tag = std::move(version_tag);
 	meta.insertion_time_ms = now;
-	meta.block_ptr = block_ptr;
+	meta.block_id = block_id;
 
-	db_instance.GetObjectCache().Put(obj_cache_key, std::move(block));
+	db_instance.GetObjectCache().Put(std::move(obj_cache_key), std::move(block));
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
 		entries[std::move(key)] = std::move(meta);
@@ -219,13 +221,13 @@ vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> ObjectCacheS
 	return result;
 }
 
-void ObjectCacheStorage::OnEntryDestroyed(const InMemCacheBlock &key, const CacheHttpfsDataBlock *block) noexcept {
+void ObjectCacheStorage::OnEntryDestroyed(const InMemCacheBlock &key, uint64_t block_id) noexcept {
 	const concurrency::lock_guard<concurrency::mutex> lock(mu);
 	auto it = entries.find(key);
 	if (it == entries.end()) {
 		return;
 	}
-	if (it->second.block_ptr != block) {
+	if (it->second.block_id != block_id) {
 		// A newer block has replaced this one; preserve the new metadata.
 		return;
 	}

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -111,15 +111,13 @@ optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 
 	auto &obj_cache = db_instance.GetObjectCache();
 	if (stale) {
-		// Outside the lock: destructor finalises the map removal.
+		// `entries` is deleted by object cache entry deletion callback.
 		obj_cache.Delete(obj_cache_key);
 		return nullopt;
 	}
 
 	auto block = obj_cache.Get<CacheHttpfsDataBlock>(obj_cache_key);
 	if (block == nullptr) {
-		// ObjectCache LRU just evicted; destructor either fired already (map cleaned) or will fire
-		// when the lingering shared_ref drops. Treat as a miss.
 		return nullopt;
 	}
 
@@ -136,34 +134,29 @@ bool ObjectCacheStorage::Delete(const InMemCacheBlock &key) {
 		if (it == entries.end()) {
 			return false;
 		}
-		// The map entry is about to be erased by `OnEntryDestroyed`; safe to steal the string.
-		// A racing `Get` on the same key would see an empty `obj_cache_key` and just miss, which
-		// is fine since the block is being deleted anyway.
-		obj_cache_key = std::move(it->second.obj_cache_key);
+		// Don't move the object cache key out, since we could have concurrent access.
+		obj_cache_key = it->second.obj_cache_key;
 	}
+	// `entries` is deleted by object cache entry deletion callback.
 	db_instance.GetObjectCache().Delete(obj_cache_key);
 	return true;
 }
 
 void ObjectCacheStorage::Clear() {
-	// Snapshot ObjectCache keys under the lock, then call ObjectCache outside it (destructors
-	// re-enter `mu`). We move the strings out of the map: callbacks erase the entries shortly
-	// after anyway, so the moved-from values are inert; a racing `Get` would observe an empty
-	// `obj_cache_key` => miss, which is the desired behaviour during Clear.
+	auto &obj_cache = db_instance.GetObjectCache();
 	vector<string> obj_cache_keys;
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
 		obj_cache_keys.reserve(entries.size());
 		for (auto &kv : entries) {
-			obj_cache_keys.push_back(std::move(kv.second.obj_cache_key));
+			// Don't move the object cache key out, since we could have concurrent access.
+			obj_cache_keys.emplace_back(kv.second.obj_cache_key);
 		}
 	}
-	auto &obj_cache = db_instance.GetObjectCache();
+	// `entries` is deleted by object cache entry deletion callback.
 	for (const auto &obj_cache_key : obj_cache_keys) {
 		obj_cache.Delete(obj_cache_key);
 	}
-	// Map cleanup happens via destructor callbacks. Entries pinned by in-flight `Get`s linger
-	// until those readers release; the map drains as those refs drop.
 }
 
 void ObjectCacheStorage::Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) {
@@ -174,7 +167,8 @@ void ObjectCacheStorage::Clear(const InMemCacheBlock &start_key, std::function<b
 			if (!filter(it->first)) {
 				break;
 			}
-			obj_cache_keys.push_back(std::move(it->second.obj_cache_key));
+			// Don't move the object cache key out, since we could have concurrent access.
+			obj_cache_keys.emplace_back(it->second.obj_cache_key);
 		}
 	}
 	auto &obj_cache = db_instance.GetObjectCache();
@@ -188,7 +182,7 @@ vector<InMemCacheBlock> ObjectCacheStorage::Keys() const {
 	vector<InMemCacheBlock> keys;
 	keys.reserve(entries.size());
 	for (const auto &kv : entries) {
-		keys.push_back(kv.first);
+		keys.emplace_back(kv.first);
 	}
 	return keys;
 }
@@ -203,11 +197,8 @@ vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> ObjectCacheS
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
 		snapshot.reserve(entries.size());
-		for (auto &kv : entries) {
-			// The map entries will be erased by `OnEntryDestroyed` after we call ObjectCache::Delete;
-			// safe to move obj_cache_key / version_tag out now.
-			snapshot.push_back(
-			    Snapshot {kv.first, std::move(kv.second.obj_cache_key), std::move(kv.second.version_tag)});
+		for (const auto &kv : entries) {
+			snapshot.emplace_back(Snapshot {kv.first, kv.second.obj_cache_key, kv.second.version_tag});
 		}
 	}
 
@@ -220,15 +211,10 @@ vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> ObjectCacheS
 			continue;
 		}
 		auto entry = make_shared_ptr<InMemCacheDataEntry>();
-		// Move the chunk out before ObjectCache drops its ref; ObjectCache's accounting will still
-		// see the original reserved bytes when the buffer pool reservation is released by
-		// `~BufferPoolPayload`.
 		entry->data = std::move(block->data);
 		entry->version_tag = std::move(snap.version_tag);
 		result.emplace_back(std::move(snap.key), std::move(entry));
 		obj_cache.Delete(snap.obj_cache_key);
-		// Drop our local ref; ~CacheHttpfsDataBlock fires and `OnEntryDestroyed` erases the map entry.
-		block.reset();
 	}
 	return result;
 }

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -89,9 +89,8 @@ void ObjectCacheStorage::Put(InMemCacheBlock key, PageAlignedDataChunk chunk, st
 	}
 }
 
-optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
+optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key, const string &expected_version_tag) {
 	string obj_cache_key;
-	string version_tag;
 	bool stale = false;
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
@@ -100,8 +99,9 @@ optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 			return nullopt;
 		}
 		obj_cache_key = it->second.obj_cache_key;
-		version_tag = it->second.version_tag;
-		if (timeout_millisec > 0) {
+		if (!PinnedBlock::ValidateVersionTag(it->second.version_tag, expected_version_tag)) {
+			stale = true;
+		} else if (timeout_millisec > 0) {
 			const uint64_t now = static_cast<uint64_t>(GetSteadyNowMilliSecSinceEpoch());
 			if (now - it->second.insertion_time_ms > timeout_millisec) {
 				stale = true;
@@ -123,7 +123,7 @@ optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 
 	const PageAlignedDataChunk *chunk_ptr = &block->data;
 	shared_ptr<void> keep_alive = std::move(block);
-	return PinnedBlock {std::move(keep_alive), chunk_ptr, std::move(version_tag)};
+	return PinnedBlock {std::move(keep_alive), chunk_ptr};
 }
 
 bool ObjectCacheStorage::Delete(const InMemCacheBlock &key) {

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -46,7 +46,7 @@ struct CacheHttpfsDataBlock : public ObjectCacheEntry {
 	}
 };
 
-string MakeOcKey(const InMemCacheBlock &key) {
+string MakeObjCacheKey(const InMemCacheBlock &key) {
 	const SanitizedCachePath sanitized {key.fname};
 	return StringUtil::Format("cache_httpfs/data/%s:%llu:%llu", sanitized.Path(), key.start_off, key.blk_size);
 }
@@ -58,43 +58,39 @@ ObjectCacheStorage::ObjectCacheStorage(DatabaseInstance &db_instance_p, uint64_t
 }
 
 ObjectCacheStorage::~ObjectCacheStorage() {
-	auto &oc = db_instance.GetObjectCache();
+	auto &obj_cache = db_instance.GetObjectCache();
 	for (const auto &kv : entries) {
-		oc.Delete(kv.second.oc_key);
+		obj_cache.Delete(kv.second.obj_cache_key);
 	}
 }
 
 void ObjectCacheStorage::Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) {
 	ALWAYS_ASSERT(chunk.length > 0);
 
-	string oc_key = MakeOcKey(key);
+	string obj_cache_key = MakeObjCacheKey(key);
 	const idx_t length = chunk.length;
-	const uint64_t now = static_cast<uint64_t>(GetSteadyNowMilliSecSinceEpoch());
+	const uint64_t now = NumericCast<uint64_t>(GetSteadyNowMilliSecSinceEpoch());
 
-	// Wrap the chunk before touching OC so `weak_from_this()` is well-defined here.
 	auto block =
 	    make_shared_ptr<CacheHttpfsDataBlock>(key, weak_ptr<ObjectCacheStorage>(shared_from_this()), std::move(chunk));
 	const CacheHttpfsDataBlock *block_ptr = block.get();
 
-	// Install into OC without holding `mu`. If this displaces an existing entry under `oc_key`,
-	// the displaced block's destructor fires on this thread (no other refs => refcount goes to 0
-	// inside the LRU's replace path) and `OnEntryDestroyed` erases its map entry before we return.
-	db_instance.GetObjectCache().Put(oc_key, std::move(block));
+	EntryMeta meta;
+	meta.obj_cache_key = std::move(obj_cache_key);
+	meta.length = length;
+	meta.version_tag = std::move(version_tag);
+	meta.insertion_time_ms = now;
+	meta.block_ptr = block_ptr;
 
+	db_instance.GetObjectCache().Put(obj_cache_key, std::move(block));
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
-		EntryMeta meta;
-		meta.oc_key = std::move(oc_key);
-		meta.length = length;
-		meta.version_tag = std::move(version_tag);
-		meta.insertion_time_ms = now;
-		meta.block_ptr = block_ptr;
 		entries[std::move(key)] = std::move(meta);
 	}
 }
 
 optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
-	string oc_key;
+	string obj_cache_key;
 	string version_tag;
 	bool stale = false;
 	{
@@ -103,7 +99,7 @@ optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 		if (it == entries.end()) {
 			return nullopt;
 		}
-		oc_key = it->second.oc_key;
+		obj_cache_key = it->second.obj_cache_key;
 		version_tag = it->second.version_tag;
 		if (timeout_millisec > 0) {
 			const uint64_t now = static_cast<uint64_t>(GetSteadyNowMilliSecSinceEpoch());
@@ -113,17 +109,17 @@ optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 		}
 	}
 
-	auto &oc = db_instance.GetObjectCache();
+	auto &obj_cache = db_instance.GetObjectCache();
 	if (stale) {
 		// Outside the lock: destructor finalises the map removal.
-		oc.Delete(oc_key);
+		obj_cache.Delete(obj_cache_key);
 		return nullopt;
 	}
 
-	auto block = oc.Get<CacheHttpfsDataBlock>(oc_key);
+	auto block = obj_cache.Get<CacheHttpfsDataBlock>(obj_cache_key);
 	if (block == nullptr) {
-		// OC LRU just evicted; destructor either fired already (map cleaned) or will fire when
-		// the lingering shared_ref drops. Treat as a miss.
+		// ObjectCache LRU just evicted; destructor either fired already (map cleaned) or will fire
+		// when the lingering shared_ref drops. Treat as a miss.
 		return nullopt;
 	}
 
@@ -133,7 +129,7 @@ optional<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
 }
 
 bool ObjectCacheStorage::Delete(const InMemCacheBlock &key) {
-	string oc_key;
+	string obj_cache_key;
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
 		auto it = entries.find(key);
@@ -141,49 +137,49 @@ bool ObjectCacheStorage::Delete(const InMemCacheBlock &key) {
 			return false;
 		}
 		// The map entry is about to be erased by `OnEntryDestroyed`; safe to steal the string.
-		// A racing `Get` on the same key would see an empty `oc_key` and just miss, which is fine
-		// since the block is being deleted anyway.
-		oc_key = std::move(it->second.oc_key);
+		// A racing `Get` on the same key would see an empty `obj_cache_key` and just miss, which
+		// is fine since the block is being deleted anyway.
+		obj_cache_key = std::move(it->second.obj_cache_key);
 	}
-	db_instance.GetObjectCache().Delete(oc_key);
+	db_instance.GetObjectCache().Delete(obj_cache_key);
 	return true;
 }
 
 void ObjectCacheStorage::Clear() {
-	// Snapshot oc_keys under the lock, then call OC outside it (destructors re-enter `mu`).
-	// We move the strings out of the map: callbacks erase the entries shortly after anyway, so
-	// the moved-from values are inert; a racing `Get` would observe an empty `oc_key` => miss,
-	// which is the desired behaviour during Clear.
-	vector<string> oc_keys;
+	// Snapshot ObjectCache keys under the lock, then call ObjectCache outside it (destructors
+	// re-enter `mu`). We move the strings out of the map: callbacks erase the entries shortly
+	// after anyway, so the moved-from values are inert; a racing `Get` would observe an empty
+	// `obj_cache_key` => miss, which is the desired behaviour during Clear.
+	vector<string> obj_cache_keys;
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
-		oc_keys.reserve(entries.size());
+		obj_cache_keys.reserve(entries.size());
 		for (auto &kv : entries) {
-			oc_keys.push_back(std::move(kv.second.oc_key));
+			obj_cache_keys.push_back(std::move(kv.second.obj_cache_key));
 		}
 	}
-	auto &oc = db_instance.GetObjectCache();
-	for (const auto &oc_key : oc_keys) {
-		oc.Delete(oc_key);
+	auto &obj_cache = db_instance.GetObjectCache();
+	for (const auto &obj_cache_key : obj_cache_keys) {
+		obj_cache.Delete(obj_cache_key);
 	}
 	// Map cleanup happens via destructor callbacks. Entries pinned by in-flight `Get`s linger
 	// until those readers release; the map drains as those refs drop.
 }
 
 void ObjectCacheStorage::Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) {
-	vector<string> oc_keys;
+	vector<string> obj_cache_keys;
 	{
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
 		for (auto it = entries.lower_bound(start_key); it != entries.end(); ++it) {
 			if (!filter(it->first)) {
 				break;
 			}
-			oc_keys.push_back(std::move(it->second.oc_key));
+			obj_cache_keys.push_back(std::move(it->second.obj_cache_key));
 		}
 	}
-	auto &oc = db_instance.GetObjectCache();
-	for (const auto &oc_key : oc_keys) {
-		oc.Delete(oc_key);
+	auto &obj_cache = db_instance.GetObjectCache();
+	for (const auto &obj_cache_key : obj_cache_keys) {
+		obj_cache.Delete(obj_cache_key);
 	}
 }
 
@@ -200,7 +196,7 @@ vector<InMemCacheBlock> ObjectCacheStorage::Keys() const {
 vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> ObjectCacheStorage::Take() {
 	struct Snapshot {
 		InMemCacheBlock key;
-		string oc_key;
+		string obj_cache_key;
 		string version_tag;
 	};
 	vector<Snapshot> snapshot;
@@ -208,27 +204,29 @@ vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> ObjectCacheS
 		const concurrency::lock_guard<concurrency::mutex> lock(mu);
 		snapshot.reserve(entries.size());
 		for (auto &kv : entries) {
-			// The map entries will be erased by `OnEntryDestroyed` after we `oc.Delete`; safe to
-			// move oc_key / version_tag out now.
-			snapshot.push_back(Snapshot {kv.first, std::move(kv.second.oc_key), std::move(kv.second.version_tag)});
+			// The map entries will be erased by `OnEntryDestroyed` after we call ObjectCache::Delete;
+			// safe to move obj_cache_key / version_tag out now.
+			snapshot.push_back(
+			    Snapshot {kv.first, std::move(kv.second.obj_cache_key), std::move(kv.second.version_tag)});
 		}
 	}
 
 	vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> result;
 	result.reserve(snapshot.size());
-	auto &oc = db_instance.GetObjectCache();
+	auto &obj_cache = db_instance.GetObjectCache();
 	for (auto &snap : snapshot) {
-		auto block = oc.Get<CacheHttpfsDataBlock>(snap.oc_key);
+		auto block = obj_cache.Get<CacheHttpfsDataBlock>(snap.obj_cache_key);
 		if (block == nullptr) {
 			continue;
 		}
 		auto entry = make_shared_ptr<InMemCacheDataEntry>();
-		// Move the chunk out before OC drops its ref; OC's accounting will still see the original
-		// reserved bytes when the buffer pool reservation is released by `~BufferPoolPayload`.
+		// Move the chunk out before ObjectCache drops its ref; ObjectCache's accounting will still
+		// see the original reserved bytes when the buffer pool reservation is released by
+		// `~BufferPoolPayload`.
 		entry->data = std::move(block->data);
 		entry->version_tag = std::move(snap.version_tag);
 		result.emplace_back(std::move(snap.key), std::move(entry));
-		oc.Delete(snap.oc_key);
+		obj_cache.Delete(snap.obj_cache_key);
 		// Drop our local ref; ~CacheHttpfsDataBlock fires and `OnEntryDestroyed` erases the map entry.
 		block.reset();
 	}

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -1,0 +1,251 @@
+#include "object_cache_data_cache_storage.hpp"
+
+#include "duckdb/common/assert.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/optional_idx.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/storage/object_cache.hpp"
+#include "page_aligned_data_chunk.hpp"
+#include "time_utils.hpp"
+#include "url_utils.hpp"
+
+#include <cstdint>
+#include <utility>
+
+namespace duckdb {
+
+namespace {
+
+// Inner ObjectCache entry that owns the page-aligned chunk.
+struct CacheHttpfsDataBlock : public ObjectCacheEntry {
+	static constexpr const char *OBJECT_TYPE = "CacheHttpfsDataBlock";
+
+	InMemCacheBlock key;
+	weak_ptr<ObjectCacheStorage> storage;
+	PageAlignedDataChunk data;
+
+	CacheHttpfsDataBlock(InMemCacheBlock key_p, weak_ptr<ObjectCacheStorage> storage_p, PageAlignedDataChunk data_p)
+	    : key(std::move(key_p)), storage(std::move(storage_p)), data(std::move(data_p)) {
+	}
+
+	~CacheHttpfsDataBlock() override {
+		if (auto s = storage.lock()) {
+			s->OnEntryDestroyed(key, this);
+		}
+	}
+
+	string GetObjectType() override {
+		return OBJECT_TYPE;
+	}
+	static string ObjectType() {
+		return OBJECT_TYPE;
+	}
+	optional_idx GetEstimatedCacheMemory() const override {
+		return optional_idx(data.length);
+	}
+};
+
+string MakeOcKey(const InMemCacheBlock &key) {
+	const SanitizedCachePath sanitized {key.fname};
+	return StringUtil::Format("cache_httpfs/data/%s:%llu:%llu", sanitized.Path(), key.start_off, key.blk_size);
+}
+
+} // namespace
+
+ObjectCacheStorage::ObjectCacheStorage(DatabaseInstance &db_instance_p, uint64_t timeout_millisec_p)
+    : db_instance(db_instance_p), timeout_millisec(timeout_millisec_p) {
+}
+
+ObjectCacheStorage::~ObjectCacheStorage() {
+	auto &oc = db_instance.GetObjectCache();
+	for (const auto &kv : entries) {
+		oc.Delete(kv.second.oc_key);
+	}
+}
+
+void ObjectCacheStorage::Put(InMemCacheBlock key, PageAlignedDataChunk chunk, string version_tag) {
+	ALWAYS_ASSERT(chunk.length > 0);
+
+	string oc_key = MakeOcKey(key);
+	const idx_t length = chunk.length;
+	const uint64_t now = static_cast<uint64_t>(GetSteadyNowMilliSecSinceEpoch());
+
+	// Wrap the chunk before touching OC so `weak_from_this()` is well-defined here.
+	auto block =
+	    make_shared_ptr<CacheHttpfsDataBlock>(key, weak_ptr<ObjectCacheStorage>(shared_from_this()), std::move(chunk));
+	const CacheHttpfsDataBlock *block_ptr = block.get();
+
+	// Install into OC without holding `mu`. If this displaces an existing entry under `oc_key`,
+	// the displaced block's destructor fires on this thread (no other refs => refcount goes to 0
+	// inside the LRU's replace path) and `OnEntryDestroyed` erases its map entry before we return.
+	db_instance.GetObjectCache().Put(oc_key, std::move(block));
+
+	{
+		const concurrency::lock_guard<concurrency::mutex> lock(mu);
+		EntryMeta meta;
+		meta.oc_key = std::move(oc_key);
+		meta.length = length;
+		meta.version_tag = std::move(version_tag);
+		meta.insertion_time_ms = now;
+		meta.block_ptr = block_ptr;
+		entries[std::move(key)] = std::move(meta);
+	}
+}
+
+unique_ptr<PinnedBlock> ObjectCacheStorage::Get(const InMemCacheBlock &key) {
+	string oc_key;
+	string version_tag;
+	bool stale = false;
+	{
+		const concurrency::lock_guard<concurrency::mutex> lock(mu);
+		auto it = entries.find(key);
+		if (it == entries.end()) {
+			return nullptr;
+		}
+		oc_key = it->second.oc_key;
+		version_tag = it->second.version_tag;
+		if (timeout_millisec > 0) {
+			const uint64_t now = static_cast<uint64_t>(GetSteadyNowMilliSecSinceEpoch());
+			if (now - it->second.insertion_time_ms > timeout_millisec) {
+				stale = true;
+			}
+		}
+	}
+
+	auto &oc = db_instance.GetObjectCache();
+	if (stale) {
+		// Outside the lock: destructor finalises the map removal.
+		oc.Delete(oc_key);
+		return nullptr;
+	}
+
+	auto block = oc.Get<CacheHttpfsDataBlock>(oc_key);
+	if (block == nullptr) {
+		// OC LRU just evicted; destructor either fired already (map cleaned) or will fire when
+		// the lingering shared_ref drops. Treat as a miss.
+		return nullptr;
+	}
+
+	const PageAlignedDataChunk *chunk_ptr = &block->data;
+	shared_ptr<void> keep_alive = std::move(block);
+	return make_uniq<PinnedBlock>(std::move(keep_alive), chunk_ptr, std::move(version_tag));
+}
+
+bool ObjectCacheStorage::Delete(const InMemCacheBlock &key) {
+	string oc_key;
+	{
+		const concurrency::lock_guard<concurrency::mutex> lock(mu);
+		auto it = entries.find(key);
+		if (it == entries.end()) {
+			return false;
+		}
+		// The map entry is about to be erased by `OnEntryDestroyed`; safe to steal the string.
+		// A racing `Get` on the same key would see an empty `oc_key` and just miss, which is fine
+		// since the block is being deleted anyway.
+		oc_key = std::move(it->second.oc_key);
+	}
+	db_instance.GetObjectCache().Delete(oc_key);
+	return true;
+}
+
+void ObjectCacheStorage::Clear() {
+	// Snapshot oc_keys under the lock, then call OC outside it (destructors re-enter `mu`).
+	// We move the strings out of the map: callbacks erase the entries shortly after anyway, so
+	// the moved-from values are inert; a racing `Get` would observe an empty `oc_key` => miss,
+	// which is the desired behaviour during Clear.
+	vector<string> oc_keys;
+	{
+		const concurrency::lock_guard<concurrency::mutex> lock(mu);
+		oc_keys.reserve(entries.size());
+		for (auto &kv : entries) {
+			oc_keys.push_back(std::move(kv.second.oc_key));
+		}
+	}
+	auto &oc = db_instance.GetObjectCache();
+	for (const auto &oc_key : oc_keys) {
+		oc.Delete(oc_key);
+	}
+	// Map cleanup happens via destructor callbacks. Entries pinned by in-flight `Get`s linger
+	// until those readers release; the map drains as those refs drop.
+}
+
+void ObjectCacheStorage::Clear(const InMemCacheBlock &start_key, std::function<bool(const InMemCacheBlock &)> filter) {
+	vector<string> oc_keys;
+	{
+		const concurrency::lock_guard<concurrency::mutex> lock(mu);
+		for (auto it = entries.lower_bound(start_key); it != entries.end(); ++it) {
+			if (!filter(it->first)) {
+				break;
+			}
+			oc_keys.push_back(std::move(it->second.oc_key));
+		}
+	}
+	auto &oc = db_instance.GetObjectCache();
+	for (const auto &oc_key : oc_keys) {
+		oc.Delete(oc_key);
+	}
+}
+
+vector<InMemCacheBlock> ObjectCacheStorage::Keys() const {
+	const concurrency::lock_guard<concurrency::mutex> lock(mu);
+	vector<InMemCacheBlock> keys;
+	keys.reserve(entries.size());
+	for (const auto &kv : entries) {
+		keys.push_back(kv.first);
+	}
+	return keys;
+}
+
+vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> ObjectCacheStorage::Take() {
+	struct Snapshot {
+		InMemCacheBlock key;
+		string oc_key;
+		string version_tag;
+	};
+	vector<Snapshot> snapshot;
+	{
+		const concurrency::lock_guard<concurrency::mutex> lock(mu);
+		snapshot.reserve(entries.size());
+		for (auto &kv : entries) {
+			// The map entries will be erased by `OnEntryDestroyed` after we `oc.Delete`; safe to
+			// move oc_key / version_tag out now.
+			snapshot.push_back(Snapshot {kv.first, std::move(kv.second.oc_key), std::move(kv.second.version_tag)});
+		}
+	}
+
+	vector<std::pair<InMemCacheBlock, shared_ptr<InMemCacheDataEntry>>> result;
+	result.reserve(snapshot.size());
+	auto &oc = db_instance.GetObjectCache();
+	for (auto &snap : snapshot) {
+		auto block = oc.Get<CacheHttpfsDataBlock>(snap.oc_key);
+		if (block == nullptr) {
+			continue;
+		}
+		auto entry = make_shared_ptr<InMemCacheDataEntry>();
+		// Move the chunk out before OC drops its ref; OC's accounting will still see the original
+		// reserved bytes when the buffer pool reservation is released by `~BufferPoolPayload`.
+		entry->data = std::move(block->data);
+		entry->version_tag = std::move(snap.version_tag);
+		result.emplace_back(std::move(snap.key), std::move(entry));
+		oc.Delete(snap.oc_key);
+		// Drop our local ref; ~CacheHttpfsDataBlock fires and `OnEntryDestroyed` erases the map entry.
+		block.reset();
+	}
+	return result;
+}
+
+void ObjectCacheStorage::OnEntryDestroyed(const InMemCacheBlock &key, const CacheHttpfsDataBlock *block) noexcept {
+	const concurrency::lock_guard<concurrency::mutex> lock(mu);
+	auto it = entries.find(key);
+	if (it == entries.end()) {
+		return;
+	}
+	if (it->second.block_ptr != block) {
+		// A newer block has replaced this one; preserve the new metadata.
+		return;
+	}
+	entries.erase(it);
+}
+
+} // namespace duckdb

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -15,8 +15,6 @@
 
 namespace duckdb {
 
-namespace {
-
 // Inner ObjectCache entry that owns the page-aligned chunk.
 struct CacheHttpfsDataBlock : public ObjectCacheEntry {
 	static constexpr const char *OBJECT_TYPE = "CacheHttpfsDataBlock";
@@ -45,6 +43,8 @@ struct CacheHttpfsDataBlock : public ObjectCacheEntry {
 		return optional_idx(data.length);
 	}
 };
+
+namespace {
 
 string MakeObjCacheKey(const InMemCacheBlock &key) {
 	const SanitizedCachePath sanitized {key.fname};

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CATCHFS_UNITTEST_OBJECTS
     test_multi_duckdb_instance_from_unit.cpp
     test_no_destructor.cpp
     test_noop_cache_reader_from_unit.cpp
+    test_object_cache_data_storage.cpp
     test_optional.cpp
     test_oversized_cache_filepath.cpp
     test_page_aligned_data_chunk.cpp

--- a/test/unittest/test_disk_cache_validation_from_unit.cpp
+++ b/test/unittest/test_disk_cache_validation_from_unit.cpp
@@ -73,7 +73,7 @@ struct ValidationTestHelper {
 		local_fs->CreateDirectory(TEST_ON_DISK_CACHE_DIRECTORY);
 
 		// Register state with instance
-		instance_state->db_config = &db.instance->config;
+		instance_state->db_instance = db.instance.get();
 		SetInstanceState(*db.instance.get(), instance_state);
 		InitializeCacheReaderForTest(instance_state, config);
 

--- a/test/unittest/test_max_fanout_subrequest.cpp
+++ b/test/unittest/test_max_fanout_subrequest.cpp
@@ -107,7 +107,7 @@ struct TestFsHelper {
 		auto local_filesystem = LocalFileSystem::CreateLocal();
 		local_filesystem->CreateDirectory(cache_directory);
 
-		instance_state->db_config = &db.instance->config;
+		instance_state->db_instance = db.instance.get();
 		SetInstanceState(*db.instance.get(), instance_state);
 		instance_state->cache_reader_manager.SetCacheReader(config, instance_state);
 		slow_fs = slow_fs_p.get();

--- a/test/unittest/test_object_cache_data_storage.cpp
+++ b/test/unittest/test_object_cache_data_storage.cpp
@@ -1,0 +1,221 @@
+// Storage-level unit tests for `ObjectCacheStorage`. No reader involvement.
+//
+// Covers the design's required scenarios:
+//   - destructor-driven map sync on global LRU eviction
+//   - timeout-based lazy expiry on Get
+//   - clear-on-switch (Clear() drains both our map and OC)
+//   - prefix-scoped Clear(start_key, filter) for file-level invalidation
+//   - replace-on-duplicate-Put preserves a single map entry with the latest version_tag
+//   - concurrent Put/Get does not race (TSan-clean)
+
+#include "catch/catch.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "duckdb.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/storage/object_cache.hpp"
+#include "in_mem_cache_block.hpp"
+#include "object_cache_data_cache_storage.hpp"
+#include "page_aligned_data_chunk.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+
+// Allocate a chunk with deterministic content for content-equality assertions.
+PageAlignedDataChunk MakeFilledChunk(idx_t size, char fill) {
+	auto chunk = AllocatePageAlignedChunk(size);
+	for (idx_t i = 0; i < size; ++i) {
+		chunk.data()[i] = fill;
+	}
+	chunk.length = size;
+	return chunk;
+}
+
+void PutBlock(ObjectCacheStorage &storage, const string &fname, idx_t start_off, idx_t blk_size,
+              const string &version_tag, char fill = 'x') {
+	storage.Put(InMemCacheBlock {fname, start_off, blk_size}, MakeFilledChunk(blk_size, fill), version_tag);
+}
+
+} // namespace
+
+TEST_CASE("ObjectCacheStorage Put/Get roundtrip", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	const InMemCacheBlock key {"/foo", 0, 1024};
+	storage->Put(key, MakeFilledChunk(1024, 'a'), "v1");
+
+	auto pinned = storage->Get(key);
+	REQUIRE(pinned != nullptr);
+	REQUIRE(pinned->Data().length == 1024);
+	REQUIRE(pinned->Data().data()[0] == 'a');
+	REQUIRE(pinned->Data().data()[1023] == 'a');
+	REQUIRE(pinned->VersionTag() == "v1");
+
+	REQUIRE(storage->Keys().size() == 1);
+}
+
+TEST_CASE("ObjectCacheStorage Get miss on unknown key", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+	const InMemCacheBlock key {"/foo", 0, 1024};
+	REQUIRE(storage->Get(key) == nullptr);
+	REQUIRE(storage->Keys().empty());
+}
+
+TEST_CASE("ObjectCacheStorage destructor-driven map sync on OC eviction", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	PutBlock(*storage, "/foo", 0, 1024, "v1");
+	PutBlock(*storage, "/foo", 1024, 1024, "v1");
+	REQUIRE(storage->Keys().size() == 2);
+
+	// Force eviction by asking OC to free more bytes than we hold; this drops every entry whose
+	// shared_ptr we don't pin. Destructors fire on this thread => our map drains in lock-step.
+	auto &oc = db.instance->GetObjectCache();
+	const idx_t evicted = oc.EvictToReduceMemory(oc.GetCurrentMemory());
+	REQUIRE(evicted > 0);
+	REQUIRE(storage->Keys().empty());
+}
+
+TEST_CASE("ObjectCacheStorage timeout invalidates on Get", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/5);
+
+	PutBlock(*storage, "/foo", 0, 1024, "v1");
+	REQUIRE(storage->Keys().size() == 1);
+
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	// Stale entry => Get returns nullptr and triggers an OC::Delete; destructor finalises map.
+	REQUIRE(storage->Get(InMemCacheBlock {"/foo", 0, 1024}) == nullptr);
+	REQUIRE(storage->Keys().empty());
+}
+
+TEST_CASE("ObjectCacheStorage Clear drains map and OC", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	constexpr idx_t N = 16;
+	for (idx_t i = 0; i < N; ++i) {
+		PutBlock(*storage, "/foo", i * 1024, 1024, "v1");
+	}
+	REQUIRE(storage->Keys().size() == N);
+	const idx_t bytes_before = db.instance->GetObjectCache().GetCurrentMemory();
+	REQUIRE(bytes_before >= N * 1024);
+
+	storage->Clear();
+
+	REQUIRE(storage->Keys().empty());
+	// Every block we owned has been dropped from OC; OC's accounting is back to whatever was
+	// there before (which may not be zero because the CacheHttpfsInstanceState entry itself is
+	// stored in OC, but it is non-evictable and unaccounted).
+	REQUIRE(db.instance->GetObjectCache().GetCurrentMemory() == 0);
+}
+
+TEST_CASE("ObjectCacheStorage prefix-scoped Clear for one file", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	PutBlock(*storage, "/a", 0, 512, "v1");
+	PutBlock(*storage, "/a", 512, 512, "v1");
+	PutBlock(*storage, "/b", 0, 512, "v1");
+	REQUIRE(storage->Keys().size() == 3);
+
+	const InMemCacheBlock start {"/a", 0, 0};
+	storage->Clear(start, [](const InMemCacheBlock &k) { return k.fname == "/a"; });
+
+	auto remaining = storage->Keys();
+	REQUIRE(remaining.size() == 1);
+	REQUIRE(remaining[0].fname == "/b");
+	REQUIRE(storage->Get(InMemCacheBlock {"/a", 0, 512}) == nullptr);
+	REQUIRE(storage->Get(InMemCacheBlock {"/a", 512, 512}) == nullptr);
+	REQUIRE(storage->Get(InMemCacheBlock {"/b", 0, 512}) != nullptr);
+}
+
+TEST_CASE("ObjectCacheStorage replace-on-duplicate-Put keeps single map entry with latest meta",
+          "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	const InMemCacheBlock key {"/x", 0, 512};
+	storage->Put(key, MakeFilledChunk(512, '1'), "v1");
+	storage->Put(key, MakeFilledChunk(512, '2'), "v2");
+
+	REQUIRE(storage->Keys().size() == 1);
+	auto pinned = storage->Get(key);
+	REQUIRE(pinned != nullptr);
+	REQUIRE(pinned->VersionTag() == "v2");
+	REQUIRE(pinned->Data().data()[0] == '2');
+}
+
+TEST_CASE("ObjectCacheStorage Delete removes both map and OC entry", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	const InMemCacheBlock key {"/foo", 0, 1024};
+	PutBlock(*storage, "/foo", 0, 1024, "v1");
+	REQUIRE(storage->Delete(key));
+	REQUIRE_FALSE(storage->Delete(key));
+	REQUIRE(storage->Keys().empty());
+}
+
+TEST_CASE("ObjectCacheStorage Take drains storage and yields owning chunks", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	PutBlock(*storage, "/foo", 0, 1024, "v1", /*fill=*/'a');
+	PutBlock(*storage, "/foo", 1024, 1024, "v1", /*fill=*/'b');
+
+	auto taken = storage->Take();
+	REQUIRE(taken.size() == 2);
+	for (auto &kv : taken) {
+		REQUIRE(kv.second != nullptr);
+		REQUIRE(kv.second->data.length == 1024);
+		REQUIRE(kv.second->version_tag == "v1");
+	}
+	REQUIRE(storage->Keys().empty());
+	REQUIRE(db.instance->GetObjectCache().GetCurrentMemory() == 0);
+}
+
+TEST_CASE("ObjectCacheStorage concurrent Put and Get", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	constexpr idx_t THREAD_COUNT = 8;
+	constexpr idx_t PER_THREAD = 32;
+	constexpr idx_t BLK = 256;
+
+	std::vector<std::thread> threads;
+	threads.reserve(THREAD_COUNT);
+	std::atomic<idx_t> hits {0};
+	for (idx_t t = 0; t < THREAD_COUNT; ++t) {
+		threads.emplace_back([&, t]() {
+			for (idx_t i = 0; i < PER_THREAD; ++i) {
+				const idx_t off = (t * PER_THREAD + i) * BLK;
+				InMemCacheBlock key {"/concurrent", off, BLK};
+				storage->Put(key, MakeFilledChunk(BLK, static_cast<char>('A' + (t % 26))), "v");
+				auto pinned = storage->Get(key);
+				if (pinned != nullptr) {
+					REQUIRE(pinned->Data().length == BLK);
+					hits.fetch_add(1, std::memory_order_relaxed);
+				}
+			}
+		});
+	}
+	for (auto &th : threads) {
+		th.join();
+	}
+
+	// Each key is unique to its thread; every Get should hit unless OC LRU evicted some entries.
+	// With 8 * 32 * 256 = 64KiB total, there's no chance of OC eviction (default 8 GiB cap).
+	REQUIRE(hits.load() == THREAD_COUNT * PER_THREAD);
+	REQUIRE(storage->Keys().size() == THREAD_COUNT * PER_THREAD);
+}

--- a/test/unittest/test_object_cache_data_storage.cpp
+++ b/test/unittest/test_object_cache_data_storage.cpp
@@ -1,17 +1,8 @@
-// Storage-level unit tests for `ObjectCacheStorage`. No reader involvement.
-//
-// Covers the design's required scenarios:
-//   - destructor-driven map sync on global LRU eviction
-//   - timeout-based lazy expiry on Get
-//   - clear-on-switch (Clear() drains both our map and ObjectCache)
-//   - prefix-scoped Clear(start_key, filter) for file-level invalidation
-//   - replace-on-duplicate-Put preserves a single map entry with the latest version_tag
-//   - concurrent Put/Get does not race (TSan-clean)
-
 #include "catch/catch.hpp"
 
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -22,6 +13,7 @@
 #include "in_mem_cache_block.hpp"
 #include "object_cache_data_cache_storage.hpp"
 #include "page_aligned_data_chunk.hpp"
+#include "thread_pool.hpp"
 
 using namespace duckdb; // NOLINT
 
@@ -42,6 +34,16 @@ void PutBlock(ObjectCacheStorage &storage, const string &fname, idx_t start_off,
 	storage.Put(InMemCacheBlock {fname, start_off, blk_size}, MakeFilledChunk(blk_size, fill), version_tag);
 }
 
+bool AllBytesEqual(const PageAlignedDataChunk &chunk, char expected) {
+	const char *data = chunk.data();
+	for (idx_t i = 0; i < chunk.length; ++i) {
+		if (data[i] != expected) {
+			return false;
+		}
+	}
+	return true;
+}
+
 } // namespace
 
 TEST_CASE("ObjectCacheStorage Put/Get roundtrip", "[object cache storage]") {
@@ -54,8 +56,7 @@ TEST_CASE("ObjectCacheStorage Put/Get roundtrip", "[object cache storage]") {
 	auto pinned = storage->Get(key, /*expected_version_tag=*/"v1");
 	REQUIRE(pinned);
 	REQUIRE(pinned->Data().length == 1024);
-	REQUIRE(pinned->Data().data()[0] == 'a');
-	REQUIRE(pinned->Data().data()[1023] == 'a');
+	REQUIRE(AllBytesEqual(pinned->Data(), 'a'));
 
 	REQUIRE(storage->Keys().size() == 1);
 
@@ -90,8 +91,6 @@ TEST_CASE("ObjectCacheStorage destructor-driven map sync on ObjectCache eviction
 	PutBlock(*storage, "/foo", 1024, 1024, /*version_tag=*/"v1");
 	REQUIRE(storage->Keys().size() == 2);
 
-	// Force eviction by asking ObjectCache to free more bytes than we hold; this drops every entry
-	// whose shared_ptr we don't pin. Destructors fire on this thread => our map drains in lock-step.
 	auto &obj_cache = db.instance->GetObjectCache();
 	const idx_t evicted = obj_cache.EvictToReduceMemory(obj_cache.GetCurrentMemory());
 	REQUIRE(evicted > 0);
@@ -105,9 +104,9 @@ TEST_CASE("ObjectCacheStorage timeout invalidates on Get", "[object cache storag
 	PutBlock(*storage, "/foo", 0, 1024, /*version_tag=*/"v1");
 	REQUIRE(storage->Keys().size() == 1);
 
+	// To reduce flakiness, sleep for 10x timeout latency.
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-	// Stale entry => Get returns nullopt and triggers an ObjectCache::Delete; destructor finalises map.
 	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/foo", 0, 1024}, /*expected_version_tag=*/""));
 	REQUIRE(storage->Keys().empty());
 }
@@ -117,8 +116,8 @@ TEST_CASE("ObjectCacheStorage Clear drains map and ObjectCache", "[object cache 
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
 	constexpr idx_t N = 16;
-	for (idx_t i = 0; i < N; ++i) {
-		PutBlock(*storage, "/foo", i * 1024, 1024, /*version_tag=*/"v1");
+	for (idx_t idx = 0; idx < N; ++idx) {
+		PutBlock(*storage, "/foo", idx * 1024, 1024, /*version_tag=*/"v1");
 	}
 	REQUIRE(storage->Keys().size() == N);
 	const idx_t bytes_before = db.instance->GetObjectCache().GetCurrentMemory();
@@ -127,9 +126,6 @@ TEST_CASE("ObjectCacheStorage Clear drains map and ObjectCache", "[object cache 
 	storage->Clear();
 
 	REQUIRE(storage->Keys().empty());
-	// Every block we owned has been dropped from ObjectCache; its accounting is back to whatever
-	// was there before (which may not be zero because the CacheHttpfsInstanceState entry itself
-	// is stored in ObjectCache, but it is non-evictable and unaccounted).
 	REQUIRE(db.instance->GetObjectCache().GetCurrentMemory() == 0);
 }
 
@@ -157,17 +153,25 @@ TEST_CASE("ObjectCacheStorage replace-on-duplicate-Put keeps single map entry wi
           "[object cache storage]") {
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+	auto &obj_cache = db.instance->GetObjectCache();
 
 	const InMemCacheBlock key {"/x", 0, 512};
 	storage->Put(key, MakeFilledChunk(512, '1'), /*version_tag=*/"v1");
-	storage->Put(key, MakeFilledChunk(512, '2'), /*version_tag=*/"v2");
+	REQUIRE(obj_cache.GetCurrentMemory() == 512);
 
+	storage->Put(key, MakeFilledChunk(512, '2'), /*version_tag=*/"v2");
 	REQUIRE(storage->Keys().size() == 1);
-	auto pinned = storage->Get(key, /*expected_version_tag=*/"v2");
-	REQUIRE(pinned);
-	REQUIRE(pinned->Data().data()[0] == '2');
+	// Second Put displaced v1 in ObjectCache; total reservation is still one block, not two.
+	REQUIRE(obj_cache.GetCurrentMemory() == 512);
+
+	{
+		auto pinned = storage->Get(key, /*expected_version_tag=*/"v2");
+		REQUIRE(pinned);
+		REQUIRE(AllBytesEqual(pinned->Data(), '2'));
+	}
 	REQUIRE_FALSE(storage->Get(key, /*expected_version_tag=*/"v1"));
 	REQUIRE(storage->Keys().empty());
+	REQUIRE(obj_cache.GetCurrentMemory() == 0);
 }
 
 TEST_CASE("ObjectCacheStorage Delete removes both map and ObjectCache entry", "[object cache storage]") {
@@ -194,6 +198,8 @@ TEST_CASE("ObjectCacheStorage Take drains storage and yields owning chunks", "[o
 		REQUIRE(kv.second != nullptr);
 		REQUIRE(kv.second->data.length == 1024);
 		REQUIRE(kv.second->version_tag == "v1");
+		const char expected_fill = kv.first.start_off == 0 ? 'a' : 'b';
+		REQUIRE(AllBytesEqual(kv.second->data, expected_fill));
 	}
 	REQUIRE(storage->Keys().empty());
 	REQUIRE(db.instance->GetObjectCache().GetCurrentMemory() == 0);
@@ -207,30 +213,31 @@ TEST_CASE("ObjectCacheStorage concurrent Put and Get", "[object cache storage]")
 	constexpr idx_t PER_THREAD = 32;
 	constexpr idx_t BLK = 256;
 
-	std::vector<std::thread> threads;
-	threads.reserve(THREAD_COUNT);
 	std::atomic<idx_t> hits {0};
+	ThreadPool tp(THREAD_COUNT);
+	std::vector<std::future<void>> futures;
+	futures.reserve(THREAD_COUNT);
 	for (idx_t t = 0; t < THREAD_COUNT; ++t) {
-		threads.emplace_back([&, t]() {
+		futures.emplace_back(tp.Push([&, t]() {
+			const char fill = static_cast<char>('A' + (t % 26));
 			for (idx_t i = 0; i < PER_THREAD; ++i) {
 				const idx_t off = (t * PER_THREAD + i) * BLK;
 				InMemCacheBlock key {"/concurrent", off, BLK};
-				storage->Put(key, MakeFilledChunk(BLK, static_cast<char>('A' + (t % 26))), /*version_tag=*/"v");
+				storage->Put(key, MakeFilledChunk(BLK, fill), /*version_tag=*/"v");
 				auto pinned = storage->Get(key, /*expected_version_tag=*/"v");
 				if (pinned) {
 					REQUIRE(pinned->Data().length == BLK);
-					hits.fetch_add(1, std::memory_order_relaxed);
+					REQUIRE(AllBytesEqual(pinned->Data(), fill));
+					hits.fetch_add(1);
 				}
 			}
-		});
+		}));
 	}
-	for (auto &th : threads) {
-		th.join();
+	tp.Wait();
+	for (auto &fut : futures) {
+		fut.get();
 	}
 
-	// Each key is unique to its thread; every Get should hit unless ObjectCache LRU evicted some
-	// entries. With 8 * 32 * 256 = 64KiB total, there's no chance of ObjectCache eviction
-	// (default 8 GiB cap).
 	REQUIRE(hits.load() == THREAD_COUNT * PER_THREAD);
 	REQUIRE(storage->Keys().size() == THREAD_COUNT * PER_THREAD);
 }

--- a/test/unittest/test_object_cache_data_storage.cpp
+++ b/test/unittest/test_object_cache_data_storage.cpp
@@ -49,23 +49,36 @@ TEST_CASE("ObjectCacheStorage Put/Get roundtrip", "[object cache storage]") {
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
 	const InMemCacheBlock key {"/foo", 0, 1024};
-	storage->Put(key, MakeFilledChunk(1024, 'a'), "v1");
+	storage->Put(key, MakeFilledChunk(1024, 'a'), /*version_tag=*/"v1");
 
-	auto pinned = storage->Get(key);
+	auto pinned = storage->Get(key, /*expected_version_tag=*/"v1");
 	REQUIRE(pinned);
 	REQUIRE(pinned->Data().length == 1024);
 	REQUIRE(pinned->Data().data()[0] == 'a');
 	REQUIRE(pinned->Data().data()[1023] == 'a');
-	REQUIRE(pinned->VersionTag() == "v1");
 
 	REQUIRE(storage->Keys().size() == 1);
+
+	REQUIRE(storage->Get(key, /*expected_version_tag=*/""));
 }
 
 TEST_CASE("ObjectCacheStorage Get miss on unknown key", "[object cache storage]") {
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 	const InMemCacheBlock key {"/foo", 0, 1024};
-	REQUIRE_FALSE(storage->Get(key));
+	REQUIRE_FALSE(storage->Get(key, /*expected_version_tag=*/""));
+	REQUIRE(storage->Keys().empty());
+}
+
+TEST_CASE("ObjectCacheStorage Get with version mismatch evicts and returns nullopt", "[object cache storage]") {
+	DuckDB db;
+	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
+
+	const InMemCacheBlock key {"/foo", 0, 1024};
+	storage->Put(key, MakeFilledChunk(1024, 'a'), /*version_tag=*/"v1");
+	REQUIRE(storage->Keys().size() == 1);
+
+	REQUIRE_FALSE(storage->Get(key, /*expected_version_tag=*/"v2"));
 	REQUIRE(storage->Keys().empty());
 }
 
@@ -73,8 +86,8 @@ TEST_CASE("ObjectCacheStorage destructor-driven map sync on ObjectCache eviction
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
-	PutBlock(*storage, "/foo", 0, 1024, "v1");
-	PutBlock(*storage, "/foo", 1024, 1024, "v1");
+	PutBlock(*storage, "/foo", 0, 1024, /*version_tag=*/"v1");
+	PutBlock(*storage, "/foo", 1024, 1024, /*version_tag=*/"v1");
 	REQUIRE(storage->Keys().size() == 2);
 
 	// Force eviction by asking ObjectCache to free more bytes than we hold; this drops every entry
@@ -89,13 +102,13 @@ TEST_CASE("ObjectCacheStorage timeout invalidates on Get", "[object cache storag
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/5);
 
-	PutBlock(*storage, "/foo", 0, 1024, "v1");
+	PutBlock(*storage, "/foo", 0, 1024, /*version_tag=*/"v1");
 	REQUIRE(storage->Keys().size() == 1);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
 	// Stale entry => Get returns nullopt and triggers an ObjectCache::Delete; destructor finalises map.
-	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/foo", 0, 1024}));
+	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/foo", 0, 1024}, /*expected_version_tag=*/""));
 	REQUIRE(storage->Keys().empty());
 }
 
@@ -105,7 +118,7 @@ TEST_CASE("ObjectCacheStorage Clear drains map and ObjectCache", "[object cache 
 
 	constexpr idx_t N = 16;
 	for (idx_t i = 0; i < N; ++i) {
-		PutBlock(*storage, "/foo", i * 1024, 1024, "v1");
+		PutBlock(*storage, "/foo", i * 1024, 1024, /*version_tag=*/"v1");
 	}
 	REQUIRE(storage->Keys().size() == N);
 	const idx_t bytes_before = db.instance->GetObjectCache().GetCurrentMemory();
@@ -124,9 +137,9 @@ TEST_CASE("ObjectCacheStorage prefix-scoped Clear for one file", "[object cache 
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
-	PutBlock(*storage, "/a", 0, 512, "v1");
-	PutBlock(*storage, "/a", 512, 512, "v1");
-	PutBlock(*storage, "/b", 0, 512, "v1");
+	PutBlock(*storage, "/a", 0, 512, /*version_tag=*/"v1");
+	PutBlock(*storage, "/a", 512, 512, /*version_tag=*/"v1");
+	PutBlock(*storage, "/b", 0, 512, /*version_tag=*/"v1");
 	REQUIRE(storage->Keys().size() == 3);
 
 	const InMemCacheBlock start {"/a", 0, 0};
@@ -135,9 +148,9 @@ TEST_CASE("ObjectCacheStorage prefix-scoped Clear for one file", "[object cache 
 	auto remaining = storage->Keys();
 	REQUIRE(remaining.size() == 1);
 	REQUIRE(remaining[0].fname == "/b");
-	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/a", 0, 512}));
-	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/a", 512, 512}));
-	REQUIRE(storage->Get(InMemCacheBlock {"/b", 0, 512}));
+	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/a", 0, 512}, /*expected_version_tag=*/""));
+	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/a", 512, 512}, /*expected_version_tag=*/""));
+	REQUIRE(storage->Get(InMemCacheBlock {"/b", 0, 512}, /*expected_version_tag=*/""));
 }
 
 TEST_CASE("ObjectCacheStorage replace-on-duplicate-Put keeps single map entry with latest meta",
@@ -146,14 +159,15 @@ TEST_CASE("ObjectCacheStorage replace-on-duplicate-Put keeps single map entry wi
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
 	const InMemCacheBlock key {"/x", 0, 512};
-	storage->Put(key, MakeFilledChunk(512, '1'), "v1");
-	storage->Put(key, MakeFilledChunk(512, '2'), "v2");
+	storage->Put(key, MakeFilledChunk(512, '1'), /*version_tag=*/"v1");
+	storage->Put(key, MakeFilledChunk(512, '2'), /*version_tag=*/"v2");
 
 	REQUIRE(storage->Keys().size() == 1);
-	auto pinned = storage->Get(key);
+	auto pinned = storage->Get(key, /*expected_version_tag=*/"v2");
 	REQUIRE(pinned);
-	REQUIRE(pinned->VersionTag() == "v2");
 	REQUIRE(pinned->Data().data()[0] == '2');
+	REQUIRE_FALSE(storage->Get(key, /*expected_version_tag=*/"v1"));
+	REQUIRE(storage->Keys().empty());
 }
 
 TEST_CASE("ObjectCacheStorage Delete removes both map and ObjectCache entry", "[object cache storage]") {
@@ -161,7 +175,7 @@ TEST_CASE("ObjectCacheStorage Delete removes both map and ObjectCache entry", "[
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
 	const InMemCacheBlock key {"/foo", 0, 1024};
-	PutBlock(*storage, "/foo", 0, 1024, "v1");
+	PutBlock(*storage, "/foo", 0, 1024, /*version_tag=*/"v1");
 	REQUIRE(storage->Delete(key));
 	REQUIRE_FALSE(storage->Delete(key));
 	REQUIRE(storage->Keys().empty());
@@ -171,8 +185,8 @@ TEST_CASE("ObjectCacheStorage Take drains storage and yields owning chunks", "[o
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
-	PutBlock(*storage, "/foo", 0, 1024, "v1", /*fill=*/'a');
-	PutBlock(*storage, "/foo", 1024, 1024, "v1", /*fill=*/'b');
+	PutBlock(*storage, "/foo", 0, 1024, /*version_tag=*/"v1", /*fill=*/'a');
+	PutBlock(*storage, "/foo", 1024, 1024, /*version_tag=*/"v1", /*fill=*/'b');
 
 	auto taken = storage->Take();
 	REQUIRE(taken.size() == 2);
@@ -201,8 +215,8 @@ TEST_CASE("ObjectCacheStorage concurrent Put and Get", "[object cache storage]")
 			for (idx_t i = 0; i < PER_THREAD; ++i) {
 				const idx_t off = (t * PER_THREAD + i) * BLK;
 				InMemCacheBlock key {"/concurrent", off, BLK};
-				storage->Put(key, MakeFilledChunk(BLK, static_cast<char>('A' + (t % 26))), "v");
-				auto pinned = storage->Get(key);
+				storage->Put(key, MakeFilledChunk(BLK, static_cast<char>('A' + (t % 26))), /*version_tag=*/"v");
+				auto pinned = storage->Get(key, /*expected_version_tag=*/"v");
 				if (pinned) {
 					REQUIRE(pinned->Data().length == BLK);
 					hits.fetch_add(1, std::memory_order_relaxed);

--- a/test/unittest/test_object_cache_data_storage.cpp
+++ b/test/unittest/test_object_cache_data_storage.cpp
@@ -3,7 +3,7 @@
 // Covers the design's required scenarios:
 //   - destructor-driven map sync on global LRU eviction
 //   - timeout-based lazy expiry on Get
-//   - clear-on-switch (Clear() drains both our map and OC)
+//   - clear-on-switch (Clear() drains both our map and ObjectCache)
 //   - prefix-scoped Clear(start_key, filter) for file-level invalidation
 //   - replace-on-duplicate-Put preserves a single map entry with the latest version_tag
 //   - concurrent Put/Get does not race (TSan-clean)
@@ -69,7 +69,7 @@ TEST_CASE("ObjectCacheStorage Get miss on unknown key", "[object cache storage]"
 	REQUIRE(storage->Keys().empty());
 }
 
-TEST_CASE("ObjectCacheStorage destructor-driven map sync on OC eviction", "[object cache storage]") {
+TEST_CASE("ObjectCacheStorage destructor-driven map sync on ObjectCache eviction", "[object cache storage]") {
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
@@ -77,10 +77,10 @@ TEST_CASE("ObjectCacheStorage destructor-driven map sync on OC eviction", "[obje
 	PutBlock(*storage, "/foo", 1024, 1024, "v1");
 	REQUIRE(storage->Keys().size() == 2);
 
-	// Force eviction by asking OC to free more bytes than we hold; this drops every entry whose
-	// shared_ptr we don't pin. Destructors fire on this thread => our map drains in lock-step.
-	auto &oc = db.instance->GetObjectCache();
-	const idx_t evicted = oc.EvictToReduceMemory(oc.GetCurrentMemory());
+	// Force eviction by asking ObjectCache to free more bytes than we hold; this drops every entry
+	// whose shared_ptr we don't pin. Destructors fire on this thread => our map drains in lock-step.
+	auto &obj_cache = db.instance->GetObjectCache();
+	const idx_t evicted = obj_cache.EvictToReduceMemory(obj_cache.GetCurrentMemory());
 	REQUIRE(evicted > 0);
 	REQUIRE(storage->Keys().empty());
 }
@@ -94,12 +94,12 @@ TEST_CASE("ObjectCacheStorage timeout invalidates on Get", "[object cache storag
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-	// Stale entry => Get returns nullopt and triggers an OC::Delete; destructor finalises map.
+	// Stale entry => Get returns nullopt and triggers an ObjectCache::Delete; destructor finalises map.
 	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/foo", 0, 1024}));
 	REQUIRE(storage->Keys().empty());
 }
 
-TEST_CASE("ObjectCacheStorage Clear drains map and OC", "[object cache storage]") {
+TEST_CASE("ObjectCacheStorage Clear drains map and ObjectCache", "[object cache storage]") {
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
@@ -114,9 +114,9 @@ TEST_CASE("ObjectCacheStorage Clear drains map and OC", "[object cache storage]"
 	storage->Clear();
 
 	REQUIRE(storage->Keys().empty());
-	// Every block we owned has been dropped from OC; OC's accounting is back to whatever was
-	// there before (which may not be zero because the CacheHttpfsInstanceState entry itself is
-	// stored in OC, but it is non-evictable and unaccounted).
+	// Every block we owned has been dropped from ObjectCache; its accounting is back to whatever
+	// was there before (which may not be zero because the CacheHttpfsInstanceState entry itself
+	// is stored in ObjectCache, but it is non-evictable and unaccounted).
 	REQUIRE(db.instance->GetObjectCache().GetCurrentMemory() == 0);
 }
 
@@ -156,7 +156,7 @@ TEST_CASE("ObjectCacheStorage replace-on-duplicate-Put keeps single map entry wi
 	REQUIRE(pinned->Data().data()[0] == '2');
 }
 
-TEST_CASE("ObjectCacheStorage Delete removes both map and OC entry", "[object cache storage]") {
+TEST_CASE("ObjectCacheStorage Delete removes both map and ObjectCache entry", "[object cache storage]") {
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 
@@ -214,8 +214,9 @@ TEST_CASE("ObjectCacheStorage concurrent Put and Get", "[object cache storage]")
 		th.join();
 	}
 
-	// Each key is unique to its thread; every Get should hit unless OC LRU evicted some entries.
-	// With 8 * 32 * 256 = 64KiB total, there's no chance of OC eviction (default 8 GiB cap).
+	// Each key is unique to its thread; every Get should hit unless ObjectCache LRU evicted some
+	// entries. With 8 * 32 * 256 = 64KiB total, there's no chance of ObjectCache eviction
+	// (default 8 GiB cap).
 	REQUIRE(hits.load() == THREAD_COUNT * PER_THREAD);
 	REQUIRE(storage->Keys().size() == THREAD_COUNT * PER_THREAD);
 }

--- a/test/unittest/test_object_cache_data_storage.cpp
+++ b/test/unittest/test_object_cache_data_storage.cpp
@@ -52,7 +52,7 @@ TEST_CASE("ObjectCacheStorage Put/Get roundtrip", "[object cache storage]") {
 	storage->Put(key, MakeFilledChunk(1024, 'a'), "v1");
 
 	auto pinned = storage->Get(key);
-	REQUIRE(pinned != nullptr);
+	REQUIRE(pinned);
 	REQUIRE(pinned->Data().length == 1024);
 	REQUIRE(pinned->Data().data()[0] == 'a');
 	REQUIRE(pinned->Data().data()[1023] == 'a');
@@ -65,7 +65,7 @@ TEST_CASE("ObjectCacheStorage Get miss on unknown key", "[object cache storage]"
 	DuckDB db;
 	auto storage = make_shared_ptr<ObjectCacheStorage>(*db.instance, /*timeout_millisec=*/0);
 	const InMemCacheBlock key {"/foo", 0, 1024};
-	REQUIRE(storage->Get(key) == nullptr);
+	REQUIRE_FALSE(storage->Get(key));
 	REQUIRE(storage->Keys().empty());
 }
 
@@ -94,8 +94,8 @@ TEST_CASE("ObjectCacheStorage timeout invalidates on Get", "[object cache storag
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-	// Stale entry => Get returns nullptr and triggers an OC::Delete; destructor finalises map.
-	REQUIRE(storage->Get(InMemCacheBlock {"/foo", 0, 1024}) == nullptr);
+	// Stale entry => Get returns nullopt and triggers an OC::Delete; destructor finalises map.
+	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/foo", 0, 1024}));
 	REQUIRE(storage->Keys().empty());
 }
 
@@ -135,9 +135,9 @@ TEST_CASE("ObjectCacheStorage prefix-scoped Clear for one file", "[object cache 
 	auto remaining = storage->Keys();
 	REQUIRE(remaining.size() == 1);
 	REQUIRE(remaining[0].fname == "/b");
-	REQUIRE(storage->Get(InMemCacheBlock {"/a", 0, 512}) == nullptr);
-	REQUIRE(storage->Get(InMemCacheBlock {"/a", 512, 512}) == nullptr);
-	REQUIRE(storage->Get(InMemCacheBlock {"/b", 0, 512}) != nullptr);
+	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/a", 0, 512}));
+	REQUIRE_FALSE(storage->Get(InMemCacheBlock {"/a", 512, 512}));
+	REQUIRE(storage->Get(InMemCacheBlock {"/b", 0, 512}));
 }
 
 TEST_CASE("ObjectCacheStorage replace-on-duplicate-Put keeps single map entry with latest meta",
@@ -151,7 +151,7 @@ TEST_CASE("ObjectCacheStorage replace-on-duplicate-Put keeps single map entry wi
 
 	REQUIRE(storage->Keys().size() == 1);
 	auto pinned = storage->Get(key);
-	REQUIRE(pinned != nullptr);
+	REQUIRE(pinned);
 	REQUIRE(pinned->VersionTag() == "v2");
 	REQUIRE(pinned->Data().data()[0] == '2');
 }
@@ -203,7 +203,7 @@ TEST_CASE("ObjectCacheStorage concurrent Put and Get", "[object cache storage]")
 				InMemCacheBlock key {"/concurrent", off, BLK};
 				storage->Put(key, MakeFilledChunk(BLK, static_cast<char>('A' + (t % 26))), "v");
 				auto pinned = storage->Get(key);
-				if (pinned != nullptr) {
+				if (pinned) {
 					REQUIRE(pinned->Data().length == BLK);
 					hits.fetch_add(1, std::memory_order_relaxed);
 				}

--- a/test/unittest/test_set_extension_config_from_unit.cpp
+++ b/test/unittest/test_set_extension_config_from_unit.cpp
@@ -78,7 +78,7 @@ TEST_CASE_METHOD(SetExtensionConfigFixture, "Test on changing extension config c
 	// Set up per-instance state for the extension
 	auto instance_state = make_shared_ptr<CacheHttpfsInstanceState>();
 	instance_state->config.cache_type = *ON_DISK_CACHE_TYPE;
-	instance_state->db_config = &instance->config;
+	instance_state->db_instance = instance.get();
 	SetInstanceState(*instance, instance_state);
 	InitializeCacheReaderForTest(instance_state, instance_state->config);
 

--- a/test/unittest/test_utils.cpp
+++ b/test/unittest/test_utils.cpp
@@ -44,7 +44,7 @@ TestCacheFileSystemHelper::TestCacheFileSystemHelper(TestCacheConfig config) : d
 		local_fs->CreateDirectory(dir);
 	}
 
-	instance_state->db_config = &db.instance->config;
+	instance_state->db_instance = db.instance.get();
 	SetInstanceState(*db.instance.get(), instance_state);
 	InitializeCacheReaderForTest(instance_state, inst_config);
 	auto internal_fs =


### PR DESCRIPTION
This PR implements the object-cache-backed in-memory cache, which provides a secondary options with currently extension-managed cache. In the followup PR, I will integrate it with the extension so DuckDB core could manage the overall memory consumption with one setting.