### PR TITLE
Fix cache key

### DIFF
--- a/src/cache_filesystem.cpp
+++ b/src/cache_filesystem.cpp
@@ -7,7 +7,6 @@
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "in_memory_cache_reader.hpp"
-#include "utils/include/url_utils.hpp"
 
 namespace duckdb {
 
@@ -42,7 +41,7 @@ connection_t GetConnectionIdFromContext(const QueryContext &context) {
 } // namespace
 
 CacheFileSystem::FileHandleCacheKey::FileHandleCacheKey(const string &path_arg, FileOpenFlags flags_arg)
-    : path(SanitizedCachePath(path_arg).Path()), flags(flags_arg | FileFlags::FILE_FLAGS_PARALLEL_ACCESS) {
+    : path(path_arg), flags(flags_arg | FileFlags::FILE_FLAGS_PARALLEL_ACCESS) {
 }
 
 CacheFileSystemHandle::CacheFileSystemHandle(unique_ptr<FileHandle> internal_file_handle_p, CacheFileSystem &fs,
@@ -173,11 +172,10 @@ void CacheFileSystem::ClearFileHandleCache(const string &filepath) {
 	if (file_handle_cache == nullptr) {
 		return;
 	}
-	const SanitizedCachePath cache_key {filepath};
 	// Start from the first key for this path (ordered by path, flags).
-	const FileHandleCacheKey start_key {cache_key.Path(), FileOpenFlags()};
+	const FileHandleCacheKey start_key {filepath, FileOpenFlags()};
 	auto file_handles = file_handle_cache->ClearAndGetValues(
-	    start_key, [&cache_key](const FileHandleCacheKey &handle_key) { return handle_key.path == cache_key.Path(); });
+	    start_key, [&filepath](const FileHandleCacheKey &handle_key) { return handle_key.path == filepath; });
 	for (auto &cur_file_handle : file_handles) {
 		cur_file_handle->Close();
 	}
@@ -225,16 +223,15 @@ void CacheFileSystem::ClearCache(const string &filepath, connection_t conn_id) {
 	auto state = instance_state.lock();
 	auto &collector = GetProfileCollectorOrThrow(state, conn_id);
 	const auto latency_guard = collector.RecordOperationStart(IoOperation::kFilePathCacheClear);
-	const SanitizedCachePath cache_key {filepath};
 	if (metadata_cache != nullptr) {
-		metadata_cache->Clear(cache_key.Path(), [&cache_key](const string &key) { return key == cache_key.Path(); });
+		metadata_cache->Clear(filepath, [&filepath](const string &key) { return key == filepath; });
 	}
 	if (glob_cache != nullptr) {
-		glob_cache->Clear(cache_key.Path(), [&cache_key](const string &key) { return key == cache_key.Path(); });
+		glob_cache->Clear(filepath, [&filepath](const string &key) { return key == filepath; });
 	}
-	ClearFileHandleCache(cache_key);
+	ClearFileHandleCache(filepath);
 	// TODO(hjiang): This seems a duplicate function call, extension statement funtion has already cleared the cache.
-	state->cache_reader_manager.ClearCache(cache_key);
+	state->cache_reader_manager.ClearCache(filepath);
 }
 
 bool CacheFileSystem::CanHandleFile(const string &fpath) {
@@ -332,7 +329,7 @@ FileMetadata CacheFileSystem::Stats(FileHandle &handle) {
 
 	// Stat with cache.
 	bool metadata_cache_hit = true;
-	const SanitizedCachePath cache_key {disk_cache_handle.internal_file_handle->GetPath()};
+	const string cache_key = disk_cache_handle.internal_file_handle->GetPath();
 	auto metadata = metadata_cache->GetOrCreate(cache_key, [this, &disk_cache_handle,
 	                                                        &metadata_cache_hit](const string & /*unused*/) {
 		metadata_cache_hit = false;
@@ -562,7 +559,7 @@ timestamp_t CacheFileSystem::GetLastModifiedTime(FileHandle &handle) {
 
 	// Stat with cache.
 	bool metadata_cache_hit = true;
-	const SanitizedCachePath cache_key {disk_cache_handle.internal_file_handle->GetPath()};
+	const string cache_key = disk_cache_handle.internal_file_handle->GetPath();
 	auto metadata = metadata_cache->GetOrCreate(cache_key, [this, &disk_cache_handle,
 	                                                        &metadata_cache_hit](const string & /*unused*/) {
 		metadata_cache_hit = false;
@@ -587,7 +584,7 @@ int64_t CacheFileSystem::GetFileSize(FileHandle &handle) {
 
 	// Stat with cache.
 	bool metadata_cache_hit = true;
-	const SanitizedCachePath cache_key {disk_cache_handle.internal_file_handle->GetPath()};
+	const string cache_key = disk_cache_handle.internal_file_handle->GetPath();
 	auto metadata = metadata_cache->GetOrCreate(cache_key, [this, &disk_cache_handle,
 	                                                        &metadata_cache_hit](const string & /*unused*/) {
 		metadata_cache_hit = false;

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -20,7 +20,6 @@
 #include "utils/include/page_aligned_data_chunk.hpp"
 #include "utils/include/thread_pool.hpp"
 #include "utils/include/thread_utils.hpp"
-#include "utils/include/url_utils.hpp"
 
 #include <cstdint>
 #include <utility>
@@ -135,7 +134,8 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 		    .attempt_direct_io = config.enable_disk_reader_mem_cache,
 		};
 		auto read_result = DiskCacheUtil::ReadLocalCacheFile(cache_dest.dest_local_filepath,
-		                                                     cache_read_chunk.chunk_size, version_tag, read_options);
+		                                                     cache_read_chunk.chunk_size, version_tag, handle.GetPath(),
+		                                                     read_options);
 		if (read_result.cache_hit) {
 			collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit, cache_read_chunk.bytes_to_copy);
 			DUCKDB_LOG_READ_CACHE_HIT((handle));
@@ -337,11 +337,9 @@ void DiskCacheReader::ClearCache(const string &fname) {
 
 	// Delete in-memory cache for on-disk cache files.
 	if (in_mem_storage != nullptr) {
-		const SanitizedCachePath cache_key {fname};
 		// Start from the first block key for this file (ordered by fname, start_off, blk_size).
-		const InMemCacheBlock start_key {cache_key.Path(), /*start_off=*/0, /*blk_size=*/0};
-		in_mem_storage->Clear(start_key,
-		                      [&cache_key](const InMemCacheBlock &block) { return block.fname == cache_key.Path(); });
+		const InMemCacheBlock start_key {fname, /*start_off=*/0, /*blk_size=*/0};
+		in_mem_storage->Clear(start_key, [&fname](const InMemCacheBlock &block) { return block.fname == fname; });
 	}
 }
 

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -134,8 +134,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 		    .attempt_direct_io = config.enable_disk_reader_mem_cache,
 		};
 		auto read_result = DiskCacheUtil::ReadLocalCacheFile(cache_dest.dest_local_filepath,
-		                                                     cache_read_chunk.chunk_size, version_tag, handle.GetPath(),
-		                                                     read_options);
+		                                                     cache_read_chunk.chunk_size, version_tag, read_options);
 		if (read_result.cache_hit) {
 			collector.RecordCacheAccess(CacheEntity::kData, CacheAccess::kCacheHit, cache_read_chunk.bytes_to_copy);
 			DUCKDB_LOG_READ_CACHE_HIT((handle));

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/uuid.hpp"
+#include "scope_guard.hpp"
 #include "utils/include/filesystem_utils.hpp"
 #include "utils/include/hash_utils.hpp"
 #include "utils/include/page_aligned_data_chunk.hpp"
@@ -190,6 +191,11 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 		return;
 	}
 
+	// Temporary file is removed after write completion whatever.
+	SCOPE_EXIT {
+		local_filesystem.TryRemoveFile(cache_dest.temp_local_filepath);
+	};
+
 	// Dump to a unique temporary location at local filesystem, since there could be multiple processes writing cache
 	// file for the same remote file.
 	{
@@ -209,11 +215,9 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	// Store validation metadata before publishing the cache file. Otherwise a concurrent reader can observe the moved
 	// file before xattrs are attached and invalidate it as a mismatched cache entry.
 	if (!version_tag.empty() && !SetCacheVersion(cache_dest.temp_local_filepath, version_tag)) {
-		local_filesystem.TryRemoveFile(cache_dest.temp_local_filepath);
 		return;
 	}
 	if (!cache_dest.file_attrs.empty() && !SetFileAttributes(cache_dest.temp_local_filepath, cache_dest.file_attrs)) {
-		local_filesystem.TryRemoveFile(cache_dest.temp_local_filepath);
 		return;
 	}
 

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -208,27 +208,29 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 		file_handle->Sync();
 	}
 
+	// Store validation metadata before publishing the cache file. Otherwise a concurrent reader can observe the moved
+	// file before xattrs are attached and invalidate it as a mismatched cache entry.
+	if (!version_tag.empty() && !SetCacheVersion(cache_dest.temp_local_filepath, version_tag)) {
+		local_filesystem.TryRemoveFile(cache_dest.temp_local_filepath);
+		return;
+	}
+	if (!cache_dest.file_attrs.empty() && !SetFileAttributes(cache_dest.temp_local_filepath, cache_dest.file_attrs)) {
+		local_filesystem.TryRemoveFile(cache_dest.temp_local_filepath);
+		return;
+	}
+
 	// Then atomically move to the target postion to prevent data corruption due to concurrent write.
 	//
 	// TODO(hjiang): Provide a way to cleanup temporary files.
 	// Issue reference: https://github.com/dentiny/duck-read-cache-fs/issues/422
 	local_filesystem.MoveFile(/*source=*/cache_dest.temp_local_filepath,
 	                          /*target=*/cache_dest.dest_local_filepath);
-
-	// Store version tag in extended attributes for validation.
-	if (!version_tag.empty()) {
-		SetCacheVersion(cache_dest.dest_local_filepath, version_tag);
-	}
-
-	// Store chunked filepath attributes for original local cache access.
-	if (!cache_dest.file_attrs.empty()) {
-		SetFileAttributes(cache_dest.dest_local_filepath, cache_dest.file_attrs);
-	}
 }
 
 /*static*/ DiskCacheUtil::LocalCacheReadResult DiskCacheUtil::ReadLocalCacheFile(const string &cache_filepath,
                                                                                  idx_t chunk_size,
                                                                                  const string &version_tag,
+                                                                                 const string &original_remote_path,
                                                                                  const ReadOption &options) {
 	auto file_open_flags = FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
 
@@ -246,7 +248,7 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	auto file_handle = local_filesystem.OpenFile(cache_filepath, file_open_flags);
 
 	// Check cache validity and clear if necessary.
-	if (file_handle != nullptr && !ValidateCacheFile(cache_filepath, version_tag)) {
+	if (file_handle != nullptr && !ValidateCacheFile(cache_filepath, version_tag, original_remote_path)) {
 		local_filesystem.TryRemoveFile(cache_filepath);
 		file_handle = nullptr;
 	}
@@ -270,7 +272,15 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	};
 }
 
-/*static*/ bool DiskCacheUtil::ValidateCacheFile(const string &cache_filepath, const string &version_tag) {
+/*static*/ bool DiskCacheUtil::ValidateCacheFile(const string &cache_filepath, const string &version_tag,
+                                                 const string &original_remote_path) {
+	if (!original_remote_path.empty()) {
+		const string cached_remote_path = TryGetOriginalRemotePath(cache_filepath);
+		if (cached_remote_path != original_remote_path) {
+			return false;
+		}
+	}
+
 	// Empty version tags means cache validation is disabled.
 	if (version_tag.empty()) {
 		return true;

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -87,12 +87,11 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
                                                                                 idx_t bytes_to_read) {
 	ALWAYS_ASSERT(!cache_directories.empty());
 
-	const SanitizedCachePath cache_key {remote_file};
 	duckdb::hash_bytes remote_file_sha256_val;
 	static_assert(sizeof(remote_file_sha256_val) == 32);
-	duckdb::sha256(cache_key.Path().data(), cache_key.Path().length(), remote_file_sha256_val);
-	const string remote_file_sha256_str = GetSha256(cache_key.Path());
-	const string fname = StringUtil::GetFileName(cache_key.Path());
+	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
+	const string remote_file_sha256_str = GetSha256(remote_file);
+	const string fname = StringUtil::GetFileName(SanitizedCachePath(remote_file).Path());
 
 	uint64_t hash_value = 0xcbf29ce484222325; // FNV offset basis
 	for (idx_t idx = 0; idx < sizeof(remote_file_sha256_val); ++idx) {
@@ -148,12 +147,11 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 }
 
 /*static*/ string DiskCacheUtil::GetLocalCacheFilePrefix(const string &remote_file) {
-	const SanitizedCachePath cache_key {remote_file};
 	duckdb::hash_bytes remote_file_sha256_val;
-	duckdb::sha256(cache_key.Path().data(), cache_key.Path().length(), remote_file_sha256_val);
+	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
 	const string remote_file_sha256_str = Sha256ToHexString(remote_file_sha256_val);
 
-	const string fname = StringUtil::GetFileName(cache_key.Path());
+	const string fname = StringUtil::GetFileName(SanitizedCachePath(remote_file).Path());
 	return StringUtil::Format("%s-%s", remote_file_sha256_str, fname);
 }
 
@@ -230,7 +228,6 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 /*static*/ DiskCacheUtil::LocalCacheReadResult DiskCacheUtil::ReadLocalCacheFile(const string &cache_filepath,
                                                                                  idx_t chunk_size,
                                                                                  const string &version_tag,
-                                                                                 const string &original_remote_path,
                                                                                  const ReadOption &options) {
 	auto file_open_flags = FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS;
 
@@ -248,7 +245,7 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	auto file_handle = local_filesystem.OpenFile(cache_filepath, file_open_flags);
 
 	// Check cache validity and clear if necessary.
-	if (file_handle != nullptr && !ValidateCacheFile(cache_filepath, version_tag, original_remote_path)) {
+	if (file_handle != nullptr && !ValidateCacheFile(cache_filepath, version_tag)) {
 		local_filesystem.TryRemoveFile(cache_filepath);
 		file_handle = nullptr;
 	}
@@ -272,15 +269,7 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	};
 }
 
-/*static*/ bool DiskCacheUtil::ValidateCacheFile(const string &cache_filepath, const string &version_tag,
-                                                 const string &original_remote_path) {
-	if (!original_remote_path.empty()) {
-		const string cached_remote_path = TryGetOriginalRemotePath(cache_filepath);
-		if (cached_remote_path != original_remote_path) {
-			return false;
-		}
-	}
-
+/*static*/ bool DiskCacheUtil::ValidateCacheFile(const string &cache_filepath, const string &version_tag) {
 	// Empty version tags means cache validation is disabled.
 	if (version_tag.empty()) {
 		return true;

--- a/src/in_mem_cache_block.cpp
+++ b/src/in_mem_cache_block.cpp
@@ -1,11 +1,9 @@
 #include "in_mem_cache_block.hpp"
 
-#include "utils/include/url_utils.hpp"
-
 namespace duckdb {
 
 InMemCacheBlock::InMemCacheBlock(const string &path, idx_t start_off_p, idx_t blk_size_p)
-    : fname(URLUtils::StripQueryAndFragment(path)), start_off(start_off_p), blk_size(blk_size_p) {
+    : fname(path), start_off(start_off_p), blk_size(blk_size_p) {
 }
 
 } // namespace duckdb

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -16,7 +16,6 @@
 #include "utils/include/page_aligned_data_chunk.hpp"
 #include "utils/include/thread_pool.hpp"
 #include "utils/include/thread_utils.hpp"
-#include "utils/include/url_utils.hpp"
 
 #include <cstdint>
 #include <future>
@@ -227,11 +226,9 @@ void InMemoryCacheReader::ClearCache() {
 
 void InMemoryCacheReader::ClearCache(const string &fname) {
 	if (storage != nullptr) {
-		const SanitizedCachePath cache_key {fname};
 		// Start from the first block key for this file (ordered by fname, start_off, blk_size).
-		const InMemCacheBlock start_key {cache_key.Path(), /*start_off_p=*/0, /*blk_size_p=*/0};
-		storage->Clear(start_key,
-		               [&cache_key](const InMemCacheBlock &block) { return block.fname == cache_key.Path(); });
+		const InMemCacheBlock start_key {fname, /*start_off_p=*/0, /*blk_size_p=*/0};
+		storage->Clear(start_key, [&fname](const InMemCacheBlock &block) { return block.fname == fname; });
 	}
 }
 

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -91,19 +91,22 @@ public:
 	};
 
 	// Attempt to open, validate, and read a local cache file at the already-resolved [cache_filepath].
-	// If the local cache file doesn't match requested [version_tag], it will be deleted.
+	// If the local cache file doesn't match requested [version_tag] or [original_remote_path], it will be deleted.
 	// Uses direct I/O when [options.attempt_direct_io] is true and conditions allow (avoids double buffering).
 	static LocalCacheReadResult ReadLocalCacheFile(const string &cache_filepath, idx_t chunk_size,
-	                                               const string &version_tag, const ReadOption &options);
+	                                               const string &version_tag, const string &original_remote_path,
+	                                               const ReadOption &options);
 
 	// Remove dead temporary cache files (write-to-temp-then-swap leftovers) under [cache_directories].
 	// Returns the number of files deleted.
 	static idx_t CleanupDeadTempFiles(const vector<string> &cache_directories);
 
 private:
-	// Return whether the cached file at [cache_filepath] is still valid for the given [version_tag].
+	// Return whether the cached file at [cache_filepath] is still valid for the given [version_tag] and
+	// [original_remote_path].
 	// Empty version tag means cache validation is disabled.
-	static bool ValidateCacheFile(const string &cache_filepath, const string &version_tag);
+	static bool ValidateCacheFile(const string &cache_filepath, const string &version_tag,
+	                              const string &original_remote_path);
 
 	// Attempt to evict cache files, if file size threshold reached.
 	// [lru_eviction_decider] is used to obtain the filepath to remove under LRU eviction policy.

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -91,22 +91,19 @@ public:
 	};
 
 	// Attempt to open, validate, and read a local cache file at the already-resolved [cache_filepath].
-	// If the local cache file doesn't match requested [version_tag] or [original_remote_path], it will be deleted.
+	// If the local cache file doesn't match the requested [version_tag], it will be deleted.
 	// Uses direct I/O when [options.attempt_direct_io] is true and conditions allow (avoids double buffering).
 	static LocalCacheReadResult ReadLocalCacheFile(const string &cache_filepath, idx_t chunk_size,
-	                                               const string &version_tag, const string &original_remote_path,
-	                                               const ReadOption &options);
+	                                               const string &version_tag, const ReadOption &options);
 
 	// Remove dead temporary cache files (write-to-temp-then-swap leftovers) under [cache_directories].
 	// Returns the number of files deleted.
 	static idx_t CleanupDeadTempFiles(const vector<string> &cache_directories);
 
 private:
-	// Return whether the cached file at [cache_filepath] is still valid for the given [version_tag] and
-	// [original_remote_path].
+	// Return whether the cached file at [cache_filepath] is still valid for the given [version_tag].
 	// Empty version tag means cache validation is disabled.
-	static bool ValidateCacheFile(const string &cache_filepath, const string &version_tag,
-	                              const string &original_remote_path);
+	static bool ValidateCacheFile(const string &cache_filepath, const string &version_tag);
 
 	// Attempt to evict cache files, if file size threshold reached.
 	// [lru_eviction_decider] is used to obtain the filepath to remove under LRU eviction policy.

--- a/src/object_cache_data_cache_storage.cpp
+++ b/src/object_cache_data_cache_storage.cpp
@@ -8,7 +8,6 @@
 #include "duckdb/storage/object_cache.hpp"
 #include "page_aligned_data_chunk.hpp"
 #include "time_utils.hpp"
-#include "url_utils.hpp"
 
 #include <cstdint>
 #include <utility>
@@ -49,8 +48,7 @@ struct CacheHttpfsDataBlock : public ObjectCacheEntry {
 namespace {
 
 string MakeObjCacheKey(const InMemCacheBlock &key) {
-	const SanitizedCachePath sanitized {key.fname};
-	return StringUtil::Format("cache_httpfs/data/%s:%llu:%llu", sanitized.Path(), key.start_off, key.blk_size);
+	return StringUtil::Format("cache_httpfs/data/%s:%llu:%llu", key.fname, key.start_off, key.blk_size);
 }
 
 } // namespace

--- a/test/sql/cache_block_size.test
+++ b/test/sql/cache_block_size.test
@@ -26,9 +26,9 @@ SET cache_httpfs_cache_block_size=8192;
 statement ok
 SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_block_size_remap=1');
 
-# Cache keys use StripQueryAndFragment; status rows use the URL without ?foo=.
+# Cache keys preserve query parameters, so status rows use the full URL.
 query II
-SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv' ORDER BY start_offset;
+SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_block_size_remap=1' ORDER BY start_offset;
 ----
 0	8192
 8192	16222
@@ -38,7 +38,7 @@ statement ok
 SET cache_httpfs_cache_block_size=4096;
 
 query II
-SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv' ORDER BY start_offset;
+SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_block_size_remap=1' ORDER BY start_offset;
 ----
 0	4096
 4096	8192

--- a/test/sql/cache_block_size.test
+++ b/test/sql/cache_block_size.test
@@ -24,11 +24,10 @@ statement ok
 SET cache_httpfs_cache_block_size=8192;
 
 statement ok
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_block_size_remap=1');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 
-# Cache keys preserve query parameters, so status rows use the full URL.
 query II
-SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_block_size_remap=1' ORDER BY start_offset;
+SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() ORDER BY start_offset;
 ----
 0	8192
 8192	16222
@@ -38,7 +37,7 @@ statement ok
 SET cache_httpfs_cache_block_size=4096;
 
 query II
-SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_block_size_remap=1' ORDER BY start_offset;
+SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() ORDER BY start_offset;
 ----
 0	4096
 4096	8192
@@ -47,7 +46,7 @@ SELECT start_offset, end_offset FROM cache_httpfs_cache_status_query() WHERE ori
 
 # Cached bytes should still satisfy a follow-up read.
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_block_size_remap=1');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 

--- a/test/sql/cache_key_query_param.test
+++ b/test/sql/cache_key_query_param.test
@@ -1,0 +1,69 @@
+# name: test/sql/cache_key_query_param.test
+# description: cache key preserves URL query parameters so URLs differing only by query string are treated as fully distinct cache entries.
+# group: [sql]
+
+require notwindows
+
+require cache_httpfs
+
+# ============================================================
+# In-memory cache.
+# ============================================================
+
+statement ok
+SET cache_httpfs_type='in_mem';
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=1');
+
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=2');
+
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query() ORDER BY original_remote_path;
+----
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=1	0	16222	in-mem
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=2	0	16222	in-mem
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+# ============================================================
+# On-disk cache.
+# Each URL hashes to a distinct on-disk filename (full URL is part of the SHA-256).
+# ============================================================
+
+statement ok
+SET cache_httpfs_type='on_disk';
+
+statement ok
+SET cache_httpfs_cache_directory='/tmp/duckdb_cache_key_query_param';
+
+statement ok
+SELECT cache_httpfs_clear_cache();
+
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=1');
+
+statement ok
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=2');
+
+query IIIII
+SELECT * FROM cache_httpfs_cache_status_query() ORDER BY original_remote_path, cache_type;
+----
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=1	0	16222	in-mem-disk-cache
+/tmp/duckdb_cache_key_query_param/61da2523eba95567247b46e8f40713aa84f7c5a042359a5642d34bd4b2d997e3-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=1	0	16222	on-disk
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=2	0	16222	in-mem-disk-cache
+/tmp/duckdb_cache_key_query_param/464dfa80858367b7fbc452196f772c8b431fbf32de0e82a58206d94838f60d39-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?v=2	0	16222	on-disk
+
+# Two distinct physical on-disk cache files exist (one per URL).
+query I
+SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_key_query_param/*');
+----
+2
+
+statement ok
+SELECT cache_httpfs_clear_cache();

--- a/test/sql/cache_key_query_param.test
+++ b/test/sql/cache_key_query_param.test
@@ -33,7 +33,6 @@ SELECT cache_httpfs_clear_cache();
 
 # ============================================================
 # On-disk cache.
-# Each URL hashes to a distinct on-disk filename (full URL is part of the SHA-256).
 # ============================================================
 
 statement ok

--- a/test/sql/disable_external_access.test
+++ b/test/sql/disable_external_access.test
@@ -28,12 +28,12 @@ statement ok
 SET enable_external_access = false;
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
@@ -64,12 +64,12 @@ statement ok
 SET enable_external_access = false;
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 

--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -320,7 +320,7 @@ SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query();
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem-disk-cache
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3	0	16222	in-mem-disk-cache
 /tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3	0	16222	on-disk
 
 # Query parquet file.

--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -34,7 +34,7 @@ SELECT * FROM cache_httpfs_cache_status_query();
 
 # Test uncached query.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=1');
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18
@@ -290,7 +290,7 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 
 # Test cached query.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=2') LIMIT 5;
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 5;
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18
@@ -306,7 +306,7 @@ SELECT * FROM cache_httpfs_cache_status_query();
 ----
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
@@ -320,8 +320,8 @@ SELECT COUNT(*) FROM glob('/tmp/duckdb_cache_httpfs_cache/*');
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query();
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3	0	16222	in-mem-disk-cache
-/tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3	0	16222	on-disk
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem-disk-cache
+/tmp/duckdb_cache_httpfs_cache/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	on-disk
 
 # Query parquet file.
 query I
@@ -338,7 +338,7 @@ SELECT cache_httpfs_clear_cache();
 
 # Uncached read.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=4') LIMIT 3;
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 3;
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18
@@ -346,7 +346,7 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 
 # Cached read.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=5') LIMIT 3;
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 3;
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18

--- a/test/sql/glob_read.test
+++ b/test/sql/glob_read.test
@@ -17,7 +17,7 @@ SELECT cache_httpfs_clear_cache();
 
 # Test uncached query.
 query IIII
-SELECT * FROM read_csv_auto(['https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv?cache_test=1', 'https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv?cache_test=2'] , union_by_name = true) ORDER BY a;
+SELECT * FROM read_csv_auto(['https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv', 'https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv'] , union_by_name = true) ORDER BY a;
 ----
 1	2	3	NULL
 3	4	5	NULL
@@ -30,14 +30,14 @@ test	88	NULL	2020-12-30 00:25:58.745232+00
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query() ORDER BY original_remote_path, cache_filepath;
 ----
-(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv?cache_test=1	0	23	in-mem-disk-cache
-/tmp/duckdb_cache_httpfs_cache/790e86440e87f3fe45cbfab00131ea59fbe90728a8277d2bc0610e9c43dae4cf-ubn1.csv-0-23	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv?cache_test=1	0	23	on-disk
-(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv?cache_test=2	0	171	in-mem-disk-cache
-/tmp/duckdb_cache_httpfs_cache/716e708a8a767ba362ce86783df2a9bdf9f1e867fa38091e09865a3d3bf96a7a-ubn2.csv-0-171	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv?cache_test=2	0	171	on-disk
+(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv	0	23	in-mem-disk-cache
+/tmp/duckdb_cache_httpfs_cache/790e86440e87f3fe45cbfab00131ea59fbe90728a8277d2bc0610e9c43dae4cf-ubn1.csv-0-23	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv	0	23	on-disk
+(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv	0	171	in-mem-disk-cache
+/tmp/duckdb_cache_httpfs_cache/716e708a8a767ba362ce86783df2a9bdf9f1e867fa38091e09865a3d3bf96a7a-ubn2.csv-0-171	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv	0	171	on-disk
 
 # Test cached query.
 query IIII
-SELECT * FROM read_csv_auto(['https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv?cache_test=3', 'https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv?cache_test=4'] , union_by_name = true) ORDER BY a;
+SELECT * FROM read_csv_auto(['https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv', 'https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv'] , union_by_name = true) ORDER BY a;
 ----
 1	2	3	NULL
 3	4	5	NULL

--- a/test/sql/glob_read.test
+++ b/test/sql/glob_read.test
@@ -28,11 +28,11 @@ fg5391jn4	92	NULL	2020-12-30 03:25:58.745232+00
 test	88	NULL	2020-12-30 00:25:58.745232+00
 
 query IIIII
-SELECT * FROM cache_httpfs_cache_status_query() ORDER BY original_remote_path;
+SELECT * FROM cache_httpfs_cache_status_query() ORDER BY original_remote_path, cache_filepath;
 ----
-(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv	0	23	in-mem-disk-cache
+(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv?cache_test=1	0	23	in-mem-disk-cache
 /tmp/duckdb_cache_httpfs_cache/790e86440e87f3fe45cbfab00131ea59fbe90728a8277d2bc0610e9c43dae4cf-ubn1.csv-0-23	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn1.csv?cache_test=1	0	23	on-disk
-(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv	0	171	in-mem-disk-cache
+(no disk cache)	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv?cache_test=2	0	171	in-mem-disk-cache
 /tmp/duckdb_cache_httpfs_cache/716e708a8a767ba362ce86783df2a9bdf9f1e867fa38091e09865a3d3bf96a7a-ubn2.csv-0-171	https://github.com/duckdb/duckdb/raw/refs/heads/v1.2-histrionicus/data/csv/union-by-name/ubn2.csv?cache_test=2	0	171	on-disk
 
 # Test cached query.

--- a/test/sql/inmem_cache_filesystem.test
+++ b/test/sql/inmem_cache_filesystem.test
@@ -25,7 +25,7 @@ SELECT cache_httpfs_clear_cache();
 
 # Test uncached query.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=1');
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18
@@ -281,7 +281,7 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 
 # Test cached query.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=2') LIMIT 5;
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 5;
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18
@@ -292,13 +292,13 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query();
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=2	0	16222	in-mem
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem
 
 statement ok
 SELECT cache_httpfs_clear_cache();
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
@@ -314,9 +314,9 @@ SELECT COUNT(*) FROM cache_httpfs_cache_status_query() WHERE original_remote_pat
 1
 
 query IIIII
-SELECT * FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3';
+SELECT * FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv';
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3	0	16222	in-mem
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok
@@ -327,7 +327,7 @@ SELECT cache_httpfs_clear_cache();
 
 # Uncached read.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=4') LIMIT 3;
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 3;
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18
@@ -335,7 +335,7 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 
 # Cached read.
 query IIIIII
-SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=5') LIMIT 3;
+SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv') LIMIT 3;
 ----
 1	Africa	Lesotho	HYBSE	NULL	2019-03-25
 2	Asia	Kazakhstan	Astana International Financial Centre	AIXK	2018-11-18

--- a/test/sql/inmem_cache_filesystem.test
+++ b/test/sql/inmem_cache_filesystem.test
@@ -292,7 +292,7 @@ SELECT * FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query();
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=2	0	16222	in-mem
 
 statement ok
 SELECT cache_httpfs_clear_cache();
@@ -314,9 +314,9 @@ SELECT COUNT(*) FROM cache_httpfs_cache_status_query() WHERE original_remote_pat
 1
 
 query IIIII
-SELECT * FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv';
+SELECT * FROM cache_httpfs_cache_status_query() WHERE original_remote_path = 'https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3';
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?cache_test=3	0	16222	in-mem
 
 # Test cases when cache block size and IO request size is smaller than file size.
 statement ok

--- a/test/sql/issue_393.test
+++ b/test/sql/issue_393.test
@@ -13,6 +13,6 @@ SELECT cache_httpfs_clear_cache();
 
 # Test uncached query.
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?dummyParam=val');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251

--- a/test/sql/issue_412.test
+++ b/test/sql/issue_412.test
@@ -23,18 +23,18 @@ SELECT * FROM cache_httpfs_cache_status_query();
 ----
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?query=cache-test');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query() ORDER BY cache_filepath;
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?query=cache-test	0	16222	in-mem-disk-cache
-/tmp/duckdb_cache_issue_412/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?query=cache-test	0	16222	on-disk
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem-disk-cache
+/tmp/duckdb_cache_issue_412/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	on-disk
 
 query I
-SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?query=cache-test');
+SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv');
 ----
 251
 
@@ -44,4 +44,4 @@ SELECT * FROM cache_httpfs_cache_access_info_query();
 metadata	5	1	0	NULL	NULL	NULL	NULL
 data	1	1	0	32444	32444	16222	16222
 file handle	1	1	0	NULL	NULL	NULL	NULL
-glob	1	1	0	NULL	NULL	NULL	NULL
+glob	0	0	0	NULL	NULL	NULL	NULL

--- a/test/sql/issue_412.test
+++ b/test/sql/issue_412.test
@@ -30,7 +30,7 @@ SELECT COUNT(*) FROM read_csv_auto('https://raw.githubusercontent.com/dentiny/du
 query IIIII
 SELECT * FROM cache_httpfs_cache_status_query() ORDER BY cache_filepath;
 ----
-(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv	0	16222	in-mem-disk-cache
+(no disk cache)	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?query=cache-test	0	16222	in-mem-disk-cache
 /tmp/duckdb_cache_issue_412/c1b7e15bc8fe00a09fd6ea693ca6bdf109f622f26f4c6b34ad568a300854b5e2-stock-exchanges.csv-0-16222	https://raw.githubusercontent.com/dentiny/duck-read-cache-fs/refs/heads/main/test/data/stock-exchanges.csv?query=cache-test	0	16222	on-disk
 
 query I

--- a/test/unittest/test_disk_cache_util.cpp
+++ b/test/unittest/test_disk_cache_util.cpp
@@ -63,12 +63,19 @@ TEST_CASE("Get remote file information from local cache filename", "[disk_cache_
 	REQUIRE(info.end_offset == 4096);
 }
 
-TEST_CASE("DiskCacheUtil::GetLocalCacheFilePrefix - query and fragment stripped", "[disk_cache_util]") {
+TEST_CASE("DiskCacheUtil::GetLocalCacheFilePrefix - query string differentiates cache key", "[disk_cache_util]") {
 	const string url_plain = "https://example.com/file.parquet";
 	const string url_with_query = "https://example.com/file.parquet?version=1";
+	const string url_with_other_query = "https://example.com/file.parquet?version=2";
 
-	REQUIRE(DiskCacheUtil::GetLocalCacheFilePrefix(url_plain) ==
+	// URLs differing by query string must produce different prefixes (different on-disk cache files).
+	REQUIRE(DiskCacheUtil::GetLocalCacheFilePrefix(url_plain) !=
 	        DiskCacheUtil::GetLocalCacheFilePrefix(url_with_query));
+	REQUIRE(DiskCacheUtil::GetLocalCacheFilePrefix(url_with_query) !=
+	        DiskCacheUtil::GetLocalCacheFilePrefix(url_with_other_query));
+
+	// The human-readable filename portion (after the SHA prefix) is still the sanitized basename.
+	REQUIRE(StringUtil::EndsWith(DiskCacheUtil::GetLocalCacheFilePrefix(url_with_query), "-file.parquet"));
 }
 
 TEST_CASE("ResolveLocalCacheDestination - normal filepath, no fallback for oversized filepath and filename",


### PR DESCRIPTION
This PR fixes three issues:
- Current cache key strips parameter for both in-memory and on-disk cache, but different parameters could returns different responses (eg, `?v=1` and `?v=2` expects to return different file versions), so we suffer incorrect return value
- When we persist on-disk cache file, in the current implementation it's atomically moved to destination **then** set file metadata; but at the same time the file could be visible to other readers
- When file attributes setting fails, we should remove the temporary file (used for atomic write), otherwise they'll be accumulated on disk

This PR also refactors sql tests related to query param:
- query param is removed for most of the unit tests to simplify
- a dedicated query param test is added