### PR TITLE
[1/N] Extract executor interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(EXTENSION_SOURCES
     src/utils/mock_filesystem.cpp
     src/utils/scoped_directory.cpp
     src/utils/thread_pool.cpp
+    src/utils/thread_pool_parallel_executor.cpp
     src/utils/thread_utils.cpp
     src/utils/time_utils.cpp
     src/utils/url_utils.cpp

--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -18,7 +18,7 @@
 #include "utils/include/chunk_utils.hpp"
 #include "utils/include/filesystem_utils.hpp"
 #include "utils/include/page_aligned_data_chunk.hpp"
-#include "utils/include/thread_pool.hpp"
+#include "utils/include/parallel_executor.hpp"
 #include "utils/include/thread_utils.hpp"
 
 #include <cstdint>
@@ -213,9 +213,7 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 	// Threads to parallelly perform IO.
 
 	const auto task_count = GetThreadCountForSubrequests(alignment_info.subrequest_count, config.max_subrequest_count);
-	ThreadPool io_threads(task_count);
-	vector<std::future<void>> io_task_futures;
-	io_task_futures.reserve(task_count);
+	auto parallel_executor = CreateParallelExecutor(task_count);
 	// Get file-level metadata once before processing chunks.
 	string version_tag = config.enable_cache_validation ? handle.Cast<CacheFileSystemHandle>().GetVersionTag() : "";
 
@@ -273,17 +271,13 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 		requested_start_offset = io_start_offset + block_size;
 
 		// Perform read operation in parallel.
-		auto cur_task_future = io_threads.Push([this, &handle, &config, &version_tag, cache_read_chunk]() {
+		parallel_executor->Schedule([this, &handle, &config, &version_tag, cache_read_chunk]() {
 			ProcessCacheReadChunk(handle, config, version_tag, cache_read_chunk);
 		});
-		io_task_futures.emplace_back(std::move(cur_task_future));
 	}
 
 	// Block wait for all IO operations to complete.
-	io_threads.Wait();
-	for (auto &cur_task_future : io_task_futures) {
-		cur_task_future.get();
-	}
+	parallel_executor->WaitAll();
 
 	// Record "bytes to read" and "bytes to cache".
 	auto &cache_handle = handle.Cast<CacheFileSystemHandle>();
@@ -322,17 +316,11 @@ void DiskCacheReader::ClearCache(const string &fname) {
 	}
 
 	const auto thread_num = std::min<size_t>(GetCpuCoreCount(), cache_files_to_remove.size());
-	ThreadPool tp {thread_num};
-	vector<std::future<void>> file_remove_futures;
-	file_remove_futures.reserve(cache_files_to_remove.size());
+	auto executor = CreateParallelExecutor(thread_num);
 	for (auto cur_cache_file : cache_files_to_remove) {
-		auto fut = tp.Push([this, cur = std::move(cur_cache_file)]() { local_filesystem->TryRemoveFile(cur); });
-		file_remove_futures.emplace_back(std::move(fut));
+		executor->Schedule([this, cur = std::move(cur_cache_file)]() { local_filesystem->TryRemoveFile(cur); });
 	}
-	tp.Wait();
-	for (auto &cur_fut : file_remove_futures) {
-		cur_fut.get();
-	}
+	executor->WaitAll();
 
 	// Delete in-memory cache for on-disk cache files.
 	if (in_mem_storage != nullptr) {

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -1,6 +1,6 @@
 #include "disk_cache_util.hpp"
 
-#include <future>
+#include <atomic>
 
 #include "duckdb/common/assert.hpp"
 #include "cache_filesystem_config.hpp"
@@ -15,7 +15,7 @@
 #include "utils/include/filesystem_utils.hpp"
 #include "utils/include/hash_utils.hpp"
 #include "utils/include/page_aligned_data_chunk.hpp"
-#include "utils/include/thread_pool.hpp"
+#include "utils/include/parallel_executor.hpp"
 #include "utils/include/url_utils.hpp"
 
 namespace duckdb {
@@ -345,30 +345,24 @@ DiskCacheUtil::ResolveLocalCacheDestination(const string &cache_directory, const
 
 	const timestamp_t now = Timestamp::GetCurrentTimestamp();
 	const size_t thread_num = temp_file_paths.size();
-	ThreadPool tp(thread_num);
-	vector<std::future<idx_t>> futures;
-	futures.reserve(temp_file_paths.size());
+	std::atomic<idx_t> deleted_count {0};
+	auto executor = CreateParallelExecutor(thread_num);
 	for (auto &path : temp_file_paths) {
-		futures.emplace_back(tp.Push([path = std::move(path), now]() -> idx_t {
+		executor->Schedule([path = std::move(path), now, &deleted_count]() {
 			LocalFileSystem fs;
 			auto file_handle =
 			    fs.OpenFile(path, FileOpenFlags::FILE_FLAGS_READ | FileOpenFlags::FILE_FLAGS_NULL_IF_NOT_EXISTS);
 			if (file_handle == nullptr) {
-				return 0;
+				return;
 			}
 			const timestamp_t last_mod_time = fs.GetLastModifiedTime(*file_handle);
 			const idx_t diff_microsec = static_cast<idx_t>(now.value - last_mod_time.value);
 			if (diff_microsec >= DEAD_TEMP_STALENESS_MICROSEC && fs.TryRemoveFile(path)) {
-				return 1;
+				deleted_count.fetch_add(1);
 			}
-			return 0;
-		}));
+		});
 	}
-	tp.Wait();
-	idx_t deleted_count = 0;
-	for (auto &f : futures) {
-		deleted_count += f.get();
-	}
+	executor->WaitAll();
 	return deleted_count;
 }
 

--- a/src/in_memory_cache_reader.cpp
+++ b/src/in_memory_cache_reader.cpp
@@ -14,11 +14,10 @@
 #include "in_memory_data_cache_storage.hpp"
 #include "utils/include/chunk_utils.hpp"
 #include "utils/include/page_aligned_data_chunk.hpp"
-#include "utils/include/thread_pool.hpp"
+#include "utils/include/parallel_executor.hpp"
 #include "utils/include/thread_utils.hpp"
 
 #include <cstdint>
-#include <future>
 #include <utility>
 namespace duckdb {
 
@@ -118,9 +117,7 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 
 	// Threads to parallelly perform IO.
 	const auto task_count = GetThreadCountForSubrequests(alignment_info.subrequest_count, config.max_subrequest_count);
-	ThreadPool io_threads(task_count);
-	vector<std::future<void>> io_task_futures;
-	io_task_futures.reserve(task_count);
+	auto parallel_executor = CreateParallelExecutor(task_count);
 	// Get file-level metadata once before processing chunks.
 	string version_tag = config.enable_cache_validation ? handle.Cast<CacheFileSystemHandle>().GetVersionTag() : "";
 
@@ -178,17 +175,13 @@ void InMemoryCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t r
 		requested_start_offset = io_start_offset + block_size;
 
 		// Perform read operation in parallel.
-		auto cur_task_future = io_threads.Push([this, &handle, &version_tag, cache_read_chunk]() {
+		parallel_executor->Schedule([this, &handle, &version_tag, cache_read_chunk]() {
 			ProcessCacheReadChunk(handle, version_tag, cache_read_chunk);
 		});
-		io_task_futures.emplace_back(std::move(cur_task_future));
 	}
 
 	// Block wait for all IO operations to complete.
-	io_threads.Wait();
-	for (auto &cur_task_future : io_task_futures) {
-		cur_task_future.get();
-	}
+	parallel_executor->WaitAll();
 
 	// Record "bytes to read" and "bytes to cache".
 	auto &cache_handle_for_profile = handle.Cast<CacheFileSystemHandle>();

--- a/src/utils/include/parallel_executor.hpp
+++ b/src/utils/include/parallel_executor.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <functional>
+
+#include "duckdb/common/unique_ptr.hpp"
+
+namespace duckdb {
+
+class BaseParallelExecutor {
+public:
+	virtual ~BaseParallelExecutor() = default;
+	// Disable copy and move.
+	BaseParallelExecutor(const BaseParallelExecutor &) = delete;
+	BaseParallelExecutor &operator=(const BaseParallelExecutor &) = delete;
+
+	virtual void Schedule(std::function<void()> task) = 0;
+
+	// Block until every scheduled task has finished.
+	// Re-throws the first exception observed across all tasks.
+	virtual void WaitAll() = 0;
+
+protected:
+	BaseParallelExecutor() = default;
+};
+
+unique_ptr<BaseParallelExecutor> CreateParallelExecutor(size_t thread_count);
+
+} // namespace duckdb

--- a/src/utils/include/thread_pool_parallel_executor.hpp
+++ b/src/utils/include/thread_pool_parallel_executor.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "parallel_executor.hpp"
+#include "thread_pool.hpp"
+
+#include <functional>
+#include <future>
+
+#include "duckdb/common/vector.hpp"
+
+namespace duckdb {
+
+class ThreadPoolParallelExecutor final : public BaseParallelExecutor {
+public:
+	explicit ThreadPoolParallelExecutor(size_t thread_count);
+
+	void Schedule(std::function<void()> task) override;
+	void WaitAll() override;
+
+private:
+	ThreadPool pool;
+	vector<std::future<void>> futures;
+};
+
+} // namespace duckdb

--- a/src/utils/thread_pool_parallel_executor.cpp
+++ b/src/utils/thread_pool_parallel_executor.cpp
@@ -1,0 +1,27 @@
+#include "thread_pool_parallel_executor.hpp"
+
+#include "duckdb/common/helper.hpp"
+
+#include <utility>
+
+namespace duckdb {
+
+ThreadPoolParallelExecutor::ThreadPoolParallelExecutor(size_t thread_count) : pool(thread_count) {
+}
+
+void ThreadPoolParallelExecutor::Schedule(std::function<void()> task) {
+	futures.emplace_back(pool.Push(std::move(task)));
+}
+
+void ThreadPoolParallelExecutor::WaitAll() {
+	pool.Wait();
+	for (auto &fut : futures) {
+		fut.get();
+	}
+}
+
+unique_ptr<BaseParallelExecutor> CreateParallelExecutor(size_t thread_count) {
+	return make_uniq<ThreadPoolParallelExecutor>(thread_count);
+}
+
+} // namespace duckdb


### PR DESCRIPTION
Related to https://github.com/dentiny/duck-read-cache-fs/issues/493

This PR abstracts an interface for parallel executor, with threadpool as the only current implementation.
TODO: implement DuckDB task executor based executor.