### PR TITLE
Skip in-flight temp files when listing disk cache entries

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -73,6 +73,12 @@ vector<DataCacheEntryInfo> DiskCacheReader::GetCacheEntriesInfo() const {
 	for (const auto &cur_cache_dir : cache_directories) {
 		local_filesystem->ListFiles(
 		    cur_cache_dir, [&cache_entries_info, cur_cache_dir](const string &fname, bool /*unused*/) {
+			    // Skip in-flight temporary cache files. Their transient names don't follow the cache filename
+			    // format, so parsing offsets/sizes out of them would throw; they appear as regular cache entries
+			    // once the write renames them into place.
+			    if (DiskCacheUtil::IsTempCacheFile(fname)) {
+				    return;
+			    }
 			    auto cache_filepath = StringUtil::Format("%s/%s", cur_cache_dir, fname);
 			    auto remote_file_info = DiskCacheUtil::GetRemoteFileInfo(cache_filepath);
 			    auto original_remote_path = DiskCacheUtil::TryGetOriginalRemotePath(cache_filepath);

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -147,6 +147,10 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	};
 }
 
+/*static*/ bool DiskCacheUtil::IsTempCacheFile(const string &filename) {
+	return StringUtil::EndsWith(filename, TEMP_CACHE_FILE_SUFFIX);
+}
+
 /*static*/ string DiskCacheUtil::GetLocalCacheFilePrefix(const string &remote_file) {
 	duckdb::hash_bytes remote_file_sha256_val;
 	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
@@ -333,7 +337,7 @@ DiskCacheUtil::ResolveLocalCacheDestination(const string &cache_directory, const
 	for (const auto &cache_directory : cache_directories) {
 		local_filesystem.ListFiles(
 		    cache_directory, [&temp_file_paths, &cache_directory](const string &fname, bool /*unused*/) {
-			    if (!StringUtil::EndsWith(fname, TEMP_CACHE_FILE_SUFFIX)) {
+			    if (!IsTempCacheFile(fname)) {
 				    return;
 			    }
 			    temp_file_paths.emplace_back(StringUtil::Format("%s/%s", cache_directory, fname));

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -50,6 +50,9 @@ public:
 	// Get remote file information from the given local cache [cache_filepath].
 	static RemoteFileInfo GetRemoteFileInfo(const string &cache_filepath);
 
+	// Returns true if [filename] is an in-flight temporary cache file (a cache write in progress).
+	static bool IsTempCacheFile(const string &filename);
+
 	// Used to delete on-disk cache files, which returns the file prefix for the given [remote_file].
 	static string GetLocalCacheFilePrefix(const string &remote_file);
 

--- a/test/unittest/test_disk_cache_util.cpp
+++ b/test/unittest/test_disk_cache_util.cpp
@@ -61,6 +61,19 @@ TEST_CASE("Get remote file information from local cache filename", "[disk_cache_
 	REQUIRE(info.end_offset == 4096);
 }
 
+TEST_CASE("DiskCacheUtil::IsTempCacheFile - identifies in-flight temp cache files", "[disk_cache_util]") {
+	const string hash64 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+	const string final_name = hash64 + "-file.parquet-0-4096";
+
+	// A finalized cache file is not a temp file.
+	REQUIRE_FALSE(DiskCacheUtil::IsTempCacheFile(final_name));
+
+	// The temp name produced for an in-flight write must be recognized so it is skipped during listing/parsing.
+	const string temp_name =
+	    StringUtil::Format("%s.%s.httpfs_local_cache", final_name, UUID::ToString(UUID::GenerateRandomUUID()));
+	REQUIRE(DiskCacheUtil::IsTempCacheFile(temp_name));
+}
+
 TEST_CASE("DiskCacheUtil::GetLocalCacheFilePrefix - query string differentiates cache key", "[disk_cache_util]") {
 	const string url_plain = "https://example.com/file.parquet";
 	const string url_with_query = "https://example.com/file.parquet?version=1";


### PR DESCRIPTION
`DiskCacheReader::GetCacheEntriesInfo` (backing the `cache_httpfs_cache_status_query()` table function) listed every file in each cache directory and parsed offsets/sizes out of the filename via `StringUtil::ToUnsigned`. Cache writes are not atomic in place: they go to a temporary `<final>.<uuid>.httpfs_local_cache` file and are then renamed. When the status query runs concurrently with a cache write, it picks up that transient temp file, whose name does not follow the `<hash>-<fname>-<start>-<size>` format, so `ToUnsigned` throws ("Invalid Error: stoull") and aborts the whole query.

Skip temp files when enumerating cache entries, mirroring the existing filter in `CleanupDeadTempFiles`. The shared check is extracted into `DiskCacheUtil::IsTempCacheFile` so both call sites stay in sync.