### PR TITLE
Rename file attributes functions to avoid windows conflict

### DIFF
--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -48,7 +48,7 @@ string ReadChunkedXattr(const string &filepath, const char *key_prefix) {
 	string result;
 	for (idx_t idx = 0;; ++idx) {
 		const string key = StringUtil::Format("%s.%03llu", key_prefix, idx);
-		string chunk = GetFileAttribute(filepath, key);
+		string chunk = GetFileXattr(filepath, key);
 		if (chunk.empty()) {
 			break;
 		}
@@ -217,7 +217,7 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	if (!version_tag.empty() && !SetCacheVersion(cache_dest.temp_local_filepath, version_tag)) {
 		return;
 	}
-	if (!cache_dest.file_attrs.empty() && !SetFileAttributes(cache_dest.temp_local_filepath, cache_dest.file_attrs)) {
+	if (!cache_dest.file_attrs.empty() && !SetFileXattrs(cache_dest.temp_local_filepath, cache_dest.file_attrs)) {
 		return;
 	}
 

--- a/src/utils/filesystem_utils.cpp
+++ b/src/utils/filesystem_utils.cpp
@@ -208,7 +208,7 @@ bool UpdateFileTimestamps(const string &filepath) {
 #endif
 }
 
-bool SetFileAttributes(const string &filepath, const unordered_map<string, string> &attrs) {
+bool SetFileXattrs(const string &filepath, const unordered_map<string, string> &attrs) {
 	bool all_ok = true;
 	for (const auto &attr : attrs) {
 		if (!SetSingleFileAttribute(filepath, attr.first, attr.second)) {
@@ -263,7 +263,7 @@ string GetCacheVersion(const string &filepath) {
 #endif
 }
 
-string GetFileAttribute(const string &filepath, const string &key) {
+string GetFileXattr(const string &filepath, const string &key) {
 #if defined(_WIN32)
 	const string ads_path = StringUtil::Format("%s:%s", filepath, key);
 	std::ifstream ads(ads_path, std::ios::binary);

--- a/src/utils/include/filesystem_utils.hpp
+++ b/src/utils/include/filesystem_utils.hpp
@@ -52,7 +52,7 @@ string GetCacheVersion(const string &filepath);
 // Set extended attributes on a file; if the attribute key already exists, it will be overwritten.
 // Return whether the operation succeeds.
 // Notice, this function doesn't provide transaction guarantee.
-bool SetFileAttributes(const string &filepath, const unordered_map<string, string> &attrs);
+bool SetFileXattrs(const string &filepath, const unordered_map<string, string> &attrs);
 
 // Check if caching is allowed (sufficient disk space)
 bool CanCacheOnDisk(const string &cache_directory, idx_t cache_block_size, idx_t min_disk_bytes_for_cache);
@@ -80,7 +80,7 @@ MaxFileNameLength GetMaxFileNameLength();
 
 // Read a single extended attribute value from a file.
 // Returns the value as a string, or empty string if missing or on error.
-string GetFileAttribute(const string &filepath, const string &key);
+string GetFileXattr(const string &filepath, const string &key);
 
 // Get the maximum size in bytes for a single extended attribute value.
 idx_t GetMaxXattrValueSize();

--- a/test/unittest/test_filesystem_utils_from_unit.cpp
+++ b/test/unittest/test_filesystem_utils_from_unit.cpp
@@ -125,22 +125,22 @@ TEST_CASE("SetFileAttributes and GetFileAttribute roundtrip", "[utils test]") {
 	unordered_map<string, string> attrs;
 	attrs["user.test_key_a"] = "value_alpha";
 	attrs["user.test_key_b"] = "value_beta";
-	REQUIRE(SetFileAttributes(test_file, attrs));
+	REQUIRE(SetFileXattrs(test_file, attrs));
 
-	REQUIRE(GetFileAttribute(test_file, "user.test_key_a") == "value_alpha");
-	REQUIRE(GetFileAttribute(test_file, "user.test_key_b") == "value_beta");
+	REQUIRE(GetFileXattr(test_file, "user.test_key_a") == "value_alpha");
+	REQUIRE(GetFileXattr(test_file, "user.test_key_b") == "value_beta");
 
 	// Overwrite one attribute and verify.
 	unordered_map<string, string> updated;
 	updated["user.test_key_a"] = "value_updated";
-	REQUIRE(SetFileAttributes(test_file, updated));
-	REQUIRE(GetFileAttribute(test_file, "user.test_key_a") == "value_updated");
+	REQUIRE(SetFileXattrs(test_file, updated));
+	REQUIRE(GetFileXattr(test_file, "user.test_key_a") == "value_updated");
 	// The other attribute should be untouched.
-	REQUIRE(GetFileAttribute(test_file, "user.test_key_b") == "value_beta");
+	REQUIRE(GetFileXattr(test_file, "user.test_key_b") == "value_beta");
 
 	// Reading a non-existent attribute returns empty.
-	REQUIRE(GetFileAttribute(test_file, "user.no_such_key").empty());
+	REQUIRE(GetFileXattr(test_file, "user.no_such_key").empty());
 
 	// Reading from a non-existent file returns empty.
-	REQUIRE(GetFileAttribute(StringUtil::Format("%s/no_such_file", dir), "user.test_key_a").empty());
+	REQUIRE(GetFileXattr(StringUtil::Format("%s/no_such_file", dir), "user.test_key_a").empty());
 }


### PR DESCRIPTION
`SetFileAttributes` is an existing windows macro (not function), so rename to avoid conflict.