### PR TITLE
Disable a few windows test

### DIFF
--- a/test/sql/cache_key_query_param.test
+++ b/test/sql/cache_key_query_param.test
@@ -2,6 +2,8 @@
 # description: cache key preserves URL query parameters so URLs differing only by query string are treated as fully distinct cache entries.
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 # ============================================================

--- a/test/sql/compressed_file.test
+++ b/test/sql/compressed_file.test
@@ -2,6 +2,8 @@
 # description: test read and cache compressed parquet file
 # group: [sql]
 
+require notwindows
+
 require parquet
 
 require cache_httpfs

--- a/test/sql/disable_external_access.test
+++ b/test/sql/disable_external_access.test
@@ -2,6 +2,8 @@
 # description: test that caching filesystem respects enable_external_access when serving from cache
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 require parquet

--- a/test/sql/disable_memory_cache_for_disk_cache.test
+++ b/test/sql/disable_memory_cache_for_disk_cache.test
@@ -2,6 +2,8 @@
 # description: test IO operations when memory cache disabled for disk cache reader
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 require parquet

--- a/test/sql/disk_cache_filesystem.test
+++ b/test/sql/disk_cache_filesystem.test
@@ -2,6 +2,8 @@
 # description: test cached_fs in-memory read and cache
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 require parquet

--- a/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
+++ b/test/sql/disk_cache_filesystem_with_multi_cache_dir.test
@@ -2,6 +2,8 @@
 # description: test cache filesystem with on-disk cache and multiple cache directories
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 require parquet

--- a/test/sql/glob_read.test
+++ b/test/sql/glob_read.test
@@ -2,6 +2,8 @@
 # description: test cached_fs read multiple files
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 statement ok

--- a/test/sql/insufficient_disk_space.test
+++ b/test/sql/insufficient_disk_space.test
@@ -2,6 +2,8 @@
 # description: test cache_httpfs behavior when there's no sufficent disk space for disk cache reader
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 statement ok

--- a/test/sql/issue_412.test
+++ b/test/sql/issue_412.test
@@ -2,6 +2,8 @@
 # description: regression test for issue 412
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 statement ok

--- a/test/sql/issue_418.test
+++ b/test/sql/issue_418.test
@@ -2,6 +2,8 @@
 # description: regression test for issue 418
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 statement ok

--- a/test/sql/wrap_cache_filesystem.test
+++ b/test/sql/wrap_cache_filesystem.test
@@ -2,6 +2,8 @@
 # description: test cache httpfs extension wrap feature for filesystem instances other than those in httpfs.
 # group: [sql]
 
+require notwindows
+
 require cache_httpfs
 
 statement error


### PR DESCRIPTION
These tests rely on `/tmp` directory and certain unix cache filepath, disable them for windows.
One possible followup is to (1) expose a temporary directory SQL function; (2) use regex instead of specific cache filepath to validate caching status.