### PR TITLE
fix(profile_collector): remove unimplemented 'duckdb' profile_type

### DIFF
--- a/src/cache_filesystem_config.cpp
+++ b/src/cache_filesystem_config.cpp
@@ -32,9 +32,7 @@ const NoDestructor<string> ON_DISK_LRU_SINGLE_PROC_EVICTION {"lru_sp"};
 const NoDestructor<string> NOOP_PROFILE_TYPE {"noop"};
 // Store the latest IO operation profiling result, which potentially suffers concurrent updates.
 const NoDestructor<string> TEMP_PROFILE_TYPE {"temp"};
-// Store the IO operation profiling results into duckdb table, which unblocks advanced analysis.
-const NoDestructor<string> PERSISTENT_PROFILE_TYPE {"duckdb"};
-const array<string, 3> ALL_PROFILE_TYPES {{"noop", "temp", "duckdb"}};
+const array<string, 2> ALL_PROFILE_TYPES {{"noop", "temp"}};
 
 // In-memory data block cache storage backend.
 const NoDestructor<string> EXT_BOUNDED_STORAGE {"extension"};

--- a/src/cache_httpfs_extension.cpp
+++ b/src/cache_httpfs_extension.cpp
@@ -604,9 +604,8 @@ void LoadInternal(ExtensionLoader &loader) {
 	    LogicalType {LogicalTypeId::UBIGINT}, Value::UBIGINT(DEFAULT_CACHE_BLOCK_SIZE), UpdateCacheBlockSize);
 	config.AddExtensionOption(
 	    "cache_httpfs_profile_type",
-	    "Profiling type for cached filesystem. There're three options available: `noop`, `temp`, and `duckdb`. `temp` "
-	    "option stores the latest IO operation profiling result, which potentially suffers concurrent updates; "
-	    "`duckdb` stores the IO operation profiling results into duckdb table, which unblocks advanced analysis.",
+	    "Profiling type for cached filesystem. There are two options available: `noop` and `temp`. `temp` "
+	    "option stores the latest IO operation profiling result, which potentially suffers concurrent updates.",
 	    LogicalType {LogicalTypeId::VARCHAR}, *DEFAULT_PROFILE_TYPE, UpdateProfileType);
 	config.AddExtensionOption(
 	    "cache_httpfs_max_fanout_subrequest",

--- a/src/cache_httpfs_instance_state.cpp
+++ b/src/cache_httpfs_instance_state.cpp
@@ -87,15 +87,8 @@ void InstanceProfileCollectorManager::SetProfileCollector(connection_t connectio
 		return;
 	}
 
-	if (profile_type == *PERSISTENT_PROFILE_TYPE) {
-		// PERSISTENT_PROFILE_TYPE ("duckdb") is declared but not yet implemented;
-		// fall back to noop so the setting is accepted without error.
-		profile_collectors[connection_id] = make_uniq<NoopProfileCollector>();
-		return;
-	}
-
 	// Invalid profile type
-	throw InvalidInputException("Invalid cache_httpfs_profile_type: '%s'. Valid types are: 'noop', 'temp', 'duckdb'",
+	throw InvalidInputException("Invalid cache_httpfs_profile_type '%s'. Valid options are: 'noop', 'temp'",
 	                            profile_type);
 }
 

--- a/src/include/cache_filesystem_config.hpp
+++ b/src/include/cache_filesystem_config.hpp
@@ -34,9 +34,7 @@ extern const NoDestructor<string> ON_DISK_LRU_SINGLE_PROC_EVICTION;
 extern const NoDestructor<string> NOOP_PROFILE_TYPE;
 // Store the latest IO operation profiling result, which potentially suffers concurrent updates.
 extern const NoDestructor<string> TEMP_PROFILE_TYPE;
-// Store the IO operation profiling results into duckdb table, which unblocks advanced analysis.
-extern const NoDestructor<string> PERSISTENT_PROFILE_TYPE;
-extern const array<string, 3> ALL_PROFILE_TYPES;
+extern const array<string, 2> ALL_PROFILE_TYPES;
 
 // In-memory data block cache storage backend.
 extern const NoDestructor<string> EXT_BOUNDED_STORAGE;

--- a/test/sql/invalid_extension_config.test
+++ b/test/sql/invalid_extension_config.test
@@ -22,6 +22,12 @@ SET cache_httpfs_profile_type='invalid_profile';
 ----
 Invalid cache_httpfs_profile_type
 
+# Test cache_httpfs_profile_type - 'duckdb' is no longer accepted
+statement error
+SET cache_httpfs_profile_type='duckdb';
+----
+Invalid cache_httpfs_profile_type
+
 # Test cache_httpfs_evict_policy - invalid value
 statement error
 SET cache_httpfs_evict_policy='invalid_policy';

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CATCHFS_UNITTEST_OBJECTS
     test_optional.cpp
     test_oversized_cache_filepath.cpp
     test_page_aligned_data_chunk.cpp
+    test_profile_collector_set.cpp
     test_read_exception_propagation.cpp
     test_remove_files_batch.cpp
     test_scoped_directory.cpp

--- a/test/unittest/test_profile_collector_set.cpp
+++ b/test/unittest/test_profile_collector_set.cpp
@@ -1,0 +1,48 @@
+#include "catch/catch.hpp"
+
+#include "base_profile_collector.hpp"
+#include "cache_filesystem_config.hpp"
+#include "cache_httpfs_instance_state.hpp"
+#include "duckdb/common/exception.hpp"
+#include "noop_profile_collector.hpp"
+#include "temp_profile_collector.hpp"
+
+using namespace duckdb; // NOLINT
+
+namespace {
+constexpr connection_t kConnId = 42;
+} // namespace
+
+TEST_CASE("SetProfileCollector with same type does not replace stored collector", "[profile collector]") {
+	InstanceProfileCollectorManager manager;
+
+	manager.SetProfileCollector(kConnId, *NOOP_PROFILE_TYPE);
+	auto &first = manager.GetProfileCollectorOrThrow(kConnId);
+	auto *first_addr = &first;
+
+	manager.SetProfileCollector(kConnId, *NOOP_PROFILE_TYPE);
+	auto &second = manager.GetProfileCollectorOrThrow(kConnId);
+	REQUIRE(&second == first_addr);
+}
+
+TEST_CASE("SetProfileCollector switching between distinct profile types replaces the stored collector",
+          "[profile collector]") {
+	InstanceProfileCollectorManager manager;
+
+	manager.SetProfileCollector(kConnId, *NOOP_PROFILE_TYPE);
+	auto &noop_collector = manager.GetProfileCollectorOrThrow(kConnId);
+	REQUIRE(noop_collector.GetProfilerType() == *NOOP_PROFILE_TYPE);
+
+	manager.SetProfileCollector(kConnId, *TEMP_PROFILE_TYPE);
+	auto &temp_collector = manager.GetProfileCollectorOrThrow(kConnId);
+	REQUIRE(temp_collector.GetProfilerType() == *TEMP_PROFILE_TYPE);
+
+	manager.SetProfileCollector(kConnId, *NOOP_PROFILE_TYPE);
+	auto &back_to_noop = manager.GetProfileCollectorOrThrow(kConnId);
+	REQUIRE(back_to_noop.GetProfilerType() == *NOOP_PROFILE_TYPE);
+}
+
+TEST_CASE("SetProfileCollector rejects 'duckdb' as an invalid profile type", "[profile collector]") {
+	InstanceProfileCollectorManager manager;
+	REQUIRE_THROWS_AS(manager.SetProfileCollector(kConnId, "duckdb"), InvalidInputException);
+}


### PR DESCRIPTION
## Summary

Reworked per review feedback: remove the unimplemented `'duckdb'` `cache_httpfs_profile_type` value entirely instead of papering over its noop fallback.

## Background

Original symptom: `SetProfileCollector` had a use-after-free when `cache_httpfs_profile_type='duckdb'` was set. `PERSISTENT_PROFILE_TYPE ("duckdb")` was declared as a placeholder but never implemented and silently fell back to a `NoopProfileCollector`. Combined with the skip-replace guard (which compared the requested `profile_type` string against the stored collector's `GetProfilerType()`), this caused the stored `unique_ptr<BaseProfileCollector>` to be destroyed and re-created on every `SET ...='duckdb'`. `SetProfileCollector` is invoked from `CacheFileSystem::InitializeGlobalConfig` on every `OpenFileExtended` / `Glob`, while `RecordOperationStart` hands out a `LatencyGuard` holding a raw `BaseProfileCollector&` into the stored `unique_ptr`; concurrent IO on the same connection can therefore dereference freed memory.

## Changes

- Remove the `PERSISTENT_PROFILE_TYPE` constant and shrink `ALL_PROFILE_TYPES` to `{"noop", "temp"}`.
- Remove the `'duckdb'`-fallback branch in `InstanceProfileCollectorManager::SetProfileCollector`. The skip-replace guard is restored to its original form.
- Update the `InvalidInputException` message and the `cache_httpfs_profile_type` extension option description to advertise only `'noop'` and `'temp'`.
- Tests:
  - `test/unittest/test_profile_collector_set.cpp` keeps the same-type / distinct-type cases and gains a `REQUIRE_THROWS_AS(InvalidInputException)` case for `'duckdb'`.
  - `test/sql/invalid_extension_config.test` gains a `statement error` case for `SET cache_httpfs_profile_type='duckdb'`.

## Compatibility

Behavior change: `SET cache_httpfs_profile_type='duckdb'` now throws `InvalidInputException` at SET time rather than being a silent (and racy) noop. Per maintainer review there is no back-compat concern since the option was never wired up to a real implementation.