### PR TITLE
Save per-chunk sha256 computation

### DIFF
--- a/src/disk_cache_reader.cpp
+++ b/src/disk_cache_reader.cpp
@@ -90,6 +90,7 @@ vector<DataCacheEntryInfo> DiskCacheReader::GetCacheEntriesInfo() const {
 }
 
 void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceConfig &config, const string &version_tag,
+                                            const DiskCacheUtil::RemoteFileCachePathInfo &path_info,
                                             CacheReadChunk cache_read_chunk) {
 	SetThreadName("RdCachRdThd");
 
@@ -97,14 +98,11 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 	auto state = instance_state.lock();
 	auto &collector = GetProfileCollectorOrThrow(state, cache_handle.GetConnectionId());
 
-	// Resolve the on-disk cache path once up-front; use the resolved filepath as the unified key for both in-memory and
-	// on-disk cache.
+	// Per-chunk path: only offset and size vary; file-level SHA-256 and basename are precomputed in [path_info].
 	auto cache_file =
-	    DiskCacheUtil::GetLocalCacheFile(config.on_disk_cache_directories, handle.GetPath(),
-	                                     cache_read_chunk.aligned_start_offset, cache_read_chunk.chunk_size);
-	const auto &cache_directory = config.on_disk_cache_directories[cache_file.cache_directory_idx];
-	auto cache_dest =
-	    DiskCacheUtil::ResolveLocalCacheDestination(cache_directory, cache_file.cache_filepath, handle.GetPath());
+	    DiskCacheUtil::GetLocalCacheFile(path_info, cache_read_chunk.aligned_start_offset, cache_read_chunk.chunk_size);
+	auto cache_dest = DiskCacheUtil::ResolveLocalCacheDestination(path_info.cache_directory, cache_file.cache_filepath,
+	                                                              handle.GetPath());
 
 	const InMemCacheBlock block_key {handle.GetPath(), cache_read_chunk.aligned_start_offset,
 	                                 cache_read_chunk.chunk_size};
@@ -171,7 +169,7 @@ void DiskCacheReader::ProcessCacheReadChunk(FileHandle &handle, const InstanceCo
 		return;
 	}
 	try {
-		DiskCacheUtil::StoreLocalCacheFile(cache_directory, cache_dest, content, version_tag, config,
+		DiskCacheUtil::StoreLocalCacheFile(path_info.cache_directory, cache_dest, content, version_tag, config,
 		                                   [this]() { return EvictCacheBlockLru(); });
 
 		// Update in-memory cache if applicable.
@@ -217,6 +215,8 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 	    CreateParallelExecutor(instance_state_locked->db_instance, config.parallel_read_mode, task_count);
 	// Get file-level metadata once before processing chunks.
 	string version_tag = config.enable_cache_validation ? handle.Cast<CacheFileSystemHandle>().GetVersionTag() : "";
+	const auto path_info =
+	    DiskCacheUtil::BuildRemoteFileCachePathInfo(config.on_disk_cache_directories, handle.GetPath());
 
 	// To improve IO performance, we split requested bytes (after alignment) into multiple chunks and fetch them in
 	// parallel.
@@ -272,8 +272,8 @@ void DiskCacheReader::ReadAndCache(FileHandle &handle, char *buffer, idx_t reque
 		requested_start_offset = io_start_offset + block_size;
 
 		// Perform read operation in parallel.
-		parallel_executor->Schedule([this, &handle, &config, &version_tag, cache_read_chunk]() {
-			ProcessCacheReadChunk(handle, config, version_tag, cache_read_chunk);
+		parallel_executor->Schedule([this, &handle, &config, &version_tag, &path_info, cache_read_chunk]() {
+			ProcessCacheReadChunk(handle, config, version_tag, path_info, cache_read_chunk);
 		});
 	}
 

--- a/src/disk_cache_util.cpp
+++ b/src/disk_cache_util.cpp
@@ -76,41 +76,62 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 	}
 }
 
+idx_t GetCacheDirectoryIdx(const duckdb::hash_bytes &remote_file_sha256_val, idx_t cache_directory_count) {
+	uint64_t hash_value = 0xcbf29ce484222325; // FNV offset basis
+	for (idx_t idx = 0; idx < sizeof(remote_file_sha256_val); ++idx) {
+		hash_value ^= static_cast<uint64_t>(remote_file_sha256_val[idx]);
+		hash_value *= 0x100000001b3; // FNV prime
+	}
+	return hash_value % cache_directory_count;
+}
+
+void PopulateRemoteFileCacheKey(const string &remote_file, duckdb::hash_bytes &remote_file_sha256_val,
+                                string &remote_file_sha256_hex, string &sanitized_fname) {
+	static_assert(sizeof(remote_file_sha256_val) == 32);
+	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
+	remote_file_sha256_hex = Sha256ToHexString(remote_file_sha256_val);
+	sanitized_fname = StringUtil::GetFileName(SanitizedCachePath(remote_file).Path());
+}
+
 } // namespace
 
 /*static*/ string DiskCacheUtil::TryGetOriginalRemotePath(const string &filepath) {
 	return ReadChunkedXattr(filepath, REMOTE_PATH_ATTR_PREFIX);
 }
 
+/*static*/ DiskCacheUtil::RemoteFileCachePathInfo
+DiskCacheUtil::BuildRemoteFileCachePathInfo(const vector<string> &cache_directories, const string &remote_file) {
+	ALWAYS_ASSERT(!cache_directories.empty());
+
+	RemoteFileCachePathInfo path_info;
+	duckdb::hash_bytes remote_file_sha256_val;
+	PopulateRemoteFileCacheKey(remote_file, remote_file_sha256_val, path_info.remote_file_sha256_hex,
+	                           path_info.sanitized_fname);
+	path_info.cache_directory_idx = GetCacheDirectoryIdx(remote_file_sha256_val, cache_directories.size());
+	path_info.cache_directory = cache_directories[path_info.cache_directory_idx];
+	if (StringUtil::EndsWith(path_info.cache_directory, "/")) {
+		throw InternalException("Cache directory %s cannot ends with '/'", path_info.cache_directory);
+	}
+	return path_info;
+}
+
+/*static*/ DiskCacheUtil::CacheFileDestination
+DiskCacheUtil::GetLocalCacheFile(const RemoteFileCachePathInfo &path_info, idx_t start_offset, idx_t bytes_to_read) {
+	auto cache_filepath =
+	    StringUtil::Format("%s/%s-%s-%llu-%llu", path_info.cache_directory, path_info.remote_file_sha256_hex,
+	                       path_info.sanitized_fname, start_offset, bytes_to_read);
+	return DiskCacheUtil::CacheFileDestination {
+	    .cache_directory_idx = path_info.cache_directory_idx,
+	    .cache_filepath = std::move(cache_filepath),
+	};
+}
+
 /*static*/ DiskCacheUtil::CacheFileDestination DiskCacheUtil::GetLocalCacheFile(const vector<string> &cache_directories,
                                                                                 const string &remote_file,
                                                                                 idx_t start_offset,
                                                                                 idx_t bytes_to_read) {
-	ALWAYS_ASSERT(!cache_directories.empty());
-
-	duckdb::hash_bytes remote_file_sha256_val;
-	static_assert(sizeof(remote_file_sha256_val) == 32);
-	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
-	const string remote_file_sha256_str = GetSha256(remote_file);
-	const string fname = StringUtil::GetFileName(SanitizedCachePath(remote_file).Path());
-
-	uint64_t hash_value = 0xcbf29ce484222325; // FNV offset basis
-	for (idx_t idx = 0; idx < sizeof(remote_file_sha256_val); ++idx) {
-		hash_value ^= static_cast<uint64_t>(remote_file_sha256_val[idx]);
-		hash_value *= 0x100000001b3; // FNV prime
-	}
-	const idx_t cache_directory_idx = hash_value % cache_directories.size();
-	const auto &cur_cache_dir = cache_directories[cache_directory_idx];
-	if (StringUtil::EndsWith(cur_cache_dir, "/")) {
-		throw InternalException("Cache directory %s cannot ends with '/'", cur_cache_dir);
-	}
-
-	auto cache_filepath = StringUtil::Format("%s/%s-%s-%llu-%llu", cur_cache_dir, remote_file_sha256_str, fname,
-	                                         start_offset, bytes_to_read);
-	return DiskCacheUtil::CacheFileDestination {
-	    .cache_directory_idx = cache_directory_idx,
-	    .cache_filepath = std::move(cache_filepath),
-	};
+	auto path_info = BuildRemoteFileCachePathInfo(cache_directories, remote_file);
+	return GetLocalCacheFile(path_info, start_offset, bytes_to_read);
 }
 
 /*static*/ DiskCacheUtil::RemoteFileInfo DiskCacheUtil::GetRemoteFileInfo(const string &cache_filepath) {
@@ -149,11 +170,10 @@ void AddChunkedXattrEntries(unordered_map<string, string> &file_attrs, const cha
 
 /*static*/ string DiskCacheUtil::GetLocalCacheFilePrefix(const string &remote_file) {
 	duckdb::hash_bytes remote_file_sha256_val;
-	duckdb::sha256(remote_file.data(), remote_file.length(), remote_file_sha256_val);
-	const string remote_file_sha256_str = Sha256ToHexString(remote_file_sha256_val);
-
-	const string fname = StringUtil::GetFileName(SanitizedCachePath(remote_file).Path());
-	return StringUtil::Format("%s-%s", remote_file_sha256_str, fname);
+	string remote_file_sha256_hex;
+	string sanitized_fname;
+	PopulateRemoteFileCacheKey(remote_file, remote_file_sha256_val, remote_file_sha256_hex, sanitized_fname);
+	return StringUtil::Format("%s-%s", remote_file_sha256_hex, sanitized_fname);
 }
 
 /*static*/ void DiskCacheUtil::EvictCacheFiles(FileSystem &local_filesystem, const string &cache_directory,

--- a/src/include/disk_cache_reader.hpp
+++ b/src/include/disk_cache_reader.hpp
@@ -5,6 +5,7 @@
 #include "base_cache_reader.hpp"
 #include "cache_filesystem_config.hpp"
 #include "cache_read_chunk.hpp"
+#include "disk_cache_util.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/map.hpp"
 #include "duckdb/common/shared_ptr.hpp"
@@ -49,6 +50,7 @@ public:
 private:
 	// Process a single cache read chunk in a worker thread.
 	void ProcessCacheReadChunk(FileHandle &handle, const InstanceConfig &config, const string &version_tag,
+	                           const DiskCacheUtil::RemoteFileCachePathInfo &path_info,
 	                           CacheReadChunk cache_read_chunk);
 
 	// Used to access local cache files.

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -31,11 +31,14 @@ public:
 	};
 
 	// File-level cache path components computed once per remote file read.
-	// Per-chunk paths are built via GetLocalCacheFile(path_info, start_offset, bytes_to_read).
 	struct RemoteFileCachePathInfo {
+		// Index for all cache directories.
 		idx_t cache_directory_idx = 0;
+		// Local cache filepath.
 		string cache_directory;
+		// SHA-256 hash of the remote filepath.
 		string remote_file_sha256_hex;
+		// Sanitized filename.
 		string sanitized_fname;
 	};
 

--- a/src/include/disk_cache_util.hpp
+++ b/src/include/disk_cache_util.hpp
@@ -30,6 +30,19 @@ public:
 		string cache_filepath;
 	};
 
+	// File-level cache path components computed once per remote file read.
+	// Per-chunk paths are built via GetLocalCacheFile(path_info, start_offset, bytes_to_read).
+	struct RemoteFileCachePathInfo {
+		idx_t cache_directory_idx = 0;
+		string cache_directory;
+		string remote_file_sha256_hex;
+		string sanitized_fname;
+	};
+
+	// Compute file-level cache path components for [remote_file] (SHA-256, sanitized basename, cache directory).
+	static RemoteFileCachePathInfo BuildRemoteFileCachePathInfo(const vector<string> &cache_directories,
+	                                                            const string &remote_file);
+
 	// Get local cache filename for the given [remote_file].
 	//
 	// Cache filename is formatted as `<cache-directory>/<filename-sha256>-<filename>-<start-offset>-<size>`. So we
@@ -39,6 +52,10 @@ public:
 	// filesystems.
 	static CacheFileDestination GetLocalCacheFile(const vector<string> &cache_directories, const string &remote_file,
 	                                              idx_t start_offset, idx_t bytes_to_read);
+
+	// Get local cache filepath for a chunk using precomputed [path_info].
+	static CacheFileDestination GetLocalCacheFile(const RemoteFileCachePathInfo &path_info, idx_t start_offset,
+	                                              idx_t bytes_to_read);
 
 	// Remote file information for a local cache filename.
 	struct RemoteFileInfo {

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -63,9 +63,8 @@ if(NOT WIN32
     unittest_cache_httpfs test_helpers duckdb ${EXTENSION_NAME}
     ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
 else()
-  target_link_libraries(
-    unittest_cache_httpfs test_helpers duckdb_static
-    ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
+  target_link_libraries(unittest_cache_httpfs test_helpers duckdb_static
+                        ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES})
   link_extension_libraries(unittest_cache_httpfs "")
 endif()
 

--- a/test/unittest/test_disk_cache_util.cpp
+++ b/test/unittest/test_disk_cache_util.cpp
@@ -50,25 +50,6 @@ TEST_CASE("Deterministic cache destination for same input", "[disk_cache_util]")
 	REQUIRE(r1.cache_filepath == r2.cache_filepath);
 }
 
-TEST_CASE("BuildRemoteFileCachePathInfo matches GetLocalCacheFile per chunk", "[disk_cache_util]") {
-	vector<string> cache_dirs = {"/cache1", "/cache2", "/cache3"};
-	const string remote = "https://example.com/data/file.parquet";
-
-	const auto path_info = DiskCacheUtil::BuildRemoteFileCachePathInfo(cache_dirs, remote);
-	const auto expected0 =
-	    DiskCacheUtil::GetLocalCacheFile(cache_dirs, remote, /*start_offset=*/0, /*bytes_to_read=*/4096);
-	const auto expected1 =
-	    DiskCacheUtil::GetLocalCacheFile(cache_dirs, remote, /*start_offset=*/4096, /*bytes_to_read=*/4096);
-
-	const auto chunk0 = DiskCacheUtil::GetLocalCacheFile(path_info, /*start_offset=*/0, /*bytes_to_read=*/4096);
-	const auto chunk1 = DiskCacheUtil::GetLocalCacheFile(path_info, /*start_offset=*/4096, /*bytes_to_read=*/4096);
-
-	REQUIRE(chunk0.cache_directory_idx == expected0.cache_directory_idx);
-	REQUIRE(chunk0.cache_filepath == expected0.cache_filepath);
-	REQUIRE(chunk1.cache_directory_idx == expected1.cache_directory_idx);
-	REQUIRE(chunk1.cache_filepath == expected1.cache_filepath);
-}
-
 TEST_CASE("Get remote file information from local cache filename", "[disk_cache_util]") {
 	// fname format: <64 hex>-<remote-fname>-<start>-<block-size>
 	string hash64 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";

--- a/test/unittest/test_disk_cache_util.cpp
+++ b/test/unittest/test_disk_cache_util.cpp
@@ -50,6 +50,25 @@ TEST_CASE("Deterministic cache destination for same input", "[disk_cache_util]")
 	REQUIRE(r1.cache_filepath == r2.cache_filepath);
 }
 
+TEST_CASE("BuildRemoteFileCachePathInfo matches GetLocalCacheFile per chunk", "[disk_cache_util]") {
+	vector<string> cache_dirs = {"/cache1", "/cache2", "/cache3"};
+	const string remote = "https://example.com/data/file.parquet";
+
+	const auto path_info = DiskCacheUtil::BuildRemoteFileCachePathInfo(cache_dirs, remote);
+	const auto expected0 =
+	    DiskCacheUtil::GetLocalCacheFile(cache_dirs, remote, /*start_offset=*/0, /*bytes_to_read=*/4096);
+	const auto expected1 =
+	    DiskCacheUtil::GetLocalCacheFile(cache_dirs, remote, /*start_offset=*/4096, /*bytes_to_read=*/4096);
+
+	const auto chunk0 = DiskCacheUtil::GetLocalCacheFile(path_info, /*start_offset=*/0, /*bytes_to_read=*/4096);
+	const auto chunk1 = DiskCacheUtil::GetLocalCacheFile(path_info, /*start_offset=*/4096, /*bytes_to_read=*/4096);
+
+	REQUIRE(chunk0.cache_directory_idx == expected0.cache_directory_idx);
+	REQUIRE(chunk0.cache_filepath == expected0.cache_filepath);
+	REQUIRE(chunk1.cache_directory_idx == expected1.cache_directory_idx);
+	REQUIRE(chunk1.cache_filepath == expected1.cache_filepath);
+}
+
 TEST_CASE("Get remote file information from local cache filename", "[disk_cache_util]") {
 	// fname format: <64 hex>-<remote-fname>-<start>-<block-size>
 	string hash64 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";


### PR DESCRIPTION
SHA256 is calculated based on remote filepath, so it should be the same for all cache files.
In the current implementation, it's re-computed per-chunk; this PR only compute once per-read.
https://github.com/dentiny/duck-read-cache-fs/blob/d029fd917d6a3c60eaf631fa7e1808a3fc51aa29/src/disk_cache_util.cpp#L85-L94